### PR TITLE
"Volume Integration Output Format" card

### DIFF
--- a/mm_flux.c
+++ b/mm_flux.c
@@ -4282,9 +4282,14 @@ evaluate_volume_integral(const Exo_DB *exo, /* ptr to basic exodus ii mesh infor
   if (print_flag && ProcID == 0) {
     FILE  *jfp;
     if( (jfp=fopen(filenm,"a")) != NULL) {
-      fprintf(jfp,"Time/iteration = %e \n", time_value);
-      fprintf(jfp,"\t  (%s) Volume Integral for block %d species %d\n", 
-                                             quantity_str,blk_id, species_id);
+      if ( ppvi_type == PPVI_VERBOSE ) {
+	fprintf(jfp,"Time/iteration = %e \n", time_value);
+	fprintf(jfp,"\t  (%s) Volume Integral for block %d species %d\n", 
+		quantity_str,blk_id, species_id);
+      }
+      if ( ppvi_type == PPVI_CSV ) {
+	fprintf(jfp,"%e,", time_value);
+      }
       fflush(jfp);
       fclose(jfp);
     }
@@ -4572,12 +4577,15 @@ evaluate_volume_integral(const Exo_DB *exo, /* ptr to basic exodus ii mesh infor
     {
       FILE *jfp;
       
-      if( (jfp = fopen( filenm, "a")) != NULL )
-	{
+      if( (jfp = fopen( filenm, "a")) != NULL )	{
+	if (ppvi_type == PPVI_VERBOSE) {
 	  fprintf(jfp,"   volume= %10.7e \n", sum );
- 	  
 	}
-      fclose(jfp);
+	if (ppvi_type == PPVI_CSV) {
+	  fprintf(jfp,"%10.7e\n", sum );
+	}
+  	fclose(jfp);
+      }
     }
 
   // Kind of a hack to keep track of the porous liquid inventory for a time-dependent BC

--- a/mm_post_def.h
+++ b/mm_post_def.h
@@ -360,6 +360,7 @@ extern int nn_post_data_sens;
 extern int nn_error_metrics;
 extern int nn_particles;
 extern int nn_volume;
+extern int ppvi_type;
 
 extern int Num_Nodal_Post_Proc_Var;
 extern int Num_Elem_Post_Proc_Var;

--- a/mm_post_proc.c
+++ b/mm_post_proc.c
@@ -91,6 +91,7 @@ int nn_post_data_sens;          /* Dimension of the following structure */
 int nn_error_metrics;           /* Dimension of the following structure */
 int nn_particles;               /* Dimension of the following structure */
 int nn_volume;                  /* number of pp_volume_int structures */
+int ppvi_type;             /* Maybe there's a better way to do this, Seems like globals abound! AMC*/
 
 struct Post_Processing_Data        **pp_data;
 struct Post_Processing_Data_Sens   **pp_data_sens;
@@ -7330,6 +7331,7 @@ rd_post_process_specs(FILE *ifp,
 
   if( nn_volume)
     {
+      ppvi_type = PPVI_VERBOSE; // Default to default output behavior see "Volumetric Integration Output Format" for other possible behaviors
       sz = sizeof( struct Post_Processing_Volumetric *);
 
       pp_volume = ( struct Post_Processing_Volumetric ** ) array_alloc( 1, nn_volume, sz );
@@ -7423,6 +7425,38 @@ rd_post_process_specs(FILE *ifp,
 	} /* end of i < nn_volume */
       ECHO("\nEND OF VOLUME_INT\n", echo_file);
     } /*if iread */ 
+
+  iread = look_for_optional(ifp, "Volumetric Integration Output Format", input, '=');
+  if ( iread == 1 ) {
+    FILE *amcfp;
+    int i;
+    if ( fscanf(ifp, "%s", ts) != 1 )
+      {
+	EH(-1,"error reading Volume Integration Output Format card \n");
+      }
+    if ( !strcasecmp( ts, "Verbose" ) ) {
+      ppvi_type = PPVI_VERBOSE;
+    }
+    else if ( !strcasecmp( ts, "CSV" ) ) {
+      ppvi_type = PPVI_CSV;
+
+      /* in order to prepend output file with data type info */
+      char ts1[MAX_CHAR_IN_INPUT];
+      for( i=0; i< nn_volume; i++) {
+	amcfp=fopen( pp_volume[i]->volume_fname ,"a");
+	if( amcfp != NULL ) {
+	  strcpy( ts1, pp_volume[i]->volume_name) ;
+	  fprintf(amcfp,"Time, %s\n", &ts1);
+	  fflush(amcfp);
+	  fclose(amcfp);
+	}
+      }
+    }
+    else {
+      WH(-1, "The Volumetric Integration Output Format was not recognized");
+      ppvi_type = PPVI_VERBOSE;
+    }
+  }
 }
 /******************************************************************************/
 /******************************************************************************/

--- a/rf_fem_const.h
+++ b/rf_fem_const.h
@@ -857,6 +857,10 @@
 #define AC_POSITION 11     // Positional constraint
 #define AC_FLUX_MAT 12
 
+/* Post Processing Volumetric Integration types - AMC Originally Aug 2013 */
+
+#define PPVI_VERBOSE    1  //  This corresponds to the original output type
+#define PPVI_CSV        2  //  This will output a properly labled csv file, useful for automated python interpretation
 
 /* table interpolation types */
 


### PR DESCRIPTION
This is a request to add the Post Processing Specifications card "Volumetric Integration Output Format" with both "Verbose" and "CSV" options

Verbose (default) output for Post Processing Volume Integration appears like this:
###### 

Time/iteration = -9.999990e-01 
      (NEGATIVE_FILL) Volume Integral for block 1 species 0
   volume= 5.6720940e-02 
Time/iteration = -9.999980e-01 
      (NEGATIVE_FILL) Volume Integral for block 1 species 0
   volume= 5.6717444e-02 
Time/iteration = -9.999970e-01 
      (NEGATIVE_FILL) Volume Integral for block 1 species 0
   volume= 5.6713970e-02 
###### 

While CSV output (easily read into matlab, python, etc.) appears like this:
###### 

Time, NEGATIVE_FILL
-9.999990e-01, 5.6720940e-02
-9.999980e-01, 5.6717444e-02
-9.999970e-01, 5.6713970e-02
###### 

I haven't tested it with anything except the lubp, level_set, and shell_lub_curve equations.
I'm fairly certain it won't break anything in either mm_flux.c or mm_post_proc.c. I tested an earlier version with parallel and it worked fine. 
The differences include a global toggle "ppvi_type" that tells evaluate_volume_integral whether to log verbose or csv type output. Also the initial labelling has been moved from the "Post Processing Volumetric Integration" read function to the "Volumetric Integration Output Format" read function.
