### PR TITLE
Cleanup unused but set variables and uninitialized variables

### DIFF
--- a/ac_display_parameter.c
+++ b/ac_display_parameter.c
@@ -70,7 +70,6 @@ display_parameterC(double lambda, /* PARAMETER VALUE */
 		   Exo_DB *exo,	 /* ptr to the finite element mesh database */
 		   Dpi *dpi)	 /* distributed processing information */
 {
-  int ic;
   int mn;
   int ibc, idf;
   
@@ -98,7 +97,6 @@ display_parameterC(double lambda, /* PARAMETER VALUE */
   if (cont->upType == 2) {
 
     mn = cont->upMTID;
-    ic = cont->upMDID;
 
     printf("\n New MT[%4d] MP[%4d] = %10.6e\n", mn+1, cont->upMPID, lambda);
  

--- a/ac_stability_util.c
+++ b/ac_stability_util.c
@@ -353,12 +353,10 @@ modify_bf_mesh_derivs_for_LSA_3D_of_2D(void)
  *									*
  ************************************************************************/
 {
-  double N;
   int b, i, j, k, q;
   int mdof, vdof, var;
   struct Basis_Functions *bfv, *bfx;
 
-  N = (dbl)LSA_3D_of_2D_wave_number;
   bfx = bf[R_MESH1];
   mdof = ei->dof[R_MESH1];
   for (k=0; k<Num_Basis_Functions; k++)
@@ -420,7 +418,7 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
  ************************************************************************/
 {
   int m, p, q, r, b, j, v, w, dim;
-  int vdof, mdof;
+  int mdof;
   struct Basis_Functions *bfx;
 
 /* Bail out fast if there's nothing to do */
@@ -438,7 +436,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = TEMPERATURE;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -453,7 +450,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = VOLTAGE;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -468,7 +464,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SURF_CHARGE;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -483,7 +478,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHELL_DIFF_FLUX;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
         {
           for (j=0; j<mdof; j++)
@@ -498,7 +492,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = ACOUS_PREAL;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -511,7 +504,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = ACOUS_PIMAG;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -524,7 +516,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = LIGHT_INTP;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -537,7 +528,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = LIGHT_INTM;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -550,7 +540,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = LIGHT_INTD;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -564,7 +553,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = ACOUS_REYN_STRESS;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -578,7 +566,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHELL_BDYVELO;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -592,7 +579,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHELL_LUBP;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
       {
         for (j=0; j<mdof; j++)
@@ -606,7 +592,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = LUBP;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
       {
         for (j=0; j<mdof; j++)
@@ -620,7 +605,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
  v = LUBP_2;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
       {
         for (j=0; j<mdof; j++)
@@ -634,7 +618,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHELL_TEMPERATURE;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
       {
         for (j=0; j<mdof; j++)
@@ -648,7 +631,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHELL_FILMP;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
       {
         for (j=0; j<mdof; j++)
@@ -662,7 +644,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHELL_FILMH;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
       {
         for (j=0; j<mdof; j++)
@@ -676,7 +657,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHELL_PARTC;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
       {
         for (j=0; j<mdof; j++)
@@ -692,7 +672,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SHEAR_RATE;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -707,7 +686,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = FILL;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -722,7 +700,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = PRESSURE;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -737,7 +714,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = BOND_EVOLUTION;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -754,7 +730,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
     {
       if (pd->v[v])
 	{
-	  vdof = ei->dof[v];
 	  for (b=0; b<dim; b++)
 	    {
 	      for (j=0; j<mdof; j++)
@@ -771,7 +746,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = POR_LIQ_PRES;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -785,7 +759,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = POR_GAS_PRES;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -799,7 +772,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = POR_POROSITY;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -814,7 +786,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = VELOCITY1;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (q=0; q<VIM; q++)
 	{
 	  for (b=0; b<dim; b++)
@@ -832,7 +803,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = EXT_VELOCITY;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (b=0; b<dim; b++)
 	{
 	  for (j=0; j<mdof; j++)
@@ -847,7 +817,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = EFIELD1;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (q=0; q<VIM; q++)
 	{
 	  for (b=0; b<dim; b++)
@@ -865,7 +834,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = PVELOCITY1;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (q=0; q<VIM; q++)
 	{
 	  for (b=0; b<dim; b++)
@@ -883,7 +851,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = MESH_DISPLACEMENT1;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (q=0; q<VIM; q++)
 	{
 	  for (b=0; b<dim; b++)
@@ -901,7 +868,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = SOLID_DISPLACEMENT1;
   if (pd->v[v])
     {
-      vdof = ei->dof[v];
       for (q=0; q<VIM; q++)
 	{
 	  for (b=0; b<dim; b++)
@@ -919,7 +885,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = POLYMER_STRESS11;
   if ( pd->v[v] )
     {
-      vdof = ei->dof[v];
       for (m=0; m<vn->modes; m++)
         {
 	  for (q=0; q<VIM; q++)
@@ -943,7 +908,6 @@ modify_fv_mesh_derivs_for_LSA_3D_of_2D(void)
   v = VELOCITY_GRADIENT11;
   if ( pd->v[v] )
     {
-      vdof = ei->dof[v];
       for (q=0; q<VIM; q++)
 	{
 	  for (r=0; r<VIM; r++)

--- a/bc_colloc.c
+++ b/bc_colloc.c
@@ -2509,7 +2509,7 @@ apply_table_bc( double *func,
    */
 
   int var, basis;
-  double slope, interp_val,x_table[1];
+  double slope, interp_val,x_table[2];
   double dfunc_dx[3];
 
   if(af->Assemble_LSA_Mass_Matrix)

--- a/bc_curve.c
+++ b/bc_curve.c
@@ -98,9 +98,7 @@ apply_integrated_curve_bc(
      ************************************************************************/
 {
   int ip, w, i, I, k, j, id, icount, ss_index, type, mn, matID_apply;
-  int iapply = 0, param_dir;
-  int elem_block_index;
-  int elem_block_id;
+  int param_dir;
   int eqn, ieqn, var, pvar,p, q, index_eq, ldof_eqn;
   int err;         /* status variable for functions */
   int status = 0;
@@ -108,15 +106,13 @@ apply_integrated_curve_bc(
   
   double s;             /* Gaussian-quadrature point locations          */
   
-  double phi_j, phi_i;
+  double phi_i;
   double xi[DIM];             /* Local element coordinates of Gauss point. */
   double x_dot[MAX_PDIM];
   /****************************************************************************/
   double wt;                  /* Quadrature weights units - ergs/(sec*cm*K) = g*cm/(sec^3*K)     */
   
   double weight;
-  double rcoord;
-  double xsurf[MAX_PDIM];
   double dsigma_dx[DIM][MDE];
   double func[DIM];
   double d_func[DIM][MAX_VARIABLE_TYPES + MAX_CONC][MDE];
@@ -188,7 +184,7 @@ apply_integrated_curve_bc(
 				  elem_edge_bc->edge_elem_node_id, 
 				  param_dir);
     
-    rcoord = 0.;
+
     /*
      * Load up physical space gradients of field variables at this
      * Gauss point.
@@ -219,12 +215,10 @@ apply_integrated_curve_bc(
       for (icount = 0; icount < ielem_dim; icount++) {
 	x_dot[icount] = fv_dot->x[icount];
 	/* calculate surface position for wall repulsion/no penetration condition */
-	xsurf[icount] = fv->x0[icount];
       }
     } else {
       for(icount=0; icount<ielem_dim; icount++) {
 	x_dot[icount] = 0.;
-	xsurf[icount] = 0.;
       }
     }
     
@@ -239,18 +233,6 @@ apply_integrated_curve_bc(
 	    EH(-1,"Cannot match side set id with that in ss_to_blks array");
 	  }
 
-	/* Set flag to indicate if we're in the right material (only one) to apply*/
-	iapply = 0;
-
-	elem_block_index = find_elemblock_index(ielem, exo);
-
-	elem_block_id    = exo->eb_id[elem_block_index];
-
-	if ( elem_block_id == ss_to_blks[1][ss_index])
-	  {
-	    iapply = 1;
-	  }
-	
 
 	/* check to see if this bc is an integrated bc */
 
@@ -600,7 +582,6 @@ apply_integrated_curve_bc(
 				  pvar = upd->vp[var];
 				  for ( j=0; j<ei->dof[var]; j++)
 				    {
-				      phi_j = bf[var]->phi[j];
 				      lec->J[ieqn][pvar] [ldof_eqn][j] += weight * func[p] * 
 					fv->dedgedet_dx[q][j];
 				    }
@@ -618,8 +599,6 @@ apply_integrated_curve_bc(
 				  {
 				    for ( j=0; j<ei->dof[var]; j++)
 				      {
-					phi_j = bf[var]->phi[j];
-
 					lec->J[ieqn][pvar] [ldof_eqn][j] += weight * fv->edge_det
 					    * (d_func[p][var][j] + d_func_ss[p][var][j]);
 				      }
@@ -630,7 +609,6 @@ apply_integrated_curve_bc(
 				      {
 					for ( j=0; j<ei->dof[var]; j++)
 					  {
-					    phi_j = bf[var]->phi[j];
 					    lec->J[ieqn][MAX_PROB_VAR + w] [ldof_eqn][j] += 
 						weight * fv->edge_det * d_func[p][MAX_VARIABLE_TYPES + w][j];
 					  }

--- a/bc_integ.c
+++ b/bc_integ.c
@@ -118,7 +118,7 @@ apply_integrated_bc(
   double xi[DIM];             /* Local element coordinates of Gauss point. */
   double x_dot[MAX_PDIM];
   double x_rs_dot[MAX_PDIM];
-  double wt, weight, pr, pb;
+  double wt, weight, pb;
   double xsurf[MAX_PDIM];
   double dsigma_dx[DIM][MDE];
   double func[DIM];
@@ -131,7 +131,6 @@ apply_integrated_bc(
   static JACOBIAN_VAR_DESC_STRUCT jacCol;
   BOUNDARY_CONDITION_STRUCT *bc;
   MATRL_PROP_STRUCT *mp_2;
-  int mn1, mn2;
   struct BC_descriptions *bc_desc;
   VARIABLE_DESCRIPTION_STRUCT *vd;
   double surface_centroid[DIM]; 
@@ -299,8 +298,6 @@ apply_integrated_bc(
 	break;
       }
     }    
-    mn1 = mp->MatID;
-    mn2 = mp_2->MatID;
 
     /*
      * Load up porous media variables and properties, if needed 
@@ -940,11 +937,7 @@ apply_integrated_bc(
 	     * bc is CAP_REPULSE or CAP_RECOIL_PRESS
 	     * because then force is calculated
 	     * later */
-	    pr = BC_Types[bc_input_id].BC_Data_Float[2];
 	    pb = BC_Types[bc_input_id].BC_Data_Float[1];
-	    if (BC_Types[bc_input_id].BC_Name == CAP_REPULSE_BC ||
-	        BC_Types[bc_input_id].BC_Name == CAP_REPULSE_ROLL_BC ||
-		BC_Types[bc_input_id].BC_Name == CAP_RECOIL_PRESS_BC) pr = 0.;
 	    if (BC_Types[bc_input_id].BC_Name == CAPILLARY_TABLE_BC)
                {
 	  apply_table_wic_bc(func, d_func, &BC_Types[bc_input_id], time_value);

--- a/bc_special.c
+++ b/bc_special.c
@@ -1391,7 +1391,7 @@ apply_shell_grad_bc (
                         {
                           pe = upd->ep[eqn];
                           idof = ei->dof[eqn];
-                          for (i=0; i<ei->dof[eqn]; i++)
+                          for (i=0; i < idof; i++)
                             {
                               ib = gnn_map[i];
 
@@ -1403,7 +1403,7 @@ apply_shell_grad_bc (
                                 {
                                   pv = upd->vp[var];
                                   jdof = n_dof[var];
-                                  for (j=0; j<n_dof[var]; j++)
+                                  for (j=0; j < jdof; j++)
                                     {
                                       lec->J[pe][pv][ib][j] +=
 					local_j[pe][pv][i][j];

--- a/dp_map_comm_vec.c
+++ b/dp_map_comm_vec.c
@@ -698,8 +698,8 @@ output_comm_stats(Dpi *dpi, Comm_Ex *cx)
   int gmax_neighbor, gmax_neighbor_proc;
   double avg_mesg = 0.0, gavg_mesg, gavg_neighbor;
   int gmin_neighbor, gmin_neighbor_proc;
-  int gmax_mesg, gmax_mesg_proc;
-  int gmin_mesg, gmin_mesg_proc;
+  int gmax_mesg_proc;
+  int gmin_mesg_proc;
   
   gmax_neighbor = gmaxloc_int(dpi->num_neighbors, ProcID,
 			      &gmax_neighbor_proc);
@@ -713,8 +713,8 @@ output_comm_stats(Dpi *dpi, Comm_Ex *cx)
     avg_mesg += cx[p].num_dofs_send;
   }
 
-  gmax_mesg = gmaxloc_int(max_mesg, ProcID, &gmax_mesg_proc);
-  gmin_mesg = gminloc_int(min_mesg, ProcID, &gmin_mesg_proc);
+  gmaxloc_int(max_mesg, ProcID, &gmax_mesg_proc);
+  gminloc_int(min_mesg, ProcID, &gmin_mesg_proc);
   if (dpi->num_neighbors > 0) {
     avg_mesg /= dpi->num_neighbors;
   }

--- a/dp_utils.c
+++ b/dp_utils.c
@@ -320,13 +320,11 @@ void
 ddd_set_commit(DDD p)
 {
 #ifdef PARALLEL
-  int rtn;
-
-  rtn = MPI_Type_struct(p->num_members, p->block_count, p->address,
-			p->data_type, &p->new_type);
-  rtn = MPI_Type_commit(&p->new_type);
-  rtn = MPI_Type_extent(p->new_type, &p->extent);
-  rtn = MPI_Type_size(p->new_type, &p->size);
+  MPI_Type_struct(p->num_members, p->block_count, p->address,
+		  p->data_type, &p->new_type);
+  MPI_Type_commit(&p->new_type);
+  MPI_Type_extent(p->new_type, &p->extent);
+  MPI_Type_size(p->new_type, &p->size);
   /*  rtn = MPI_Type_count(p->new_type, &p->count); */
 #endif
 
@@ -339,27 +337,25 @@ ddd_set_commit(DDD p)
 char *
 type2string(MPI_Datatype type)
 {
-  Strcpy_rtn strcpy_rtn;
-
   if( type == MPI_INT )
     {
-      strcpy_rtn = strcpy(mpistringbuffer, "MPI_INT");
+      strcpy(mpistringbuffer, "MPI_INT");
     }
   else if( type == MPI_CHAR )
     {
-      strcpy_rtn = strcpy(mpistringbuffer, "MPI_CHAR");
+      strcpy(mpistringbuffer, "MPI_CHAR");
     }
   else if( type == MPI_FLOAT )
     {
-      strcpy_rtn = strcpy(mpistringbuffer, "MPI_FLOAT");
+      strcpy(mpistringbuffer, "MPI_FLOAT");
     }
   else if( type == MPI_DOUBLE )
     {
-      strcpy_rtn = strcpy(mpistringbuffer, "MPI_DOUBLE");
+      strcpy(mpistringbuffer, "MPI_DOUBLE");
     }
   else
     {
-      strcpy_rtn = strcpy(mpistringbuffer, "MPI_WHAT?");
+      strcpy(mpistringbuffer, "MPI_WHAT?");
     }
 
   return(mpistringbuffer);

--- a/el_quality.c
+++ b/el_quality.c
@@ -210,7 +210,7 @@ element_quality(Exo_DB *exo, double *x, int *proc_config)
 static double jacobian_metric(Exo_DB *exo, double *x, int *proc_config)
 {
   int  dofs,  k;
-  int err, ielem, e_start, e_end, igp, ngp, store_shape;
+  int ielem, e_start, e_end, igp, ngp, store_shape;
   double gwt, Jw, Jw_sum, Jw_min, els, eq, eqavg;
   double eqsum = 0.0, eqmin = 999.9;
   double dj00, dj01, dj10, dj11, detJ;
@@ -253,7 +253,7 @@ static double jacobian_metric(Exo_DB *exo, double *x, int *proc_config)
           dj10 = 0.0;
           dj11 = 0.0;
           find_stu(igp, ei->ielem_type, &xi[0], &xi[1], &xi[2]);
-          err = load_basis_functions(xi, bfd);
+          load_basis_functions(xi, bfd);
           gwt = Gq_weight(igp, ei->ielem_type);
 
 	  /* Sum components of elemental Jacobian */
@@ -328,7 +328,8 @@ static double volume_metric(int *proc_config)
 
 static double angle_metric(Exo_DB *exo, double *x, int *proc_config)
 {
-  int i, ielem, e_start, e_end, e_sens, sense;
+  int i, ielem, e_start, e_end, sense;
+  /* int e_sens */
   int bad_elem = FALSE;
   int n, nn;
   double angle, delta, delta_sum, f, els;
@@ -369,7 +370,7 @@ static double angle_metric(Exo_DB *exo, double *x, int *proc_config)
 	  /* First local vertex: set numbering sense */
           if (i == 0)
             {
-              e_sens = sense;
+              /* e_sens = sense; */
             }
 
 	  /* Other vertices: check against reference sense */
@@ -415,7 +416,8 @@ static double angle_metric(Exo_DB *exo, double *x, int *proc_config)
  
 static double triangle_metric(Exo_DB *exo, double *x, int *proc_config)
 {
-  int i, ielem, e_start, e_end, e_sens, sense;
+  int i, ielem, e_start, e_end, sense;
+  /* e_sens */
   int v1, v2, v3;
   int bad_elem = FALSE;
   int isort[4], jsort[4];
@@ -458,7 +460,7 @@ static double triangle_metric(Exo_DB *exo, double *x, int *proc_config)
 	  /* For first subtriangle, record node numbering sense */
           if (v2 == 0)
             {
-              e_sens = sense;
+	      /* e_sens = sense; */
             }
 
 	  /* For others, check sense and update rank arrays */

--- a/exo_conn.c
+++ b/exo_conn.c
@@ -598,7 +598,6 @@ build_elem_elem(Exo_DB *exo)
   int prev_set[MAX_EPN];	/* list of elements attached to previous node*/
   int curr_set[MAX_EPN];	/* list of elements attached to "this" node */
 
-  int interset[MAX_EPN];	/* values of hits between */
 
   int ip[MAX_EPN];		/* indeces of hits for prev_set[] */
   int ic[MAX_EPN];		/* indeces of hits for curr_set[] */
@@ -719,7 +718,6 @@ build_elem_elem(Exo_DB *exo)
 	       {
 		 prev_set[i] = -1;
 		 curr_set[i] = -1;
-		 interset[i] = -1;
 	       }
 	     len_prev  = 0;
 	     len_curr  = 0;
@@ -852,7 +850,6 @@ build_elem_elem(Exo_DB *exo)
 
 		 for ( i=0; i<MAX_EPN; i++)
 		   {
-		     interset[i] = -1;
 		     ip[i]       = -1;
 		     ic[i]       = -1;
 		   }
@@ -1118,7 +1115,6 @@ build_side_node_list(int elem,
   int element_type;
   int i;
   int nodes_this_side;
-  int num_sides;
   int shape;
   
   int local_nodeces[MAX_NODES_PER_SIDE];
@@ -1131,7 +1127,6 @@ build_side_node_list(int elem,
 
   element_type = Elem_Type(exo, elem);
   shape        = type2shape(element_type);
-  num_sides    = shape2sides(shape);
 
   /*
    * Count up the number of nodes and provide their local 0-based

--- a/loca_eigenvalue.c
+++ b/loca_eigenvalue.c
@@ -266,7 +266,7 @@ static int eig_driver(char which[], char bmat[], int iparam[], int mode,
 {
   int      j, kk, ldv, lworkl;
   int      nloc, nloc_max, nloc2, ido, flag;
-  int      count, nconv, ierr;
+  int      count, nconv=0, ierr;
   int      ipntr[14];
   int      dummy1, dummy2, dummy3, dummy4;
   double   *rhs_orig;

--- a/loca_lib.c
+++ b/loca_lib.c
@@ -1039,7 +1039,7 @@ static void print_cont_step1(int order, double step, double step_old,
   struct general_info_struct *cgi = &(con->general_info);
   struct private_info_struct *cpi = &(con->private_info);
 
-  const char *string;
+  const char *string = "";
 
   if (cgi->method == TURNING_POINT_CONTINUATION)
              string = "Zero-order Turning Point Continuation";

--- a/md_timer.c
+++ b/md_timer.c
@@ -133,10 +133,8 @@ void
 get_date(char *string)
 {
   char date_format[80];
-  int i, err;
+  int i;
   char buffer[80];
-  size_t bufsize;
-  time_t s;
   time_t now;
 
   int month_number;
@@ -146,8 +144,7 @@ get_date(char *string)
   for ( i=0; i<80; i++ ) buffer[i] = '\0';
 
   strcpy(date_format, "%m/%d/%y");
-  bufsize = strlen(date_format) + 1; /* to hold the terminating null */
-  s       = time(&now);
+  time(&now);
 
   /*
    * Yes, I know that %y only returns two digits for the year and that's not
@@ -159,13 +156,13 @@ get_date(char *string)
    * a certified warning-free Y2K-complacent version.
    */
 
-  err          = strftime(buffer, 80, "%m", localtime(&now) );
+  strftime(buffer, 80, "%m", localtime(&now) );
   month_number = atoi(buffer);
 
-  err          = strftime(buffer, 80, "%d", localtime(&now) );
+  strftime(buffer, 80, "%d", localtime(&now) );
   day_of_month = atoi(buffer);
 
-  err          = strftime(buffer, 80, "%Y", localtime(&now) );
+  strftime(buffer, 80, "%Y", localtime(&now) );
   year_number  = atoi(buffer);
 
   sprintf(string, "%2d/%2d/%2d", month_number, day_of_month, year_number%100);
@@ -183,15 +180,13 @@ void
 get_time(char *string)
 {
   char time_format[80];
-  int err;
   size_t bufsize;
-  time_t s;
   time_t now;
   
   strcpy(time_format, "%H:%M:%S");
   bufsize = strlen(time_format) + 1;
-  s       = time(&now);
-  err     = strftime(string, bufsize, "%H:%M:%S", localtime(&now) );
+  time(&now);
+  strftime(string, bufsize, "%H:%M:%S", localtime(&now) );
   return;
 } /* end of get_time() */
 

--- a/mm_as_alloc.c
+++ b/mm_as_alloc.c
@@ -893,7 +893,6 @@ assembly_alloc(Exo_DB *exo)
   int mn;
   int vim, dim, wim;                 /* problem dimension */
   int num_species_eqn;                 /* active number of species eqn */
-  int num_phase_funcs;          /* number of active phase functions */
 
   /*
    * The problem description has already been set up. But we need to access
@@ -988,10 +987,6 @@ assembly_alloc(Exo_DB *exo)
    *  in any one domain
    */
   num_species_eqn = upd->Max_Num_Species_Eqn;
-
-  if( pfd != NULL ) num_phase_funcs = pfd->num_phase_funcs;
-  else num_phase_funcs = 0;
-
 
 #ifdef DEBUG
   fprintf(stderr, "%s allocating esp with dim=%d, vim=%d\n", yo, dim, vim);

--- a/mm_augc_util.c
+++ b/mm_augc_util.c
@@ -120,7 +120,6 @@ load_extra_unknownsAC(int iAC,    /* ID NUMBER OF AC'S */
 		      Dpi *dpi)	  /* distributed processing information */
 {
 
-  int ic;
   int mn;
   int ibc, idf;
   struct Boundary_Condition *BC_Type;
@@ -223,7 +222,6 @@ load_extra_unknownsAC(int iAC,    /* ID NUMBER OF AC'S */
     if (augc[iAC].Type == AC_USERMAT || augc[iAC].Type == AC_FLUX_MAT) {
 
       mn = map_mat_index(augc[iAC].MTID);
-      ic = augc[iAC].MDID;
 
       switch (augc[iAC].MPID) {
 
@@ -615,7 +613,6 @@ update_parameterAC(int iAC,      /* ID NUMBER OF The AC */
 		   Exo_DB *exo,	 /* ptr to the finite element mesh database */
 		   Dpi *dpi)	 /* distributed processing information */
 {
-  int ic;
   int mn;
   int ibc, idf;
   int iCC;
@@ -834,7 +831,6 @@ update_parameterAC(int iAC,      /* ID NUMBER OF The AC */
     if (augc[iAC].Type == AC_USERMAT || augc[iAC].Type == AC_FLUX_MAT ) {
 
       mn = map_mat_index(augc[iAC].MTID);
-      ic = augc[iAC].MDID;
 
       switch (augc[iAC].MPID) {
 
@@ -1817,7 +1813,7 @@ overlap_aug_cond ( int ija[],
  * cAC arrays as appropriate.
  */
 {
-  int err, ibf = -1, ibs = -1, ib, i, jAC, kdir;
+  int err, ibf = -1, ibs = -1, ib, i, jAC;
   int e_start, e_end, ielem, iside, jelem, jside;
   int solid_eb, fluid_eb, lm_eb;
   double h[DIM];
@@ -1911,7 +1907,6 @@ overlap_aug_cond ( int ija[],
             {
               ielem = augc[jAC].lm_elem;
               iside = augc[jAC].lm_side;
-              kdir  = augc[jAC].lm_dim;
               if (ielem != jelem || iside != jside)
                 {
 
@@ -1983,7 +1978,6 @@ overlap_aug_cond ( int ija[],
             {
               ielem = augc[jAC].lm_elem;
               iside = augc[jAC].lm_side;
-              kdir  = augc[jAC].lm_dim;
               if (ielem == -1 || ielem != jelem || iside != jside)
                 {
 
@@ -2704,7 +2698,6 @@ std_lgr_cond ( int iAC,
 		
 {
   double inventory;
-  double lambda ; 
   int i, jAC;
   double theta_scale = 1.0;
 #ifdef PARALLEL
@@ -2725,10 +2718,6 @@ std_lgr_cond ( int iAC,
    */
   load_extra_unknownsAC(iAC, x_AC, cx, mf_args->exo, mf_args->dpi);
 
-
-
-  lambda = x_AC[iAC];   
-  
   if( augc[iAC].Type == AC_LGRM )
     {
 	  
@@ -2921,7 +2910,7 @@ create_overlap_acs(Exo_DB *exo, int iAC)
   int old_nAC, new_ACs = -1, new_nAC;
   int ac_count, i, j, k, nqp, si = 0, ss = -1;
   int sb, fb, lb;
-  int e, s, qp;
+  int e, s;
   int found = FALSE;
   int dim = pd->Num_Dim;
   int sse_first[MAX_NGV];
@@ -3031,7 +3020,6 @@ create_overlap_acs(Exo_DB *exo, int iAC)
             {
               for (j=0; j<nqp; j++)
                 {
-                  qp = j;
                   for (k=0; k<pd->Num_Dim; k++)
                     {
                       augc[ac_count].Type = AC_OVERLAP;
@@ -3114,10 +3102,10 @@ assign_overlap_acs( double x[], Exo_DB *exo )
  */
 {
   int iAC, k;
-  int sb, fb, lb;
+  int fb, lb;
   int e;
   int e_start, e_end;
-  int ibs = -1, ibf = -1, ib;
+  int ibf = -1, ib;
   
   for (iAC=0; iAC<nAC; iAC++)
     {
@@ -3129,7 +3117,6 @@ assign_overlap_acs( double x[], Exo_DB *exo )
     } 
 
 /* Read inputs from existing overlap AC */
-  sb = augc[iAC].solid_eb + 1;
   fb = augc[iAC].fluid_eb + 1;
   lb = augc[iAC].lm_eb + 1;
 
@@ -3139,7 +3126,6 @@ assign_overlap_acs( double x[], Exo_DB *exo )
   /* Locate fluid and solid blocks in exo structure */
   for (ib = 0; ib < exo->num_elem_blocks; ib++)
     {
-      if (exo->eb_id[ib] == sb) ibs = ib;
       if (exo->eb_id[ib] == fb) ibf = ib;
     }
 
@@ -3411,7 +3397,6 @@ double getPositionAC(struct AC_Information *augc, double *cAC_iAC,
   double posNode[3];
   int i, ins, inode;
   NODE_INFO_STRUCT  *node_ptr;
-  NODAL_VARS_STRUCT *nv;
   double pos1D = 0.0;
 
   if (augc->COMPID != 0 && augc->COMPID != 1) {
@@ -3444,7 +3429,6 @@ double getPositionAC(struct AC_Information *augc, double *cAC_iAC,
   int node = -1;
   for (i = 0; i <  Num_Internal_Nodes + Num_Border_Nodes ; i++) {
     node_ptr = Nodes[i];
-    nv = node_ptr->Nodal_Vars_Info;
     if (globalNodeNum  == node_ptr->Global_Node_Num) {
       node = i;
       break;

--- a/mm_bc.c
+++ b/mm_bc.c
@@ -166,7 +166,7 @@ find_and_set_Dirichlet(double x[],    /* solution vector at this processor */
 #endif /* DEBUG_BC */
   int apply_pressure_datum;	/* boolean */
   int i, ibc, ins, inode = -1, error_cond = FALSE;
-  int num_nodes, n, iconnect_ptr, ndof, datum_set, var, ie, local_elem;
+  int num_nodes, n, iconnect_ptr, datum_set, ie, local_elem;
   NODE_INFO_STRUCT *node;
   NODAL_VARS_STRUCT *nv;
   VARIABLE_DESCRIPTION_STRUCT *vd;
@@ -459,8 +459,6 @@ find_and_set_Dirichlet(double x[],    /* solution vector at this processor */
       inode = Proc_Elem_Connect[iconnect_ptr + n];
       node = Nodes[inode];
       nv = node->Nodal_Vars_Info;
-      ndof  = 0;	
-      var   = PRESSURE;
       if (Dolphin[inode][PRESSURE] > 0 && datum_set) {
 	datum_set = 0;
 	if (!node->DBC) {
@@ -1448,7 +1446,6 @@ set_up_Edge_BC (struct elem_edge_bc_struct *First_Elem_Edge_BC_Array[ ],
   int j;
   int ss_id1;
   int ss_id2;
-  int side;
   int kdex;
   int k2_start;
   char err_msg[MAX_CHAR_IN_INPUT];
@@ -1470,6 +1467,9 @@ set_up_Edge_BC (struct elem_edge_bc_struct *First_Elem_Edge_BC_Array[ ],
   int l, k, k_node;
   int node_list[MDE];
   int node_ctr = -1;
+#ifdef DEBUG
+  int side;
+#endif
 #ifdef PARALLEL
   int iss1g, iss2g;
 #endif
@@ -1578,8 +1578,8 @@ set_up_Edge_BC (struct elem_edge_bc_struct *First_Elem_Edge_BC_Array[ ],
 	      for ( i=0; i<exo->ss_num_sides[iss1]; i++)
 		{
 		  ielem = exo->ss_elem_list[exo->ss_elem_index[iss1]+i];
-		  side  = exo->ss_side_list[exo->ss_elem_index[iss1]+i];
 #ifdef DEBUG
+		  side  = exo->ss_side_list[exo->ss_elem_index[iss1]+i];
 		  fprintf(stderr, "Side/elem = %d, %d\n", ielem, side);
 #endif
 		  num_nodes_on_side = ( exo->ss_node_side_index[iss1][i+1] -
@@ -1812,7 +1812,7 @@ set_up_Embedded_BC ()
 {
   int 	                ibc;
   struct LS_Embedded_BC *bc;
-  int                   found_capillary=FALSE;
+  /* int                   found_capillary=FALSE; */
   int                   pf;
 
   /*****************************************************************************/
@@ -1851,7 +1851,7 @@ set_up_Embedded_BC ()
       
       bc->bc_input_id = ibc;
       
-      if ( BC_Types[ibc].BC_Name == LS_CAPILLARY_BC ) found_capillary = TRUE;
+      /* if ( BC_Types[ibc].BC_Name == LS_CAPILLARY_BC ) found_capillary = TRUE; */
 
     } else if (!strcmp(BC_Types[ibc].Set_Type, "PF")) {
       
@@ -1873,7 +1873,7 @@ set_up_Embedded_BC ()
       
       bc->bc_input_id = ibc;
       
-      if ( BC_Types[ibc].BC_Name == PF_CAPILLARY_BC ) found_capillary = TRUE;
+      /* if ( BC_Types[ibc].BC_Name == PF_CAPILLARY_BC ) found_capillary = TRUE; */
 
     }
   }  /* END for (ibc = 0; ibc < Num_BC; ibc++)			     */
@@ -2402,8 +2402,6 @@ find_id_side(const int ielem,			/* element index number */
   int i;
   double sum;
   
-  Spfrtn sr;
-    
   char err_msg[MAX_CHAR_ERR_MSG];  
 
   static char *yo = "find_id_side";

--- a/mm_bc_conflict.c
+++ b/mm_bc_conflict.c
@@ -293,7 +293,7 @@ check_for_bc_conflicts2D(Exo_DB *exo, Dpi *dpi)
   int ivar, jvar, var=-1;
   int count_BC, count_DC, count_rotate, count_weak, count_strong;
   int count_coll, count_special;
-  int ss_rot, bc_rot, dir_rot, i_rotate, two_ss_rot;
+  int ss_rot, dir_rot, i_rotate, two_ss_rot;
   int divert;			/* output diag of duplications to file */
   int bickel;			/* BC list temp variable */
   char bc_divert_fn[MAX_FNL];
@@ -1828,7 +1828,6 @@ check_for_bc_conflicts2D(Exo_DB *exo, Dpi *dpi)
 	  count_special = 0;
 	  ss_rot = -1;
 	  two_ss_rot = -1;
-	  bc_rot = -1;
 	  dir_rot = -1;
 	  for (jvar = 0; jvar < pd_glob[0]->Num_Dim; jvar++) {
 	    var = eqn + jvar;
@@ -1853,7 +1852,6 @@ check_for_bc_conflicts2D(Exo_DB *exo, Dpi *dpi)
 		    two_ss_rot = 1;
 		  }
 		  ss_rot = BC_Types[ibc].BC_ID;
-		  bc_rot = BC_Types[ibc].BC_Name;
 		  dir_rot = jvar;
 		  count_rotate++;
 		} else {
@@ -2015,16 +2013,15 @@ check_for_bc_conflicts3D(Exo_DB *exo, Dpi *dpi)
   int i, ibc, iss, num_bc_nodes;
   int  ibc1, ibc2, inode, bct1, bct2, k, ins;
   int ***BC_Unk_List, **NS_list, eqn, idup, p, q, j, num_total_nodes, dups;
-  int num_rot_nodes, irc, eq = -1, bc_found, node_ok, iptr;
+  int num_rot_nodes, irc, eq = -1, node_ok, iptr;
+#ifndef PARALLEL
+  int bc_found;
+#endif
   int dim, bct, bcSS, bcSS1, eprint;
   int standard_BC, ndup, j_DC, j_PC, j_SI, j_CSWI;
   int save_this_bc[MAX_SS_PER_NODE];
   int ndup1[DIM], save_this_bc1[DIM][MAX_SS_PER_NODE];
-  int tilt_bct = -1;
-  int tilt_bcSS = -1;
-  int tilt_save = -1;
   int faceBC, vertexBC, edgeBC;
-  int val = 0;
   FILE *ofbc = NULL;		/* output file stream handle for BC info */
   char ofbc_fn[MAX_FNL];	/* output file name for BC info */
   int matIndex, offset, retn_matIndex;
@@ -2033,6 +2030,12 @@ check_for_bc_conflicts3D(Exo_DB *exo, Dpi *dpi)
   NODE_INFO_STRUCT *node;
   NODAL_VARS_STRUCT *nv;
   VARIABLE_DESCRIPTION_STRUCT *vd, *vd_retn2;
+#ifndef PARALLEL
+  int tilt_bct = -1;
+  int tilt_bcSS = -1;
+  int tilt_save = -1;
+  int val = 0;
+#endif
 
   strcpy(ofbc_fn, BC_3D_INFO_FILENAME); /* def in rf_bc_const.h */
 
@@ -2543,11 +2546,15 @@ check_for_bc_conflicts3D(Exo_DB *exo, Dpi *dpi)
 	    for (p=0; p<dim; p++) {
 	      bct  = ROT_Types[irc].BC_Type[p];
 	      bcSS = ROT_Types[irc].BC_SS[p];
+#ifndef PARALLEL
 	      bc_found = 0;
+#endif
 
 	      if (bct < 0) {
 		/* don't do anything this is a rotated piece */
+#ifndef PARALLEL
 		bc_found = 1;
+#endif
 	      } else {
 		/* find BC in dup list */
 
@@ -2574,10 +2581,12 @@ check_for_bc_conflicts3D(Exo_DB *exo, Dpi *dpi)
 		     * not found...
 		     */
 
+#ifndef PARALLEL
 		    tilt_bct  = ( bct != bct1 );
 		    tilt_bcSS = ( bcSS != bcSS1 );
 		    tilt_save = ( save_this_bc1[q][j] != 0 );
 		    val       = save_this_bc1[q][j];
+#endif
 
 		    if ( bct == bct1 && 
 			 bcSS == bcSS1 && 
@@ -2586,7 +2595,9 @@ check_for_bc_conflicts3D(Exo_DB *exo, Dpi *dpi)
 		       * Found the BC which is specified 
 		       * by ROT condition!! 
 		       */
+#ifndef PARALLEL
 		      bc_found = 1;
+#endif
 		      ROT_Types[irc].BC_desc[p] = 
 			  BC_Types[ibc1].desc;
 		      ROT_Types[irc].BC_id[p] = ibc1;

--- a/mm_dil_viscosity.c
+++ b/mm_dil_viscosity.c
@@ -280,14 +280,11 @@ dil_viscosity(GEN_NEWT_STRUCT *gn_local,
        * 1.0E-4.
        */
       double volF = mp->volumeFractionGas;
-      int volFCropped = 0;
       if (mp->volumeFractionGas < 1.0E-4) {
 	volF = 1.0E-4;
-	volFCropped = 1;
       } else if (mp->volumeFractionGas < 1.0) {
 	volF = mp->volumeFractionGas;
       } else {
-	volFCropped = 1;
 	volF = 1.0;
       }
      

--- a/mm_fill_aux.c
+++ b/mm_fill_aux.c
@@ -1324,7 +1324,7 @@ surface_determinant_and_normal(
   int 		i, id, inode, a, b, p, q;
   int		ShapeVar, ldof;
   int		DeformingMesh;
-  double        det, r_det, det_h01, r_det_h01, d_det_h01_x;
+  double        r_det, det_h01, r_det_h01, d_det_h01_x;
   double        phi_i;
   int siz;
   double        T[DIM-1][DIM], t[DIM-1][DIM];  /* t = J . T */
@@ -1354,7 +1354,6 @@ surface_determinant_and_normal(
       /*
        *  This code should be considered to be untested. It worked for one case.
        */
-      det = fv->sdet = 1.0;
       // ok we fill up snormal
       shell_determinant_and_normal(ei->ielem, ei->iconnect_ptr, ei->num_local_nodes,
 				   ei->ielem_dim, 1);

--- a/mm_fill_fill.c
+++ b/mm_fill_fill.c
@@ -164,7 +164,6 @@ assemble_fill(double tt,
   int eqn, var, peqn, pvar, dim, status;
   int i, j, a, b, c;
   
-  dbl F;				/* Fill function. */
   dbl F_dot;				/* Fill derivative wrt time. */
   dbl *grad_F;  			/* Fill gradient. */
 
@@ -238,7 +237,6 @@ assemble_fill(double tt,
 
   if(eqn == R_FILL)
 	{
-  	F = fv->F;
   	if (pd->TimeIntegration != STEADY)
     		{ F_dot = fv_dot->F; }
   	else
@@ -247,7 +245,6 @@ assemble_fill(double tt,
 	}
   else
 	{
-	F = fv->pF[ls->var-PHASE1];
   	if (pd->TimeIntegration != STEADY)
     		{ F_dot = fv_dot->pF[ls->var-PHASE1]; }
   	else
@@ -1155,7 +1152,6 @@ assemble_fill_ext_v(double tt,
   int eqn, var, peqn, pvar, dim, status;
   int i, j, a, b;
   
-  dbl F;				/* Fill function. */
   dbl F_dot;				/* Fill derivative wrt time. */
   dbl *grad_F;  			/* Fill gradient. */
 
@@ -1198,7 +1194,7 @@ assemble_fill_ext_v(double tt,
   int dofs;
   dbl ext_v, ext_v_old, ext_v_mag, ext_v_avg;
   dbl d_tau_ext_v[MDE];
-  dbl gfmag_inv, gfmag_old;
+  dbl gfmag_old;
 
   /* terms for shock capturing term */
   dbl d_visc_dF[MDE];
@@ -1238,7 +1234,6 @@ assemble_fill_ext_v(double tt,
 
   if(pfd == NULL)
 	{
-  	F = fv->F;
   	if (pd->TimeIntegration != STEADY)
     		{ F_dot = fv_dot->F; }
   	else
@@ -1247,7 +1242,7 @@ assemble_fill_ext_v(double tt,
 	}
   else
 	{
-	F = fv->pF[ls->var-PHASE1];
+
   	if (pd->TimeIntegration != STEADY)
     		{ F_dot = fv_dot->pF[ls->var-PHASE1]; }
   	else
@@ -1276,8 +1271,6 @@ assemble_fill_ext_v(double tt,
 
   load_lsi( 0. );
   load_lsi_derivs();
-
-  gfmag_inv = 1./lsi->gfmag;
 
   dofs     = ei->dof[EXT_VELOCITY];
 
@@ -1880,7 +1873,6 @@ assemble_fill_gradf(double tt,
   int eqn, var, peqn, pvar, dim, status;
   int i, j, a, b;
   
-  dbl F;				/* Fill function. */
   dbl *grad_F;  			/* Fill gradient. */
   dbl phi_i;                    /* i-th basis function for the FILL equation. */
 
@@ -1900,7 +1892,6 @@ assemble_fill_gradf(double tt,
   dbl gradphi_gradphi[MDE][MDE];/* gradphi.gradphi */
   dbl d_gradF_dmesh_gradF;      /* d_dgradF_dmesh.gradF */
   dbl S;                        /* sign(F) */
-  dbl dtinv;                    /* = 1 / dt */
   int Fill_Weight_Fcn;          /* Fill weight function. */
 
   /* Terms needed for GLS stabilization */
@@ -1932,9 +1923,6 @@ assemble_fill_gradf(double tt,
   wt		  = fv->wt;                       /* Gauss point weight. */
   h3		  = fv->h3;                       /* Differential volume element. */
   det_J		  = bf[eqn]->detJ;                /* Really, ought to be mesh eqn. */
-  dtinv           = 1.0 / dt;                     /* Ah, 1 / dt. */
-
-  F = fv->F;
 
   h_elem = 0.;
   for ( a=0; a<dim; a++) h_elem += hsquared[a];
@@ -4462,7 +4450,7 @@ assemble_surface (Exo_DB *exo,	/* ptr to basic exodus ii mesh information */
 {
 /*    TAB certifies that this function conforms to the exo/patran side numbering convention 11/9/98. */
 
-  int ip, ip1, i, j, I, J, dim;     /* counters */
+  int ip, ip1, i, j, I, J;     /* counters */
   int a, idof, jdof, ie, je, ja;    /* more counters */
   int nodes_per_side;
   int local_elem_node_id[MAX_NODES_PER_SIDE];
@@ -4498,7 +4486,6 @@ assemble_surface (Exo_DB *exo,	/* ptr to basic exodus ii mesh information */
   ip_total = elem_info(NQUAD_SURF, ielem_type);
   
   eqn = FILL;
-  dim =  pd->Num_Dim;
 
   /* Use one point surface quadrature integration 
      to get the sign of v*n */
@@ -5537,7 +5524,6 @@ neighbor_species(Exo_DB *exo,	/* ptr to basic exodus ii mesh information */
   int inode[MAX_NODES_PER_SIDE];
   int ip, ip_total;
   int p, dim;     /* counters */
-  int ktype;
   int nvdof;
   int status = 0;
   int v;
@@ -5616,9 +5602,6 @@ neighbor_species(Exo_DB *exo,	/* ptr to basic exodus ii mesh information */
 				ielem_shape, pd->i[v], i);
 	}
 
-
-      
-      ktype = 0;
       iconnect_ptr    = Proc_Connect_Ptr[neighbor_elem]; /* find pointer to beginning */
       for ( i=0; i< ei->dof[v]; i++)
 	{
@@ -5921,7 +5904,7 @@ assemble_phase_function ( double time_value,
 
   double det_J, h3, wt, phi_i, phi_j, wfcn = 0, *grad_phi_j, *grad_phi_i;
   double d_wfcn_du;
-  double pf, pf_dot,  *grad_pf ;
+  double pf_dot,  *grad_pf ;
   double *v, *v_old;
   dbl *xx;                              /* Nodal coordinates. */
   dbl *x_old;                           /* Old xx[]. */
@@ -5941,7 +5924,8 @@ assemble_phase_function ( double time_value,
   dbl supg_term, vcent[DIM], d_vcent_du[DIM][MDE][DIM], d_supg_term_du[MDE][DIM], d_supg_term_dx[MDE][DIM];
 
 
-  double rhs = 0, mass=0.0, advection=0.0, tmp = 0.0, d_n_gradT_dT[MDE];
+  double rhs = 0, mass=0.0, advection=0.0, tmp = 0.0;
+  /* double pf, d_n_gradT_dT[MDE]; */
   double tau_gls,vmag_old;
   struct Level_Set_Data *ls_old;
 
@@ -6114,7 +6098,7 @@ assemble_phase_function ( double time_value,
       eqn = R_PHASE1 + a;
       peqn = upd->ep[eqn];
 	  
-      pf = fv->pF[a];
+      /* pf = fv->pF[a]; */
       pf_dot = fv_dot->pF[a];
       grad_pf = fv->grad_pF[a];
       ls_old = ls;

--- a/mm_fill_potential.c
+++ b/mm_fill_potential.c
@@ -211,6 +211,12 @@ assemble_potential(double time,	/* present time value */
    */
   int n_species = mp->Num_Species; 
 
+  /* initialize grad_phi_j, grad_phi_i */
+  for (j = 0; j < DIM; j++) {
+    grad_phi_i[j] = 0;
+    grad_phi_j[j] = 0;
+  }
+
   /*   static char yo[] = "assemble_current";*/
 
   status = 0;
@@ -2273,7 +2279,7 @@ int i, j, a, w;
 
   int i_elec_cond;                       /* index of external field elec. conductivity */
   int n, l, m, mn, kk; 
-  dbl sum1, sum2, sum3, err;
+  dbl sum1, sum2, sum3;
 
   dim = pd->Num_Dim;
   /*** Electrical Conductivity ****/
@@ -2704,8 +2710,8 @@ int i, j, a, w;
        */
       if (mp->VoltageFormulation == V_PERMITTIVITY)
         {
-	  err = level_set_property(mp->u_electrical_conductivity[0], mp->u_electrical_conductivity[1], 
-				   mp->u_electrical_conductivity[2], &k, NULL);
+	  level_set_property(mp->u_electrical_conductivity[0], mp->u_electrical_conductivity[1], 
+			     mp->u_electrical_conductivity[2], &k, NULL);
         }
       else
         {

--- a/mm_fill_pthings.c
+++ b/mm_fill_pthings.c
@@ -160,11 +160,10 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
 						 explicit (tt = 1) to implicit (tt = 0) */
 			dbl dt)               /* current time step size */
 {
-  int err, dim, wim, p, q, a, b, eqn, var, ii, peqn, pvar, w, ledof;
+  int dim, wim, p, q, a, b, eqn, var, ii, peqn, pvar, w, ledof;
   int i, j, m, status;
   struct Basis_Functions *bfm;
 
-  dbl T;				/* Temperature. */
   dbl pv[DIM];			        /* Velocity field. */
   dbl pv_dot[DIM];		         	/* time derivative of velocity field. */
   dbl x_dot[DIM];			/* current position field derivative wrt time. */
@@ -175,16 +174,8 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
   dbl grad_pv[DIM][DIM];	        /* Gradient of pv. */
   dbl gamma[DIM][DIM];                  /* shrearrate tensor based on velocity */
 
-  dbl muk[DIM][DIM];			/* mu/kappa where kappa is the */
-					/* permeability of the porous media */
-
   dbl Pi[DIM][DIM];		/* Total stress tensor (multiplied by coeff). */
   dbl Pi_raw[DIM][DIM];		/* Rate of strain tensor (no coeff). */
-
-  dbl s[DIM][DIM];                      /* polymer stress tensor */
-  dbl gamma_cont[DIM][DIM];             /* shearrate tensor based on continuous gradient of velocity */
-
-  dbl P;				/* Pressure. */
 
   dbl rho;				/* Density. */
   
@@ -273,7 +264,7 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
   DENSITY_DEPENDENCE_STRUCT *d_rho = &d_rho_struct;
   
 /* set porous-flow parameters depending on which zone we are in. KSC on 5/10/95 */ 
-  dbl evss_f;      /* flag to add in the continuous velocity 
+  /* dbl evss_f; */     /* flag to add in the continuous velocity 
 		      gradient tensor for Fortin's formulation */
 
   /* MMH
@@ -281,8 +272,7 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
    * at the particle momentum model.
    */
   int species=-1;		/* Species number of particle phase */
-  double rho_f,rho_p=1e12;	/* Fluid and solid densities */
-  double delta_rho;		/* rhof-rhos */
+  double rho_p=1e12;	/* Fluid and solid densities */
   double p_vol_frac=1e12;	/* Particle volume fraction (phi) */
   double mul1;			/* Used for the strain tensor */
   double EpEp[DIM][DIM];	/* For tensor . tensor */
@@ -366,9 +356,7 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
     {
       /* This is the species number of the particle phase. */
       species = (int) mp->u_density[0]; 
-      rho_f = mp->u_density[1];
       rho_p = mp->u_density[2];
-      delta_rho = rho_p-rho_f;
       p_vol_frac = fv->c[species];
       if(p_vol_frac<0.0 || p_vol_frac>1.0)
 	{
@@ -397,10 +385,6 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
       vis = mp->FlowingLiquid_viscosity;
       sc  = mp->Inertia_coefficient;
       
-      for ( a=0; a<dim; a++)
-	{
-	  muk[a][a] = (vis/per);   
-	}
     } 
   else 
     {
@@ -410,14 +394,13 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
       sc  = 0.;
     }
 
-  err = pmomentum_source_term(f, dfdT, dfdX, dfdC, dfdv);
+  pmomentum_source_term(f, dfdT, dfdX, dfdC, dfdv);
 
   eqn   = R_PMOMENTUM1;
 		
   /*
    * Field variables...
    */
-  T = fv->T;
   for (a = 0; a < wim; a++) {
     pv[a] = fv->pv[a];
     if (pd->TimeIntegration != STEADY &&
@@ -441,8 +424,6 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
     } 
   speed = sqrt(speed);
 
-  P = fv->P;
-
   /*
    * In Cartesian coordinates, this velocity gradient tensor will
    * have components that are...
@@ -458,18 +439,11 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
 	{
 	  grad_pv[a][b] = fv->grad_pv[a][b];
 	  
-	  if ( pd->v[POLYMER_STRESS11] )
-	    {
-	      s[a][b] = fv->S[0][a][b];
-	    }
-	  else
-	    {
-	      s[a][b] = 0.;
-	    }
 	}
     }
 
 
+  /*
   if ( pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F) )
     {
       evss_f = 1.;
@@ -478,30 +452,7 @@ int assemble_pmomentum (dbl time_value,       /* current time for density model 
     {
       evss_f = 0.;
     }
-
-  if ( evss_f )
-    {
-      for ( a=0; a<VIM; a++)
-	{
-	  for ( b=0; b<VIM; b++)
-	    {
-	      gamma_cont[a][b] = fv->G[a][b] + fv->G[b][a] ;
-	    }
-	}
-    }
-  else
-    {
-      for ( a=0; a<VIM; a++)
-	{
-	  for ( b=0; b<VIM; b++)
-	    {
-	       gamma_cont[a][b] = 0.;
-	     }
-	}
-    }
-
-	     
-
+  */
 /* load up shearrate tensor based on velocity */
   for ( a=0; a<VIM; a++)
     {

--- a/mm_fill_ptrs.c
+++ b/mm_fill_ptrs.c
@@ -208,7 +208,6 @@ load_ei(const int elem, const Exo_DB *exo, struct Element_Indices *ei_ptr_fill)
   bool ImAChild, ImAParent;
 
   int n_eb_Parent, elem_Parent, n_mn_Parent, n_ielem_type_Parent;
-  int  n_elem_blk_index_Parent, n_elem_blk_id_Parent , n_ielem_dim_Parent;
   int iconnect_ptr_Parent;
   int  num_local_nodes_Parent;
   
@@ -1043,10 +1042,6 @@ load_ei(const int elem, const Exo_DB *exo, struct Element_Indices *ei_ptr_fill)
 	      /* Get the element type of the parent */
 	      n_ielem_type_Parent = Elem_Type(exo, elem_Parent);
 	      
-	      /* Get the element block index # of the parent */
-	      n_elem_blk_index_Parent = find_elemblock_index(elem_Parent, exo);
-	      n_elem_blk_id_Parent    = exo->eb_id[n_elem_blk_index_Parent];
-	      n_ielem_dim_Parent      = elem_info(NDIM, n_ielem_type_Parent);
 	      /*
 	       *   Store the pointer to the beginning of this element's
 	       *   connectivity list
@@ -1144,10 +1139,6 @@ load_ei(const int elem, const Exo_DB *exo, struct Element_Indices *ei_ptr_fill)
 	      /* Get the element type of the parent */
 	      n_ielem_type_Parent = Elem_Type(exo, elem_Parent);
 	      
-	      /* Get the element block index # of the parent */
-	      n_elem_blk_index_Parent = find_elemblock_index(elem_Parent, exo);
-	      n_elem_blk_id_Parent    = exo->eb_id[n_elem_blk_index_Parent];
-	      n_ielem_dim_Parent      = elem_info(NDIM, n_ielem_type_Parent);
 	      /*
 	       *   Store the pointer to the beginning of this element's
 	       *   connectivity list

--- a/mm_fill_rs.c
+++ b/mm_fill_rs.c
@@ -155,7 +155,6 @@ assemble_real_solid(double time_value,
   dbl mass, diffusion, advection=0, advect_a, advect_b, advect_c;
 
   dbl source;
-  dbl porous;
 
   dbl wt;
 
@@ -461,7 +460,6 @@ assemble_real_solid(double time_value,
 		  source *= pd->etm[eqn][(LOG2_SOURCE)];
 		}
 
-	      porous = 0.;
 	      /* porous term removed for SOLID equation - the additional effects due
 		 to porosity are entered into the consitutive equation for stress */
 
@@ -2051,7 +2049,7 @@ get_convection_velocity_rs(double vconv[DIM], /*Calculated convection velocity *
    * Some local variables for convenience...
    */
   
-  int err, dim, p, q, b, var, i;
+  int dim, p, q, b, var, i;
   
   dim = pd->Num_Dim;
 
@@ -2115,7 +2113,7 @@ get_convection_velocity_rs(double vconv[DIM], /*Calculated convection velocity *
    else if (elc_rs->v_mesh_sfs_model == ROTATIONAL ||
 		elc_rs->v_mesh_sfs_model == ROTATIONAL_3D )
      {
-       err = V_mesh_sfs_model(elc_rs->u_v_mesh_sfs, elc_rs->v_mesh_sfs, 
+       V_mesh_sfs_model(elc_rs->u_v_mesh_sfs, elc_rs->v_mesh_sfs, 
 				elc_rs->v_mesh_sfs_model, -1);
      }
    
@@ -2382,11 +2380,11 @@ f_kinematic_displacement_rs_bc(double func[DIM],
   int j, kdir, var, p;
   double phi_j;
   double base_displacement[DIM];
-  double base_displacement_rs[DIM];
+  /*  double base_displacement_rs[DIM];*/
   int *n_dof = NULL;
 /***************************** EXECUTION BEGINS *******************************/
   for (p = 0; p<pd->Num_Dim; p++) base_displacement[p] = fv->initial_displacements[p];
-  for (p = 0; p<pd->Num_Dim; p++) base_displacement_rs[p] = fv->initial_displacements[p + DIM];
+  /*  for (p = 0; p<pd->Num_Dim; p++) base_displacement_rs[p] = fv->initial_displacements[p + DIM];*/
 
  /*
    * Prepare geometry

--- a/mm_fill_solid.c
+++ b/mm_fill_solid.c
@@ -5566,8 +5566,6 @@ load_plastic_properties(double d_plastic_mu_dc[MAX_CONC][MDE],
   /*local variables */
   int err = 0;
   double min;
-  double plastic_mu;
-  double yield;
   int b, j, var;
 
   if(evpl->plastic_mu_model == USER )
@@ -5575,11 +5573,6 @@ load_plastic_properties(double d_plastic_mu_dc[MAX_CONC][MDE],
 /*  Take care of this later
       err = usr_plastic_mu(evpl->u_plastic_mu); */
       EH(err,"bad user plastic_mu model");
-      plastic_mu = evpl->plastic_mu;
-    }
-  else if (evpl->plastic_mu_model == CONSTANT )
-    {
-      plastic_mu = evpl->plastic_mu;
     }
   else if (evpl->plastic_mu_model == LINEAR )
     {
@@ -5599,7 +5592,7 @@ load_plastic_properties(double d_plastic_mu_dc[MAX_CONC][MDE],
         {
           min= evpl->u_plastic_mu[1];
 	}   
-      plastic_mu = evpl->plastic_mu = min + (elc->Strss_fr_sol_vol_frac - fv->c[0])/elc->Strss_fr_sol_vol_frac *
+      evpl->plastic_mu = min + (elc->Strss_fr_sol_vol_frac - fv->c[0])/elc->Strss_fr_sol_vol_frac *
 		   fabs(evpl->u_plastic_mu[1] - evpl->u_plastic_mu[0]); 
       var=MASS_FRACTION;
       for (b=0; b<pd->Num_Species_Eqn; b++) 
@@ -5621,11 +5614,6 @@ load_plastic_properties(double d_plastic_mu_dc[MAX_CONC][MDE],
 /*   take care of this later 
       err = usr_plastic_mu(evpl->u_yield); */
       EH(err,"bad user yield model");
-      yield = evpl->yield;
-    }
-  else if (evpl->yield_model == CONSTANT )
-    {
-      yield = evpl->yield;
     }
   else if (evpl->yield_model == LINEAR )
     {
@@ -5645,7 +5633,7 @@ load_plastic_properties(double d_plastic_mu_dc[MAX_CONC][MDE],
         {
           min= evpl->u_yield[1];
 	} 
-      yield = evpl->yield = min + (elc->Strss_fr_sol_vol_frac - fv->c[0])/elc->Strss_fr_sol_vol_frac *
+      evpl->yield = min + (elc->Strss_fr_sol_vol_frac - fv->c[0])/elc->Strss_fr_sol_vol_frac *
 		   fabs(evpl->u_yield[1] - evpl->u_yield[0]); 
       var=MASS_FRACTION;
       for (b=0; b<pd->Num_Species_Eqn; b++) 

--- a/mm_fill_stress.c
+++ b/mm_fill_stress.c
@@ -112,8 +112,6 @@ assemble_stress(dbl tt,		/* parameter to vary time integration from
   int i, j, status;
 
   dbl v[DIM];			        /* Velocity field. */
-  dbl xx[DIM];	        		/* position field. */
-  dbl x_old;		        	/* old position field. */
   dbl x_dot[DIM];			/* current position field derivative wrt time. */
   dbl h3;		        	/* Volume element (scale factors). */
   dbl dh3dmesh_pj;	        	/* Sensitivity to (p,j) mesh dof. */
@@ -203,10 +201,6 @@ assemble_stress(dbl tt,		/* parameter to vary time integration from
   dbl alpha;     /* This is the Geisekus mobility parameter */
   dbl lambda=0;    /* polymer relaxation constant */
 
-  /*  shift function */
-  dbl at;
-  dbl wlf_denom;
-
   /* advective terms are precalculated */
   dbl v_dot_del_g[DIM][DIM];
   dbl x_dot_del_g[DIM][DIM];
@@ -273,8 +267,6 @@ assemble_stress(dbl tt,		/* parameter to vary time integration from
       /* note, these are zero for steady calculations */
       if (  pd->TimeIntegration != STEADY &&  pd->v[MESH_DISPLACEMENT1+a] )
 	{
-	  xx[a] = fv->x[a];
-	  x_old = fv_old->x[a];
 	  x_dot[a] = fv_dot->x[a];
 	}
       else
@@ -364,24 +356,6 @@ assemble_stress(dbl tt,		/* parameter to vary time integration from
 
   (void) stress_eqn_pointer(v_s);
   (void) stress_eqn_pointer(R_s);
-
-      /*  shift factor  */
-      if(vn->shiftModel == CONSTANT)
-	{
-	  at = vn->shift[0];
-	}
-      else if(vn->shiftModel == MODIFIED_WLF)
-	{
-  	wlf_denom = vn->shift[1] + fv->T - mp->reference[TEMPERATURE];
-  	if(wlf_denom != 0.)
-        	{
-      		at=exp(vn->shift[0]*(mp->reference[TEMPERATURE]-fv->T)/wlf_denom);
-        	}
-  	else
-    		{ 
-      		at = 1.;
-    		} 
-	}
 
   /* Begin loop over modes */
   for ( mode=0; mode<vn->modes; mode++)
@@ -1378,8 +1352,6 @@ assemble_stress_fortin(dbl tt,	/* parameter to vary time integration from
 
   int i, j, status, mode;
   dbl v[DIM];			        /* Velocity field. */
-  dbl xx[DIM];	        		/* position field. */
-  dbl x_old;		        	/* old position field. */
   dbl x_dot[DIM];			/* current position field derivative wrt time. */
   dbl h3;		        	/* Volume element (scale factors). */
   dbl dh3dmesh_pj;	        	/* Sensitivity to (p,j) mesh dof. */
@@ -1537,8 +1509,6 @@ assemble_stress_fortin(dbl tt,	/* parameter to vary time integration from
       /* note, these are zero for steady calculations */
       if (  pd->TimeIntegration != STEADY &&  pd->v[MESH_DISPLACEMENT1+a] )
 	{
-	  xx[a] = fv->x[a];
-	  x_old = fv_old->x[a];
 	  x_dot[a] = fv_dot->x[a];
 	}
       else
@@ -2482,8 +2452,6 @@ assemble_stress_level_set(dbl tt,	/* parameter to vary time integration from
 
   int i, j, mode;
   dbl v[DIM];			        /* Velocity field. */
-  dbl xx[DIM];	        		/* position field. */
-  dbl x_old;		        	/* old position field. */
   dbl x_dot[DIM];			/* current position field derivative wrt time. */
   dbl h3;		        	/* Volume element (scale factors). */
   dbl dh3dmesh_pj;	        	/* Sensitivity to (p,j) mesh dof. */
@@ -2499,7 +2467,6 @@ assemble_stress_level_set(dbl tt,	/* parameter to vary time integration from
   dbl advection;	
   dbl advection_a, advection_b, advection_c, advection_d;
   dbl source;
-  dbl source1;
   dbl source_a=0, source_b=0, source_c=0;
 
   /*
@@ -2626,8 +2593,6 @@ assemble_stress_level_set(dbl tt,	/* parameter to vary time integration from
       /* note, these are zero for steady calculations */
       if (  pd->TimeIntegration != STEADY &&  pd->v[MESH_DISPLACEMENT1+a] )
 	{
-	  xx[a] = fv->x[a];
-	  x_old = fv_old->x[a];
 	  x_dot[a] = fv_dot->x[a];
 	}
       else
@@ -2903,7 +2868,6 @@ assemble_stress_level_set(dbl tt,	/* parameter to vary time integration from
 				  phi_j = bf[var]->phi[j];
 				  
 				  source    = 0.;
-				  source1    = 0.;
 				  if ( pd->e[eqn] & T_SOURCE )
 				    {
 				      source -=  s[a][b] * (1.-H_ls)/(mup*mup)* d_mup->T[j];

--- a/mm_fill_util.c
+++ b/mm_fill_util.c
@@ -1783,10 +1783,11 @@ load_bf_grad(void)
       * Note: Axisymmetric convention (z,r,theta) are coordinates.
       ********************************************************************************/
 {
-  int i, k, a, b, p, dofs, v, vi, status, WIM, siz;
+  int i, k, a, b, p, dofs, v, vi, status, siz;
   struct Basis_Functions *bfv;
 
-  status = 0;
+#ifdef DO_NOT_UNROLL
+  int WIM;
 
   if ((pd->CoordinateSystem == CARTESIAN)|| 
       (pd->CoordinateSystem == CYLINDRICAL))
@@ -1797,6 +1798,9 @@ load_bf_grad(void)
     {
       WIM=VIM;
     }
+#endif
+
+  status = 0;
 
   /* zero array for initialization */
   /*  v_length = DIM*DIM*DIM*MDE;

--- a/mm_input.c
+++ b/mm_input.c
@@ -640,12 +640,12 @@ rd_file_specs(FILE *ifp,
 #ifdef DEBUG
   static const char yo[] = "rd_file_specs";
 #endif
-  int iread, foundMappingFile;
+  int foundMappingFile;
   char echo_string[MAX_CHAR_IN_INPUT]="\0";
   char *echo_file = Echo_Input_File;
   
  
-  iread = look_for_optional(ifp,"FEM File Specifications",input,'=');
+  look_for_optional(ifp,"FEM File Specifications",input,'=');
 
   ECHO("\n***FEM File Specifications***\n", echo_file);
   
@@ -5597,19 +5597,15 @@ void
 rd_solver_specs(FILE *ifp,
 		char *input )
 {
-  char *yo, *c;
+  char *c;
   char echo_string[MAX_CHAR_IN_INPUT]="\0";
   char *echo_file = Echo_Input_File;
 
   char def_form[MAX_CHAR_IN_INPUT]= " (%s = %s) %s";
 
   int iread, k, i;
-  int Iterative, Direct;
   int is_Solver_Serial = TRUE;
   
-  yo = "rd_solver_specs";
-
-
   /*
    * Caution! This routine is gradually evolving to a dumb reader. Checking
    * for consistent and meaningful input is now done mostly in
@@ -5625,8 +5621,6 @@ rd_solver_specs(FILE *ifp,
    *		will throw us out.
    *
    */
-  Direct              = TRUE;
-  Iterative           = !Direct;
 
   strcpy(Matrix_Solver,			"lu"); /* Kundert's - not y12m ! */
   strcpy(Matrix_Format,			"msr"); 
@@ -6575,13 +6569,11 @@ rd_eigen_specs(FILE *ifp,
 		 char *input)
 {
   int i;
-  char *yo;
   int iread;
   char copy_of_input[MAX_CHAR_IN_INPUT];
   char echo_string[MAX_CHAR_IN_INPUT]="\0";
   char *echo_file = Echo_Input_File;
   /*  */
-  yo = "rd_eigen_specs";
 
 /* READ IN EIGENSOLVER SPECIFICATIONS */
   
@@ -7490,7 +7482,7 @@ rd_matl_blk_specs(FILE *ifp,
 		  char *input)
 {
   char err_msg[MAX_CHAR_IN_INPUT];
-  int	err, mn, iread, i;
+  int	err, mn, i;
   FILE *imp;
   char MatFile[MAX_FNL];	/* Raw material database file. */
   char TmpMatFile[MAX_FNL];	/* Temporary copy of mat db after APREPRO. */
@@ -7507,7 +7499,7 @@ rd_matl_blk_specs(FILE *ifp,
    */
 
   Use_DG = FALSE;
-  iread = look_for_optional(ifp, "Problem Description", input, '=');
+  look_for_optional(ifp, "Problem Description", input, '=');
   ECHO("\nProblem Description =\n", echo_input_file);
 
   look_for(ifp, "Number of Materials", input, '=');
@@ -10074,7 +10066,7 @@ look_for_mat_prop(FILE *imp,			/* ptr to input stream (in)*/
   char  line[132];
   char  *arguments[MAX_NUMBER_PARAMS];
 
-  int num_const, np, i, species_no, got_it;
+  int num_const, i, species_no, got_it;
 
   species_no = 0;		/* set species number to zero as default
 				   so it works for non-species properties*/
@@ -10212,7 +10204,7 @@ look_for_mat_prop(FILE *imp,			/* ptr to input stream (in)*/
 	    User_count[species_no] = num_const;
 
 	    /* parse parameters into little strings */ 
-  	    np = tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);
+  	    tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);
 	    
 	    for(i=0; i< num_const; i++)
 	      {
@@ -10257,7 +10249,7 @@ look_for_mat_prop(FILE *imp,			/* ptr to input stream (in)*/
 	    User_constants[species_no] = (dbl *)array_alloc(1, num_const, sizeof(dbl));
 	    
 	    /* parse parameters into little strings */ 
-	    np = tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);
+	    tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);
 	    
 
 	    for(i=0; i< num_const; i++)
@@ -10366,7 +10358,7 @@ look_for_mat_proptable(FILE *imp,			/* ptr to input stream (in)*/
   int DumModel;			/* dummy int for story input model */
   char  line[132];
   char  *arguments[MAX_NUMBER_PARAMS];
-  int num_const=0, np, i, species_no, got_it;
+  int num_const=0, i, species_no, got_it;
   struct  Data_Table *table_local;
 
   species_no = 0;		/* set species number to zero as default
@@ -10487,7 +10479,7 @@ look_for_mat_proptable(FILE *imp,			/* ptr to input stream (in)*/
 	    User_count[species_no] = num_const;
 
 	    /* parse parameters into little strings */ 
-	    np = tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);	    
+	    tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);	    
 	    
 	    for(i=0; i< num_const; i++)
 	      {
@@ -10532,7 +10524,7 @@ look_for_mat_proptable(FILE *imp,			/* ptr to input stream (in)*/
 	    User_constants[species_no] = (dbl *)array_alloc(1, num_const, sizeof(dbl));
 	    
 	    /* parse parameters into little strings */ 
-	    np = tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);
+	    tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);
 	    
 	    for(i=0; i< num_const; i++)
 	      {
@@ -10623,7 +10615,7 @@ look_for_modal_prop(FILE *imp,	/* ptr to input stream (in)*/
   int DumModel;			              /* dummy int for story input model */
   char  line[132];
   char  *arguments[MAX_NUMBER_PARAMS];
-  int num_const, np, i, got_it;
+  int num_const, i, got_it;
   char	model_name[MAX_CS_KEYWORD_LENGTH];
 
   
@@ -10660,7 +10652,7 @@ look_for_modal_prop(FILE *imp,	/* ptr to input stream (in)*/
 	      }
 
 	    /* parse parameters into little strings */ 
-	    np = tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);	    
+	    tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);	    
 	    
 	    for(i=0; i< num_const; i++)
 	      {
@@ -10719,7 +10711,7 @@ read_constants(FILE *imp,	     /* pointer to file */
   static char yo[] = "read_species";
   char  line[255];
   char  *arguments[MAX_NUMBER_PARAMS];
-  int np, num_const, i;
+  int num_const, i;
   int wspec=-1;
   
   if (species_no >= 0) wspec = species_no;
@@ -10742,7 +10734,7 @@ read_constants(FILE *imp,	     /* pointer to file */
       if ((num_const = count_parameters(line)) > 0) {
 	User_constants[wspec] = alloc_dbl_1(num_const, 0.0);
 	
-        np = tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);	
+        tokenize_by_whsp(line, arguments, MAX_NUMBER_PARAMS);	
 	for(i = 0; i < num_const; i++) {
 	  User_constants[wspec][i] = atof(arguments[i]);
 	}
@@ -10788,15 +10780,10 @@ set_mp_to_unity(const int mn)
 #endif
   int	i;
   int p;
-  int status;
   int v;
   int w;
   struct Elastic_Constitutive *e;
   MATRL_PROP_STRUCT  *m = mp_glob[mn];
-
-
-  status = 0;
-
 
   /*
    * First load up the simplest constitutive relations for all fluxes...
@@ -14288,7 +14275,7 @@ static void read_MAT_line(FILE *ifp, int mn, char *input)
      *     
      ************************************************************************/
 {
-  int ln, numTok, i;
+  int numTok, i;
   TOKEN_STRUCT tok;
   char *yo = "read_MAT_line";
   char echo_string[MAX_CHAR_IN_INPUT]="\0";
@@ -14303,7 +14290,7 @@ static void read_MAT_line(FILE *ifp, int mn, char *input)
    *  Store the remainder of the line in the character buffer, then tokenize
    *  it.
    */
-  ln = read_line(ifp, input, FALSE);
+  read_line(ifp, input, FALSE);
   numTok = fillTokStruct(&tok, input);
 
   /*

--- a/mm_input_bc.c
+++ b/mm_input_bc.c
@@ -172,7 +172,7 @@ rd_bc_specs(FILE *ifp,
   int overlap_bc = FALSE;
   int   iread;
   int   NO_SPECIES = -1;
-  int k, bc_found, eq_found, eqn, irc, p;
+  int k, eq_found, eqn, irc, p;
   dbl sx, sy, sz;
 
   struct Rotation_Specs *rot;
@@ -3518,9 +3518,6 @@ rd_bc_specs(FILE *ifp,
 
 	  strcpy(condition_string[p], ts);
 
-	/* compare string to valid BC names */
-	  bc_found = 0;
-
 	/* compare string to valid rotation vectors */
 	  if (!strcmp(ts, "NONE") || !strcmp(ts, "NA") || !strcmp(ts, "NO")) 
 	    {
@@ -3531,7 +3528,6 @@ rd_bc_specs(FILE *ifp,
 	       * Case: a = a	 self replacement ain't even worth the effort
 	       */
 	      strcpy(instruction_string[p], coordinate_string[p]);
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "N"))
 	    {
@@ -3540,7 +3536,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "n");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "N2")) 
 	    {
@@ -3549,7 +3544,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "n2");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "N3")) 
 	    {
@@ -3558,7 +3552,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "n3");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "T")) 
 	    {
@@ -3567,7 +3560,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "t");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "T1")) 
 	    {
@@ -3576,7 +3568,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "t1");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "T2")) 
 	    {
@@ -3585,7 +3576,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "t2");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "B")) 
 	    {
@@ -3594,7 +3584,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "b");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "S")) 
 	    {
@@ -3603,7 +3592,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "s");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "X")) 
 	    {
@@ -3612,7 +3600,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "ex");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "Y")) 
 	    {
@@ -3621,7 +3608,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "ey");
-	      bc_found = 1;
 	    } 
 	  else if (!strcmp(ts, "Z")) 
 	    {
@@ -3630,7 +3616,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->ROTATE = 1;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "ez");
-	      bc_found = 1;
 	    }
 	  else if (!strcmp(ts, "GD")) 
 	    {
@@ -3638,7 +3623,6 @@ rd_bc_specs(FILE *ifp,
 	      rot->BC_desc[p] = NULL;
 	      rot->BC_SS[p] = -1;
 	      strcpy(instruction_string[p], "GD");
-	      bc_found = 1;
 	    } 
 	  else 
 	    {
@@ -3650,8 +3634,6 @@ rd_bc_specs(FILE *ifp,
 		      rot->BC_Type[p]       = BC_Desc[k].BC_Name;
 		      rot->BC_desc[p]       = &BC_Desc[k];
 		      rot->BC_desc_index[p] = k;
-		      bc_found = 1;
-		      
 		    }
 		}
 

--- a/mm_matrl.c
+++ b/mm_matrl.c
@@ -293,11 +293,10 @@ reconcile_bc_to_matrl(void)
      *   -1 = Something went terribly amiss.
      ************************************************************************/
 {
-  int ibc, specID, eb_index, matID, num_species;
+  int ibc, eb_index, matID, num_species;
   static char *yo = "reconcile_bc_to_matrl: ";
   BOUNDARY_CONDITION_STRUCT *bc;
   MATRL_PROP_STRUCT *matrl_ptr;
-  struct BC_descriptions *bc_desc;
 
   for (ibc = 0; ibc < Num_BC; ibc++) {    
     /*
@@ -305,8 +304,6 @@ reconcile_bc_to_matrl(void)
      *  amount of indirect addressing
      */
     bc = BC_Types + ibc;
-    bc_desc = bc->desc;
-
 
     switch (bc->BC_Name) {
 
@@ -332,7 +329,6 @@ reconcile_bc_to_matrl(void)
 	  /*
 	   * Check the molecular weights
 	   */
-          specID = bc->BC_Data_Int[0];
           eb_index = bc->BC_Data_Int[1];
 	  matID = map_mat_index(eb_index);
           if (matID < 0) {
@@ -447,7 +443,7 @@ calc_density(MATRL_PROP_STRUCT *matrl, int doJac,
      *    Actual value of the density.
      ***************************************************************************/
 {
-  int w, iTerm;
+  int w;
   int species, num_dep, matID, num_species;
   dbl F, vol=0, rho=0, rho_f, rho_s, pressureThermo, RGAS_CONST;
   double avgMolecWeight = 0.0, tmp;
@@ -461,7 +457,6 @@ calc_density(MATRL_PROP_STRUCT *matrl, int doJac,
    */
   if (densityJac == NULL) doJac = FALSE;
   if (doJac) {
-    iTerm = 0;
     densityJac->Num_Terms = 0;
     if (upd->vp[TEMPERATURE] != -1) {
       num_dep = 1;

--- a/mm_more_utils.c
+++ b/mm_more_utils.c
@@ -404,8 +404,8 @@ sum_total_stress(double sol_vec[],
    ********************************************************************/
 {
   int eb_index;
-  int mn, e_start, e_end, ielem, ielem_type, ip_total, num_local_nodes;
-  int ielem_dim, iconnect_ptr, var, ktype, i, I, index, ileft, Ileft;
+  int mn, e_start, e_end, ielem, ielem_type, num_local_nodes;
+  int iconnect_ptr, var, ktype, i, I, index, ileft, Ileft;
 
   int iright, Iright;
   int mode;
@@ -425,12 +425,10 @@ sum_total_stress(double sol_vec[],
       for( ielem = e_start; ielem < e_end; ielem++)
 	{
 	  ielem_type      = Elem_Type(exo, ielem); 
-	  ip_total        = elem_info(NQUAD, ielem_type);
-	                     /* number of quadrature points */
+
 	  num_local_nodes = elem_info(NNODES, ielem_type);
                              /* number of local  basis functions */
     
-	  ielem_dim       = elem_info(NDIM, ielem_type);
 	  iconnect_ptr    = Proc_Connect_Ptr[ielem];
 	                     /* find ptr to beginning of this element's */
      			     /* connectivity list */
@@ -698,8 +696,8 @@ extract_nodal_eb_vec(double sol_vec[], int var_no, int ktype, int matIndex,
    *                of nodes)
    *********************************************************************************/
 {
-  int mn, e_start, e_end, ielem, ielem_type, ip_total, num_local_nodes;
-  int ielem_dim, iconnect_ptr, i, I, index;
+  int mn, e_start, e_end, ielem, ielem_type, num_local_nodes;
+  int iconnect_ptr, i, I, index;
   int ileft, Ileft, iright, Iright, midside;
   int lastSpeciesSum, iDof, j;
   MATRL_PROP_STRUCT *matrl;
@@ -748,16 +746,6 @@ extract_nodal_eb_vec(double sol_vec[], int var_no, int ktype, int matIndex,
      *  
      */
     ielem_type      = Elem_Type(exo, ielem);
-
-    /*
-     *  Get the total number of quadrature points
-     */
-    ip_total        = elem_info(NQUAD, ielem_type); 
-
-    /*
-     *  Get the dimensionality of the elements in the element block
-     */
-    ielem_dim       = elem_info(NDIM, ielem_type);
 
     /*
      * Number of local nodes in the element
@@ -943,7 +931,7 @@ extract_elem_vec(const double sol_vec[],
 {
   int eb_index;
   int mn, e_start, e_end, ielem, ielem_type, num_local_nodes;
-  int ielem_dim, iconnect_ptr, var, ktype, i, I, index;
+  int iconnect_ptr, var, ktype, i, I, index;
   int found_quantity;
 
   for ( eb_index=0; eb_index < exo->num_elem_blocks; eb_index++ ) {
@@ -972,7 +960,6 @@ extract_elem_vec(const double sol_vec[],
 
       ielem_type      = Elem_Type(exo, ielem); /* func defd in el_geom.h */
       num_local_nodes = elem_info(NNODES, ielem_type);
-      ielem_dim       = elem_info(NDIM, ielem_type);
       iconnect_ptr    = Proc_Connect_Ptr[ielem]; /* find ptr to beginning */
       /* of this element's */
       /* connectivity list */

--- a/mm_numjac.c
+++ b/mm_numjac.c
@@ -149,7 +149,8 @@ numerical_jacobian(struct Aztec_Linear_Solver_System *ams,
   int *ija = ams->bindx;
   double *aj_diag, *aj_off_diag, *scale;
   double *resid_vector_1, *x_1, resid_scale;
-  double resid_min, resid_max, resid_error, resid_scaled_error;
+  double resid_min, resid_max, resid_error;
+  /* double resid_scaled_error; */
   double dx, delta_min, delta_max;
   double delta_aj_percentage, roundoff, confidence, resid_diff;
   int *irow, *jcolumn, *nelem;
@@ -162,7 +163,7 @@ numerical_jacobian(struct Aztec_Linear_Solver_System *ams,
   NODE_INFO_STRUCT *node;
   NODAL_VARS_STRUCT *nvs;
   VARIABLE_DESCRIPTION_STRUCT *vd;
-  int I, J, var_i, var_j, ibc, bc_input_id, eqn;
+  int I, var_i, var_j, ibc, bc_input_id, eqn;
   struct elem_side_bc_struct *elem_side_bc;
 	  double x_scale[MAX_VARIABLE_TYPES];
 	  int count[MAX_VARIABLE_TYPES];
@@ -694,7 +695,7 @@ numerical_jacobian(struct Aztec_Linear_Solver_System *ams,
 	      if ( resid_vector_1[i]<resid_min ) resid_error = resid_min - resid_vector_1[i];
 	      else resid_error = resid_vector_1[i] - resid_max;
 	      
-              resid_scaled_error = resid_error / resid_diff;
+              /* resid_scaled_error = resid_error / resid_diff; */
                                    
               /* The following is a measure of the percentage of the acceptance band that is
                * due to changes in the jacobian from the unperturbed to perturbed
@@ -784,7 +785,6 @@ numerical_jacobian(struct Aztec_Linear_Solver_System *ams,
                               var_i = idv[i][0];
                               var_j = idv[j][0];
                               I = idv[i][2];
-                              J = idv[j][2];
                               
                               if (in_list( I, 0, elem_side_bc->num_nodes_on_side, elem_side_bc->local_node_id ))
                                 {

--- a/mm_qtensor_model.c
+++ b/mm_qtensor_model.c
@@ -523,7 +523,7 @@ assemble_new_qtensor(dbl *el_length) /* 2 x approximate element length scales */
   int i, j, p, k1;
   int ielem_type, ip_total, ip;
   dbl dp;
-  dbl delta[DIM], xi[DIM], delta_xi[DIM], new_xi[DIM];
+  dbl delta[DIM], xi[DIM], delta_xi[DIM];
   dbl local_q[DIM][DIM], local_q2[DIM][DIM];
   dbl d_qtensor[DIM][DIM][DIM];
 
@@ -581,10 +581,6 @@ assemble_new_qtensor(dbl *el_length) /* 2 x approximate element length scales */
             {
               delta[p] = dp * ( (k1 == 0) ? 1.0 : -1.0);
               map_direction(delta_xi, delta);
-              for (i = 0; i < DIM; i++)
-                {
-                  new_xi[i] = xi[i] + delta_xi[i];
-                }
 
               /* Perform assembly sequence up to load_fv_grads at this point */
               err = load_basis_functions(xi, bfd);
@@ -647,7 +643,7 @@ get_local_qtensor(double q[DIM][DIM])
   dbl E[DIM][DIM], Erot[DIM][DIM];
   dbl mag_E, mag_Erot, rho_k;
   dbl theta, cc, ss;
-  dbl stt, stc, sct, scc;
+  dbl stt, stc, scc;
   dbl ev[DIM], v_comp[DIM], v_vort[DIM], v_tens[DIM];
 
 
@@ -722,7 +718,6 @@ get_local_qtensor(double q[DIM][DIM])
    */
   scc = 0.5 * (rho_k + (1.0 - rho_k) * mp->Qtensor_Extension_P);
   stc = -mp->Qtensor_Nct;
-  sct = stc;
   stt = scc;
 
   /* Transform qtensor into Cartesian coordinates (2D case only) */
@@ -1282,13 +1277,8 @@ hydro_qtensor_flux (struct Species_Conservation_Terms *st,
 
   dbl c_term, mu_term;
 
-  dbl dDc_dy = 0.;
-  dbl dDmu_dy = 0.;
-
   dbl phi_j;
   dbl *grad_phi_j;
-
-  dbl Y_avg, f0, rzexp;
 
   dbl div_gdYVQVt[DIM]; /* div(gammadot * Y * (V Q Vt)) */
   dbl VQVt_grad_mu[DIM]; /* (V Q V^t) . grad(mu) */
@@ -1372,7 +1362,6 @@ hydro_qtensor_flux (struct Species_Conservation_Terms *st,
       if (mp->GamDiffType[w] == LINEAR) 
 	{
 	  Dc  = mp->u_gadiffusivity[w][0] * 1.4 * Y[w];
-	  dDc_dy = mp->u_gadiffusivity[w][0] * 1.4;
 	}
       else if (mp->GamDiffType[w] == LEVEL_SET ) 
 	{
@@ -1396,7 +1385,6 @@ hydro_qtensor_flux (struct Species_Conservation_Terms *st,
       if (mp->MuDiffType[w] == LINEAR) 
 	{
 	  Dmu  = mp->u_mdiffusivity[w][0] * 1.4 * Y[w];
-	  dDmu_dy = mp->u_mdiffusivity[w][0] * 1.4;
 	}
       else if (mp->MuDiffType[w] == LEVEL_SET ) 
 	{
@@ -1419,20 +1407,14 @@ hydro_qtensor_flux (struct Species_Conservation_Terms *st,
       if (mp->GravDiffType[w] == BISECTION)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
-	  Y_avg = mp->u_gdiffusivity[w][1];
-	  f0    = mp->u_gdiffusivity[w][2];
 	}
       else if(mp->GravDiffType[w] == RZBISECTION)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
-          rzexp =  mp->u_gdiffusivity[w][1];
-	  Y_avg = mp->u_gdiffusivity[w][2];
-	  f0    = mp->u_gdiffusivity[w][3];
 	}
       else if(mp->GravDiffType[w] == RICHARDSON_ZAKI)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
-          rzexp =  mp->u_gdiffusivity[w][1];
 	}
       else if (mp->GravDiffType[w] == LEVEL_SET ) 
 	{
@@ -1641,12 +1623,9 @@ hydro_qtensor_flux_new (struct Species_Conservation_Terms *st,
 
   dbl c_term, mu_term, d_term;
 
-  dbl dDc_dy = 0.;
-  dbl dDmu_dy = 0.;
-
   dbl phi_j = 0.0;
 
-  dbl maxpack = 0.0, Y_avg, f0, rzexp;  /*  ERROR !!! maxpack is never set before use !!!! */
+  dbl maxpack = 0.0;  /*  ERROR !!! maxpack is never set before use !!!! */
 
   dbl div_gdYVQVt[DIM]; /* div(gammadot * Y * (V Q Vt)) */
   dbl VQVt_grad_mu[DIM]; /* (V Q V^t) . grad(mu) */
@@ -1735,7 +1714,6 @@ hydro_qtensor_flux_new (struct Species_Conservation_Terms *st,
       if (mp->GamDiffType[w] == LINEAR) 
 	{
 	  Dc  = mp->u_gadiffusivity[w][0] * 1.4 * Y[w];
-	  dDc_dy = mp->u_gadiffusivity[w][0] * 1.4;
 	}
       else if (mp->GamDiffType[w] == LEVEL_SET ) 
 	{
@@ -1759,7 +1737,6 @@ hydro_qtensor_flux_new (struct Species_Conservation_Terms *st,
       if (mp->MuDiffType[w] == LINEAR) 
 	{
 	  Dmu  = mp->u_mdiffusivity[w][0] * 1.4 * Y[w];
-	  dDmu_dy = mp->u_mdiffusivity[w][0] * 1.4;
 	}
       else if (mp->MuDiffType[w] == LEVEL_SET ) 
 	{
@@ -1782,20 +1759,14 @@ hydro_qtensor_flux_new (struct Species_Conservation_Terms *st,
       if (mp->GravDiffType[w] == BISECTION)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
-	  Y_avg = mp->u_gdiffusivity[w][1];
-	  f0    = mp->u_gdiffusivity[w][2];
 	}
       else if(mp->GravDiffType[w] == RZBISECTION)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
-          rzexp =  mp->u_gdiffusivity[w][1];
-	  Y_avg = mp->u_gdiffusivity[w][2];
-	  f0    = mp->u_gdiffusivity[w][3];
 	}
       else if(mp->GravDiffType[w] == RICHARDSON_ZAKI)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
-          rzexp =  mp->u_gdiffusivity[w][1];
 	}
       else if (mp->GravDiffType[w] == LEVEL_SET ) 
 	{
@@ -2203,7 +2174,7 @@ compute_principle_directions(dbl *v_flow,
 			     dbl *v_vort,
 			     int print)
 {
-  dbl vf_norm, vv_norm;
+  dbl vf_norm;
   int i,j,k;
   dbl t1;
 
@@ -2254,7 +2225,7 @@ compute_principle_directions(dbl *v_flow,
     }
 #endif
 
-  vv_norm = normalize_really_simple_vector(v_vort, VIM);
+  normalize_really_simple_vector(v_vort, VIM);
 
   for(i = 0; i < VIM; i++)
     for(j = 0; j < VIM; j++)
@@ -2296,7 +2267,7 @@ find_eigenvector(dbl AA[3][3],
 		 int print)
 {
   int i, p[3];
-  dbl A[3][3], m12, m13, m23, norm;
+  dbl A[3][3], m12, m13, m23;
   dbl a11, a12, a13, a22, a23;
   dbl x, y, z;
 
@@ -2565,7 +2536,7 @@ find_eigenvector(dbl AA[3][3],
   v[0] = x;
   v[1] = y;
   v[2] = z;
-  norm = normalize_really_simple_vector(v, 3);
+  normalize_really_simple_vector(v, 3);
 
 #ifdef DEBUG_QTENSOR
   if(print)
@@ -2761,7 +2732,7 @@ diagonalize_symmetric_tensor(dbl T[DIM][DIM],
   dbl A[3][3];
   dbl a0, a2, a1;
   dbl q, r, d, m, theta, z1, z2, z3;
-  dbl tmp1, vfnorm, vvnorm;
+  dbl tmp1, vfnorm;
 
   memset(v0, 0, DIM * sizeof(dbl));
   memset(v1, 0, DIM * sizeof(dbl));
@@ -2955,7 +2926,7 @@ diagonalize_symmetric_tensor(dbl T[DIM][DIM],
 	    printf( "Setting v2[%d] = %g\n", i, v2[i]);
 	  */
 	}
-      vvnorm = normalize_really_simple_vector(v2, DIM);
+      normalize_really_simple_vector(v2, DIM);
       for(i = 0; i < DIM; i++)
 	for(j = 0; j < DIM; j++)
 	  for(k = 0; k < DIM; k++)
@@ -2998,7 +2969,7 @@ diagonalize_rate_of_deformation_tensor(dbl T[3][3],
   dbl A[3][3];
   dbl a0, a1, a2;		/* a2 is ignored b/c tr(T) = 0 */
   dbl q, r, d, m, theta, costheta, sintheta, z1, z2, z3;
-  dbl tmp1, vfnorm, vvnorm;
+  dbl tmp1, vfnorm;
 
   memset(v0, 0, DIM * sizeof(dbl));
   memset(v1, 0, DIM * sizeof(dbl));
@@ -3187,7 +3158,7 @@ diagonalize_rate_of_deformation_tensor(dbl T[3][3],
 	    printf( "Setting v2[%d] = %g\n", i, v2[i]);
 	  */
 	}
-      vvnorm = normalize_really_simple_vector(v2, DIM);
+      normalize_really_simple_vector(v2, DIM);
       for(i = 0; i < DIM; i++)
 	for(j = 0; j < DIM; j++)
 	  for(k = 0; k < DIM; k++)
@@ -3334,11 +3305,11 @@ please_work(dbl T[3][3],	/* Rate of deformation tensor */
 	    int print)		/* print toggle */
 {
   int i;
-  dbl v0[3], v2[3], evalues[3], flownorm;
+  dbl v0[3], v2[3], evalues[3];
 
   for(i = 0; i < DIM; i++)
     v_flow[i] = fv->v[i];
-  flownorm = normalize_really_simple_vector(v_flow, DIM);
+  normalize_really_simple_vector(v_flow, DIM);
 
   /* v1 will be the eigenvector with smallest |eigenvalue| since the
    * tensor is symmetric.

--- a/mm_shell_bc.c
+++ b/mm_shell_bc.c
@@ -404,7 +404,7 @@ shell_n_dot_gradp_bc(double func[DIM],
   int *n_dof = NULL;
   int dof_map[MDE];
   double grad_P[DIM];
-  double DisjPress, grad_DisjPress[DIM], dgrad_DisjPress_dH1[DIM][MDE], dgrad_DisjPress_dH2[DIM][MDE]; 
+  double grad_DisjPress[DIM], dgrad_DisjPress_dH1[DIM][MDE], dgrad_DisjPress_dH2[DIM][MDE]; 
   double phi_j;
   double grad_phi_j[DIM], grad_II_phi_j[DIM];
   double bound_normal[DIM];
@@ -431,7 +431,7 @@ shell_n_dot_gradp_bc(double func[DIM],
 
 /* Calculate disjoining pressure gradient and its sensitivities */
   
-   DisjPress = disjoining_pressure_model(fv->sh_fh, fv->grad_sh_fh, grad_DisjPress, dgrad_DisjPress_dH1, dgrad_DisjPress_dH2);
+   disjoining_pressure_model(fv->sh_fh, fv->grad_sh_fh, grad_DisjPress, dgrad_DisjPress_dH1, dgrad_DisjPress_dH2);
 
   if (af->Assemble_LSA_Mass_Matrix)
     {
@@ -545,11 +545,6 @@ shell_n_dot_gradh_bc(double func[DIM],
   double grad_phi_j[DIM], grad_II_phi_j[DIM];
   double grad_II_H[DIM];
   double bound_normal[DIM], shell_normal[DIM];
-  double sigma;
-
-  
-  sigma = mp->surface_tension;
-  
 
 /* Save the boundary normal vector */
 
@@ -679,21 +674,20 @@ shell_n_dot_pflux_bc(double func[DIM],
   int j, ii, jj, var;
   double phi_j;
   double grad_phi_j[DIM], grad_phi_j_corrected[DIM];
-  double veloc, veloU[DIM], veloL[DIM];
+  double veloU[DIM], veloL[DIM];
   double grad_C[DIM];
   double bound_normal[DIM], shell_normal[DIM];
-  double C, H;
+  double H;
   double mu, dmu_dc, diff_coeff, ddiff_dmu, ddiff_dc;
   VISCOSITY_DEPENDENCE_STRUCT d_mu_struct;  /* viscosity dependence */
   VISCOSITY_DEPENDENCE_STRUCT *d_mu = &d_mu_struct;
 
-  C = fv->sh_pc;
   H = fv->sh_fh;
   mu = viscosity(gn, NULL, d_mu);
   diff_coeff = diffusion_coefficient_model(mu, &ddiff_dmu);
   dmu_dc = mp->d_viscosity[SHELL_PARTC];
   ddiff_dc = ddiff_dmu * dmu_dc;
-  veloc = velocity_function_model(veloU, veloL, time, dt);
+  velocity_function_model(veloU, veloL, time, dt);
 
 
 /* Save the boundary normal vector */
@@ -836,14 +830,12 @@ void
 {
   int j_id;
   int var = -1;
-  int dim;
   double phi_j;
 
   /* local contributions of boundary condition to residual and jacobian */
 
 /***************************** EXECUTION BEGINS *******************************/
-/*  initialize variables */
-    dim = pd->Num_Dim;
+
 
 /***************************** Confined Lubrication SIDE *******************************/
 
@@ -928,15 +920,11 @@ put_lub_flux_in_film(int id, /* local element node number for the
 						* boundaries)          */
 
 {
-    int j_id, dim, wim, var, pvar, q, id_doflubp, id_doffilmp;
+    int j_id, dim, var, pvar, q, id_doflubp, id_doffilmp;
     int peqn_lubp, peqn_filmp;
     int ieqn_lubp, ieqn_filmp;
 
-    NODE_INFO_STRUCT *node = Nodes[I];
-
     dim = pd->Num_Dim;
-    wim   = dim;
-
 
     /*
      * if you are in the film phase, return without doing anything

--- a/mm_std_models.c
+++ b/mm_std_models.c
@@ -136,12 +136,12 @@ bouss_momentum_source(dbl f[DIM], /* Body force. */
 					* head in thermal buoyancy term */
 {
   int eqn, var;
-  int dim;
   int a, b, c;
 
   int w;
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
+  dbl T, C[MAX_CONC]; /* Convenient local variables */
+
   dbl J[DIM], B[DIM];         /* Local versions for REAL j-field and b-field */
   dbl J_I[DIM], B_I[DIM];    /* Local versions for Imag j-field and b-field */
   dbl g[DIM];
@@ -150,15 +150,12 @@ bouss_momentum_source(dbl f[DIM], /* Body force. */
 
   /* Begin Execution */
 
-  dim   = pd->Num_Dim;
-
   /**********************************************************/
   
   /***********Load up convenient local variables*************/
   /*NB This ought to be done once for all fields at gauss pt*/
 
   T = fv->T;                                       
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		   
   for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];
 
   /* Next, if jxb is to be computed, load up J and B vectors */
@@ -475,7 +472,6 @@ EHD_POLARIZATION_source(dbl f[DIM], /* Body force. */
   int a, b, p;
   dbl phi_j;
   dbl advection_a;
-  dbl X[DIM];              /* Convenient local variables */
   dbl Efield[DIM];         /* Local versions for E-field    */
   dbl g[DIM];
   int j;
@@ -487,7 +483,6 @@ EHD_POLARIZATION_source(dbl f[DIM], /* Body force. */
   /***********Load up convenient local variables*************/
   /*NB This ought to be done once for all fields at gauss pt*/
 
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		   
   for(a=0; a<DIM; a++)Efield[a] = fv->E_field[a];		   
 
   /*components of whatever (charge density?) from input card */
@@ -594,9 +589,8 @@ gravity_vibrational_source (dbl f[DIM], /* Body force. */
 			    dbl time)
 {
   int eqn;
-  int dim, wim;
+  int dim;
   int a;
-  dbl X[DIM]; /* Convenient local variables */
   dbl g[DIM];
   dbl omega;  /* frequency of vibration  */
   dbl omega2; /* frequency of vibration squared */
@@ -608,12 +602,9 @@ gravity_vibrational_source (dbl f[DIM], /* Body force. */
   double rho = density(d_rho, time);
 
   dim   = pd->Num_Dim;
-  wim   = dim; 
   
   /***********Load up convenient local variables*************/
   /*NB This ought to be done once for all fields at gauss pt*/
-
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		   
 
   /*components of gravity vector from input card */
   for(a=0; a<DIM; a++)  g[a] = mp->momentum_source[a];
@@ -657,7 +648,6 @@ suspend_momentum_source(dbl f[DIM], /* Body force. */
 			MOMENTUM_SOURCE_DEPENDENCE_STRUCT *df )
 {
   int eqn, var;
-  int dim;
   int a;
 
   int species;
@@ -684,7 +674,6 @@ suspend_momentum_source(dbl f[DIM], /* Body force. */
       return(status);
     }
 
-  dim   = pd->Num_Dim;
 
   /*  if(fv->c[species] > 0.)
     {
@@ -802,7 +791,6 @@ epoxy_dea_species_source( int species_no,    /* Current species number */
      
 {
   int eqn, var, var_offset;
-  int dim;
   
   dbl T;           /* temperature for rate constants */
   dbl A1, E1, A2, E2, A3;
@@ -812,8 +800,6 @@ epoxy_dea_species_source( int species_no,    /* Current species number */
   
   /* Begin Execution */
   
-  dim   = pd->Num_Dim;
-
   T = fv->T;
   /* extent of reaction, alpha */
   alpha = fv->c[species_no];
@@ -927,7 +913,6 @@ epoxy_species_source(int species_no,   /* Current species number */
 {
   /* Local Variables */
   int eqn, var, var_offset;
-  int dim;
   /*  int p, q, a, b, c;*/
   
   /*  int v,w;*/
@@ -943,7 +928,6 @@ epoxy_species_source(int species_no,   /* Current species number */
   
   /* Begin Execution */
   
-  dim   = pd->Num_Dim;
 
   T = fv->T;
   /* extent of reaction, alpha */
@@ -1031,7 +1015,6 @@ foam_epoxy_species_source(int species_no,   /* Current species number */
 /* tt, dt - time derivative parameters */  
 {
   int eqn, var;
-  int dim;
   /*  int p, q, a, b, c;*/
   double Press, rho, rho2, rho_v_inv, rho_v, d_rho_v_dT, d_rho_v_inv_dT;
   double rho_a_inv, d_rho_a_inv_dT; 
@@ -1039,7 +1022,7 @@ foam_epoxy_species_source(int species_no,   /* Current species number */
   double aT, bT, p_vap, vch, Cc, Ce, ff_c, ff_e, sigma;
   double Rc_1 = 0.0, Rc_2 = 0.0, Rc = 0.0, dRc_dc_v = 0.0, dRc_dc_a = 0.0, dRc_dc_l = 0.0, dRc_dT = 0.0; 
   double Re_1 = 0.0, Re_2 = 0.0, Re = 0.0, dRe_dc_v = 0.0, dRe_dc_a = 0.0, dRe_dc_l = 0.0, dRe_dT = 0.0;
-  double Rgas = 0.0, MW_f = 0.0, MW_a = 0.0, rho_epoxy = 0.0, rho_fluor = 0.0, T = 0.0, T_dot = 0.0;
+  double Rgas = 0.0, MW_f = 0.0, MW_a = 0.0, rho_epoxy = 0.0, rho_fluor = 0.0, T = 0.0;
   int species_l = -1, species_v = -1, species_a = -1;
 
   if (mp->DensityModel == DENSITY_FOAM_CONC)
@@ -1060,10 +1043,8 @@ foam_epoxy_species_source(int species_no,   /* Current species number */
   
   /* Begin Execution */
   
-  dim   = pd->Num_Dim;
 
   T = fv->T;
-  T_dot = fv_dot->T;
 
   Press = upd->Pressure_Datum;
   rho_v_inv = Rgas*T/(Press*MW_f);
@@ -1193,23 +1174,18 @@ epoxy_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
 				 * explicit (tt = 1) to implicit (tt = 0) */
 		  double dt)	/* current time step size */
 {
-  int eqn, var, var_offset;
-  int dim;
+  int eqn, var;
   int j;
   int w;
   int species_no=-1;
 
   double h = 0.;
   
-  dbl T;           /* temperature for rate constants */
   /*  dbl A1, E1, A2, E2;*/
-  dbl alpha, alpha_old, alpha_dot;
+  dbl alpha_dot;
   dbl delta_h;
   
   /* Begin Execution */
-  
-  dim   = pd->Num_Dim;
-  T = fv->T;
   
   /* find equation that has extent of reaction */
   for (w = 0; w < pd->Num_Species_Eqn; w++) {
@@ -1219,8 +1195,6 @@ epoxy_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
       species_no = w;
     }
   }
-  alpha     = fv->c[species_no];
-  alpha_old = fv_old->c[species_no];
   if (pd->TimeIntegration != STEADY) {
     alpha_dot = fv_dot->c[species_no];
   } else {
@@ -1242,7 +1216,6 @@ epoxy_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
 	  if(mp->SpeciesSourceModel[species_no] == EPOXY
 	     ||(mp->SpeciesSourceModel[species_no] == EPOXY_DEA ) )
 	    {
-	      var_offset = MAX_VARIABLE_TYPES + species_no;	
 	      for (j=0; j<ei->dof[var]; j++)
 		{
 		  d_h->C[species_no][j] +=
@@ -1474,25 +1447,22 @@ vary_rho_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
 		  double dt)	/* current time step size */
 {
   int eqn, var;
-  int dim;
   int w, j;
   
   dbl T, Cp, sv_p;
   dbl sv[MAX_CONC], d_rho_dot_dc[MAX_CONC];
-  dbl rho_dot=0, rho;
+  dbl rho_dot=0;
   double h = 0.;
   
   /* Begin Execution */
   /* this is mass_concentration based
       7/99 ACS */
-  dim   = pd->Num_Dim;
   T = fv->T;
   Cp = mp->heat_capacity;
   
   if( mp->DensityModel == SOLVENT_POLYMER)
     {
       /* added ACSun 7/99 */
-      rho = 0.;
       rho_dot = 0.;
 
       for (w = 0; w < pd->Num_Species_Eqn; w++)
@@ -1567,12 +1537,11 @@ foam_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
 				double tt,	/* parameter to vary time integration from explicit (tt = 1) to implicit (tt = 0) */
 				double dt)	/* current time step size */
 {
-	double rho, hT, Tb, a0, phi0; 
+	double hT, Tb, a0, phi0; 
 	double h;
 	
 	int j,var;
 	
-	rho = mp->u_heat_source[0];
 	hT = mp->u_heat_source[1];
 	Tb = mp->u_heat_source[2];
 	a0 = mp->u_heat_source[3];
@@ -1619,20 +1588,17 @@ double
 joule_heat_source( HEAT_SOURCE_DEPENDENCE_STRUCT *d_h, dbl time )
    
 {
-  int var, var_offset;
+  int var;
   int dim;
-  int a, b;
+  int a = 0, b;
 
   int w;
 
-  dbl X[DIM], T, V, C[MAX_CONC]; /* Convenient local variables */
   dbl k=1e12;                                /* electrical conductivity. */
   dbl dkdT[MDE];			/* Temperature derivative of electrical conductivity. */
   dbl dkdV[MDE];			/* Voltage derivative of electrical conductivity. */
-  dbl dkdC[MAX_CONC][MDE];		/* Concentration derivative of electrical conductivity. */
   dbl dkdX[DIM][MDE];   	       	/* Spatial derivatives of t.c. */
-  int i, j;
-  int err;
+  int j;
   double h = 0.;
   dbl scale = 1.0;
 
@@ -1640,7 +1606,7 @@ joule_heat_source( HEAT_SOURCE_DEPENDENCE_STRUCT *d_h, dbl time )
 
   if(mp->Elec_ConductivityModel == USER)
        {
-	 err = usr_electrical_conductivity(mp->u_electrical_conductivity, time);
+	 usr_electrical_conductivity(mp->u_electrical_conductivity, time);
 	 
 	 k   = mp->electrical_conductivity;
 	 
@@ -1674,11 +1640,6 @@ joule_heat_source( HEAT_SOURCE_DEPENDENCE_STRUCT *d_h, dbl time )
 	     for ( w=0; w<pd->Num_Species_Eqn; w++)
 	       {
 		 var = MASS_FRACTION;
-		 var_offset = MAX_VARIABLE_TYPES + w;
-		 for ( j=0; j<ei->dof[var]; j++)
-		   {
-		     dkdC[w][j] =mp->d_electrical_conductivity[var_offset]*bf[var]->phi[j];
-		   }
 	       }
 	   }
        }
@@ -1714,11 +1675,6 @@ joule_heat_source( HEAT_SOURCE_DEPENDENCE_STRUCT *d_h, dbl time )
 	     for ( w=0; w<pd->Num_Species_Eqn; w++)
 	       {
 		 var = MASS_FRACTION;
-		 var_offset = MAX_VARIABLE_TYPES + w;
-		 for ( j=0; j<ei->dof[var]; j++)
-		   {
-		     dkdC[w][j] = 0.;
-		   }
 	       }
 	   }
        }
@@ -1727,14 +1683,6 @@ joule_heat_source( HEAT_SOURCE_DEPENDENCE_STRUCT *d_h, dbl time )
 	 EH(-1,"Unimplemented electrical conductivity model");
        }
   
-  /***********Load up convenient local variables*************/
-  /*NB This ought to be done once for all fields at gauss pt*/
-  
-  T = fv->T;                                       
-  V = fv->V;                                       
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		   
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];
-
   /* Load current density */
   dbl J[DIM];
   char err_msg[MAX_CHAR_IN_INPUT];
@@ -1851,11 +1799,8 @@ visc_diss_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
 		      dbl *param) /* General multipliers */
 {
   int var;
-  int dim;
   int p, q, a, b;
-  int mdofs=0;
 
-  dbl X[DIM], T, V, C[MAX_CONC]; /* Convenient local variables */
   dbl gamma_dot[DIM][DIM];
   VISCOSITY_DEPENDENCE_STRUCT d_mu_struct;  /* viscosity dependence */
   VISCOSITY_DEPENDENCE_STRUCT *d_mu = &d_mu_struct;
@@ -1872,22 +1817,11 @@ visc_diss_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
   int mode;
   int v_s[MAX_MODES][DIM][DIM];
 
-  int i, j;
-  int err;
+  int j;
   double h = 0.;
 
   /* Begin Execution */
 
-  dim   = pd->Num_Dim;
-  
-  /***********Load up convenient local variables*************/
-  /*NB This ought to be done once for all fields at gauss pt*/
-  
-  T = fv->T;                                       
-  V = fv->V;                                       
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		   
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];
-  
   
   /**********************************************************/
   /* Source constant * viscosity* gammadot .. grad_v */
@@ -1929,7 +1863,7 @@ visc_diss_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
   /* get mu and grad_mu */
 
   mu = viscosity(gn, gamma_dot, d_mu);
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   h +=  mu * gammadot*gammadot ;
 
@@ -1938,10 +1872,6 @@ visc_diss_heat_source(HEAT_SOURCE_DEPENDENCE_STRUCT *d_h,
   /* Now do sensitivies */
 if(af->Assemble_Jacobian)
   {
- if ( pd->e[R_MESH1] )
-    {
-      mdofs = ei->dof[R_MESH1];
-    }
 
   var = TEMPERATURE;
   if ( d_h != NULL && pd->v[var] )
@@ -2053,8 +1983,7 @@ if(af->Assemble_Jacobian)
 double
 enthalpy_heat_capacity_model( HEAT_CAPACITY_DEPENDENCE_STRUCT *d_Cp )
 {
-  int eqn, var, var_offset;
-  int dim;
+  int var;
   int a, b;
   dbl latent_heat, T_liq, T_sol;
   dbl Cp;
@@ -2063,11 +1992,8 @@ enthalpy_heat_capacity_model( HEAT_CAPACITY_DEPENDENCE_STRUCT *d_Cp )
 
   dbl grad_H[DIM], d_grad_H_dT[DIM][MDE], norm_grad_H, norm_grad_T, Cp_base, T_ave;
   int i, j;
-  dbl X[DIM], T, V, C[MAX_CONC];        /* Convenient local variables */
 
   /* Begin Execution */
-
-  dim   = pd->Num_Dim;
 
   latent_heat = mp->latent_heat_fusion[0]; /*single component for now*/
                                            /* if this depends on conc'n */
@@ -2077,8 +2003,6 @@ enthalpy_heat_capacity_model( HEAT_CAPACITY_DEPENDENCE_STRUCT *d_Cp )
   Cp_base = mp->heat_capacity;
 
   /************Initialize everything for saftey**************/
-
-  eqn   = R_ENERGY;
 
   Cp = 0.;			
 
@@ -2108,7 +2032,6 @@ enthalpy_heat_capacity_model( HEAT_CAPACITY_DEPENDENCE_STRUCT *d_Cp )
       for ( w=0; w<pd->Num_Species_Eqn; w++)
 	{
 	  var = MASS_FRACTION;
-	  var_offset = MAX_VARIABLE_TYPES + w;
 	  for (j=0; j<ei->dof[var]; j++)
 	    {
 	      d_Cp->C[w][j] = 0.;
@@ -2129,11 +2052,7 @@ enthalpy_heat_capacity_model( HEAT_CAPACITY_DEPENDENCE_STRUCT *d_Cp )
     }
 
   
-  T = fv->T;                                       
-  V = fv->V;                                       
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		   
   for(a=0; a<DIM; a++)grad_H[a] = 0.;		   
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];
   
   
   /**********************************************************/
@@ -2548,7 +2467,6 @@ int
 Free_Vol_Theory_Diffusivity(int species_no,  /* current species number*/
 			    double *param)  /* free volume params from mat file */
 {
-  int var;
   int w, fv_model_number;
 
   double T, C[MAX_CONC], dDdT;
@@ -2717,7 +2635,7 @@ Free_Vol_Theory_Diffusivity(int species_no,  /* current species number*/
     {
       if (pd->v[TEMPERATURE] )
 	{
-	  var = TEMPERATURE;
+
 	  if (fv_model_number != 4)
 	    {
 	      dDdT = mp->diffusivity[0]*
@@ -2806,7 +2724,6 @@ Free_Vol_Theory_Diffusivity(int species_no,  /* current species number*/
 	    }
  
 
-	  var = MASS_FRACTION;
 	  switch(fv_model_number)
 	    {  
 	    case 0: 
@@ -3017,7 +2934,6 @@ Generalized_Diffusivity()
 int
 Generalized_FV_Diffusivity(int species_no)  /* current species number*/
 {
-  int var;
   int w, w1, mode;
   int w2=pd->Num_Species_Eqn;
 
@@ -3032,7 +2948,7 @@ Generalized_FV_Diffusivity(int species_no)  /* current species number*/
   double numerator[MAX_CONC], omega[MAX_CONC];
   double xsi[MAX_CONC][MAX_CONC];
   double vs[MAX_CONC],K1_gamma[MAX_CONC],
-    K2mTg[MAX_CONC],chi[MAX_CONC], Do[MAX_CONC],
+    K2mTg[MAX_CONC], Do[MAX_CONC],
     E_div_R[MAX_CONC], V0[MAX_CONC];
   double vsp, K1p_gamma, K2pmTg, V0p;
   double allmass = 0.;
@@ -3072,7 +2988,6 @@ Generalized_FV_Diffusivity(int species_no)  /* current species number*/
       vs[w]       = mp->u_diffusivity[w][0];
       K1_gamma[w] = mp->u_diffusivity[w][2];
       K2mTg[w]    = mp->u_diffusivity[w][4];
-      chi[w]      = mp->u_diffusivity[w][6];
       Do[w]       = mp->u_diffusivity[w][8];
       E_div_R[w]  = mp->u_diffusivity[w][9];
       V0[w]       = mp->u_diffusivity[w][10];
@@ -3143,8 +3058,6 @@ Generalized_FV_Diffusivity(int species_no)  /* current species number*/
     {
       if (pd->v[TEMPERATURE] )
 	{
-	  var = TEMPERATURE;
-
 	  mp->d_diffusivity[species_no][TEMPERATURE] = 
 	    mp->diffusivity[species_no]*
 	    d_Vfh_dT*numerator[species_no]/pow(V_fh_gamma,2.0);
@@ -3162,7 +3075,6 @@ Generalized_FV_Diffusivity(int species_no)  /* current species number*/
       if (pd->v[MASS_FRACTION] )
 	{
 
-	  var = MASS_FRACTION;
 	  for (w=0; w<pd->Num_Species_Eqn; w++)
 	    {
 	      d_Vfh_domega[w] = K1_gamma[w]*(K2mTg[w]+T) - K1p_gamma*(K2pmTg+T);
@@ -3246,10 +3158,10 @@ hydro_flux(struct Species_Conservation_Terms *st,
   dbl y_dot, adv, conv_flux;
   dbl hh_siz, h_elem;
 
-  dbl *Y, (*grad_Y)[DIM], *dmu_dY, *d2mu_dY2, dmu_dT, d2mu_dT2;
-  dbl d2mu_dgd_dY; /* cross derivative of viscosity wrt
+  dbl *Y, (*grad_Y)[DIM], *dmu_dY, *d2mu_dY2;
+  /*  dbl d2mu_dgd_dY; */ /* cross derivative of viscosity wrt
 		      shear rate and concentration */
-  dbl f, maxpack, nexp, Y_avg, f0, rzexp;
+  dbl f, maxpack, nexp, rzexp;
   dbl df_dy, df_dmu, df_dmu0=0;
 
   dbl (* d_grad_gd_dmesh)[DIM][MDE];
@@ -3319,9 +3231,7 @@ hydro_flux(struct Species_Conservation_Terms *st,
     
   dmu_dY = &(mp->d_viscosity[MAX_VARIABLE_TYPES]);
   d2mu_dY2 = &(mp->d2_viscosity[MAX_VARIABLE_TYPES]);
-  dmu_dT = mp->d_viscosity[TEMPERATURE];
-  d2mu_dT2 = mp->d2_viscosity[TEMPERATURE];
-  d2mu_dgd_dY = mp->d2_viscosity[MAX_VARIABLE_TYPES + MAX_CONC];
+  /*  d2mu_dgd_dY = mp->d2_viscosity[MAX_VARIABLE_TYPES + MAX_CONC]; */
   
   /* Compute gamma_dot[][], acceleration vector accel[], 
      and the norm of the velocity vector */
@@ -3330,9 +3240,7 @@ hydro_flux(struct Species_Conservation_Terms *st,
   
   memset(gamma_dot, 0, DIM*DIM*sizeof(dbl) );
 
-  f0  = 0.;
   rzexp = 0.;
-  Y_avg = 0.5;
   
   for( a=0; a<VIM; a++ )
     {
@@ -3479,15 +3387,11 @@ hydro_flux(struct Species_Conservation_Terms *st,
       if (mp->GravDiffType[w] == BISECTION)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
-	  Y_avg = mp->u_gdiffusivity[w][1];
-	  f0    = mp->u_gdiffusivity[w][2];
 	}
       else if (mp->GravDiffType[w] == RZBISECTION)
 	{
 	  Dg  = mp->u_gdiffusivity[w][0]*del_rho;
           rzexp =  mp->u_gdiffusivity[w][1];
-	  Y_avg = mp->u_gdiffusivity[w][2];
-	  f0    = mp->u_gdiffusivity[w][3];
 	}
       else if (mp->GravDiffType[w] == RICHARDSON_ZAKI)
 	{
@@ -3863,7 +3767,6 @@ suspension_balance(struct Species_Conservation_Terms *st,
   int a, j, p, b, var;
   int status=1;
   int dim;
-  int err;
   dbl gamma_dot[DIM][DIM];
   VISCOSITY_DEPENDENCE_STRUCT d_mu_struct;  /* viscosity dependence */
   VISCOSITY_DEPENDENCE_STRUCT *d_mu = &d_mu_struct;
@@ -3872,10 +3775,9 @@ suspension_balance(struct Species_Conservation_Terms *st,
   dbl Dg;
   dbl Dd[DIM];
   dbl dDd_dy[DIM];
-  dbl *Y, (*grad_Y)[DIM], *dmu_dY, *d2mu_dY2, dmu_dT, d2mu_dT2;
-  dbl d2mu_dgd_dY; /* cross derivative of viscosity wrt
-		      shear rate and concentration */
-  dbl f, maxpack, nexp, rzexp = 0;
+  dbl *Y, (*grad_Y)[DIM];
+
+  dbl f, maxpack, rzexp = 0;
   dbl df_dy, df_dmu;
   dbl M;  /* hindrance function */
   dbl dM_dy, dM_dmu;
@@ -3890,8 +3792,6 @@ suspension_balance(struct Species_Conservation_Terms *st,
   dbl d_div_tau_p_dvd[DIM][DIM][MDE];          /* derivative wrt vorticity dir */
   dbl d_div_tau_p_dp[DIM][MDE];                /* derivative wrt pressure */
   
-  dbl (* grad_phi_e ) [DIM][DIM][DIM] = NULL;
-  
   dbl df_dmu0 = 0.0, dmu0_dcure = 0.0, dmu0_dT = 0.0;
   dbl del_rho = 0.0;
 
@@ -3901,12 +3801,6 @@ suspension_balance(struct Species_Conservation_Terms *st,
   grad_Y = fv->grad_c;
   
   dim = pd->Num_Dim;
-  
-  dmu_dY = &(mp->d_viscosity[MAX_VARIABLE_TYPES]);
-  d2mu_dY2 = &(mp->d2_viscosity[MAX_VARIABLE_TYPES]);
-  dmu_dT = mp->d_viscosity[TEMPERATURE];
-  d2mu_dT2 = mp->d2_viscosity[TEMPERATURE];
-  d2mu_dgd_dY = mp->d2_viscosity[MAX_VARIABLE_TYPES + MAX_CONC];
   
   /* Compute gamma_dot[][] */
   
@@ -3931,13 +3825,11 @@ suspension_balance(struct Species_Conservation_Terms *st,
     {
       maxpack = gn->maxpack;
       mu0 = gn->mu0; /* viscosity of pure fluid */
-      nexp = gn->nexp ;
     }
   else
     {
       maxpack = .68;
       mu0 = mu; /* viscosity of pure fluid */
-      nexp = 0.;
     }  
   
   
@@ -4021,7 +3913,7 @@ suspension_balance(struct Species_Conservation_Terms *st,
   memset( d_div_tau_p_dp, 0, sizeof(double) * DIM*MDE);
   
   /* This is the divergence of the particle stress  */
-  err = divergence_particle_stress(div_tau_p, d_div_tau_p_dgd, d_div_tau_p_dy,
+  divergence_particle_stress(div_tau_p, d_div_tau_p_dgd, d_div_tau_p_dy,
 				   d_div_tau_p_dv, d_div_tau_p_dmesh, d_div_tau_p_dvd,d_div_tau_p_dp, w);
 
   
@@ -4126,7 +4018,6 @@ suspension_balance(struct Species_Conservation_Terms *st,
       
       if(pd->v[var])
 	{
-	  grad_phi_e = bf[var]->grad_phi_e;
 	  for ( a=0; a<VIM; a++)   
 	    {
 	      for( p=0; p<VIM; p++ )
@@ -4148,7 +4039,6 @@ suspension_balance(struct Species_Conservation_Terms *st,
       
       if(pd->v[var])
 	{
-	  grad_phi_e = bf[var]->grad_phi_e;
 	  for ( a=0; a<VIM; a++)   
 	    {
 	      for( p=0; p<VIM; p++ )
@@ -4264,7 +4154,7 @@ particle_stress(dbl tau_p[DIM][DIM],                     /* particle stress */
 {
   /*local variables */
   int a, b, p, q, var, j, dofs;
-  int status=1, err;
+  int status=1;
   int dim;
   dbl gammadot, gamma_dot[DIM][DIM];
   
@@ -4281,7 +4171,7 @@ particle_stress(dbl tau_p[DIM][DIM],                     /* particle stress */
   dbl pp = 0, d_pp_dy = 0;
   dbl y_norm, comp = 0, comp1;
   
-  dbl maxpack, nexp;
+  dbl maxpack;
   
   /* Q tensor info */
   dbl qtensor[DIM][DIM];	/* I - 1/2 v^t v at a gauss point */
@@ -4306,7 +4196,7 @@ particle_stress(dbl tau_p[DIM][DIM],                     /* particle stress */
     }
   
   /* This is the shear rate based on velocity */
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
   
   
   /* get mu and grad_mu */
@@ -4320,13 +4210,11 @@ particle_stress(dbl tau_p[DIM][DIM],                     /* particle stress */
     {
       maxpack = gn->maxpack;
       mu0 = gn->mu0; /* viscosity of pure fluid */
-      nexp = gn->nexp ;
     }
   else
     {
       maxpack = .68;
       mu0 = mu; /* viscosity of pure fluid */
-      nexp = 0.;
     }  
   
   y_norm = Y[w]/maxpack;
@@ -4601,7 +4489,7 @@ divergence_particle_stress(dbl div_tau_p[DIM],               /* divergence of th
   
   dbl (* grad_phi_e)[DIM][DIM][DIM]= NULL;
 
-  dbl maxpack, maxpack2, nexp, Ks, Kn;
+  dbl maxpack, maxpack2, Kn;
   dbl pp,  d_pp_dy, d_pp2_dy2;
   dbl comp, comp1, comp2 = 0, y_norm;
   Y = fv->c;
@@ -4762,13 +4650,11 @@ divergence_particle_stress(dbl div_tau_p[DIM],               /* divergence of th
     {
       maxpack = gn->maxpack;
       mu0 = gn->mu0; /* viscosity of pure fluid */
-      nexp = gn->nexp ;
     }
   else
     {
       maxpack = .68;
       mu0 = mu; /* viscosity of pure fluid */
-      nexp = 0.;
     }  
   
   y_norm = Y[w]/maxpack;
@@ -5385,7 +5271,7 @@ int
 foam_species_source(double *param)
 {
   int eqn;
-  int j, var, dim;
+  int j;
   dbl foam, gas, s1; /*mass fractions of gas and solid_1 */
   dbl T;           /* temperature for rate constants */
   dbl A1, E1, A2, E2, expon1, expon2, sigma1, sigma2;
@@ -5402,7 +5288,6 @@ foam_species_source(double *param)
 
   /* Begin Execution */
   
-  dim   = pd->Num_Dim;
   T = fv->T;
 
   foam = fv->c[0];
@@ -5476,7 +5361,6 @@ foam_species_source(double *param)
   eqn = MASS_FRACTION;
   if ( pd->e[eqn] & T_SOURCE )
     {
-      var = MASS_FRACTION;
       mp->species_source[0] = -r1 ;
       mp->species_source[1] = (0.3*r1+0.943*r2);
       mp->species_source[2] = (0.7*r1-r2);
@@ -5727,12 +5611,18 @@ ion_reaction_source ( int species_no )   /* current species number */
  */
 
 {
+  int i;
   int eqn, var, j;
   int four, five;
   dbl k1, k2, k3, K1, K2, K3;
   dbl Q1 = 0.0, Q2 = 0.0, Q3 = 0.0;
   dbl dQ1dx2 = 0.0, dQ1dx3 = 0.0, dQ2dx5 = 0.0, dQ2dx1 = 0.0, dQ2dx2 = 0.0, dQ3dx4 = 0.0, dQ3dx0 = 0.0, dQ3dx3 = 0.0;
   dbl c, rho, M_mix, x[MAX_CONC] = {0};
+
+  /* initialize x[] */
+  for (i = 0; i < MAX_CONC; i++) {
+    x[i] = 0;
+  }
  
   /* Begin Execution */
  
@@ -6054,7 +5944,7 @@ assemble_bond_evolution(double time,	/* present time value */
   /*local variables */
   int eqn, var, peqn, pvar;
   int a, b, p, i, j;
-  int status=1, err;
+  int status=1;
   int dim;
 
   dbl nn;				/* number of bonds */
@@ -6111,6 +6001,10 @@ assemble_bond_evolution(double time,	/* present time value */
 				   wrt mesh */ 
   dbl offset = 0.00001;
 
+  for (i = 0; i < DIM; i++) {
+    grad_phi_i[i] = 0;
+  }
+
   /* Compute gamma_dot[][] */
   
   /* Compute gammadot, grad(gammadot), gamma_dot[][], d_gd_dG, and d_grad_gd_dG */
@@ -6143,7 +6037,7 @@ assemble_bond_evolution(double time,	/* present time value */
       }
     }
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   nn = fv->nn;
   if (pd->TimeIntegration != STEADY) 

--- a/mm_std_models_shell.c
+++ b/mm_std_models_shell.c
@@ -645,9 +645,10 @@ velocity_function_model (double veloU[DIM],
      dbl n[DIM], v[DIM], t1[DIM], t2[DIM];
      dbl vel1, vel2, t1mag, t2mag;
      int i, j;
-     dbl H, H_U, H_L, dH_U_dtime, dH_L_dtime, dH_U_dp, dH_U_ddh;
+     /* dbl H; */
+     dbl H_U, H_L, dH_U_dtime, dH_L_dtime, dH_U_dp, dH_U_ddh;
      dbl dH_U_dX[DIM], dH_L_dX[DIM];
-     dbl thetax, thetay, thetaz;
+     dbl thetax, thetay;
      dbl n2[DIM] = {0.0};
      dbl R[DIM][DIM];
 
@@ -665,10 +666,12 @@ velocity_function_model (double veloU[DIM],
       * situations.  Regardless, if dH_U_dX is zero, this function will work
       * in any situation.  If you need dH_U_dX on a curved surface
       * we really need to think about what dH_U_dX really means. --SAR */
-     H = height_function_model(&H_U, &dH_U_dtime, &H_L, &dH_L_dtime, dH_U_dX, dH_L_dX, &dH_U_dp, &dH_U_ddh, time, delta_t); 
+
+     /* H = height_function_model(&H_U, &dH_U_dtime, &H_L, &dH_L_dtime, dH_U_dX, dH_L_dX, &dH_U_dp, &dH_U_ddh, time, delta_t); */
+
+     height_function_model(&H_U, &dH_U_dtime, &H_L, &dH_L_dtime, dH_U_dX, dH_L_dX, &dH_U_dp, &dH_U_ddh, time, delta_t); 
      thetax = atan(dH_U_dX[1]);
      thetay =-atan(dH_U_dX[0]);
-     thetaz = 0.0;
      R[0][0] = cos(thetay);
      R[0][1] = 0.0;
      R[0][2] = sin(thetay);
@@ -803,9 +806,10 @@ velocity_function_model (double veloU[DIM],
      dbl n[DIM], v[DIM], t1[DIM], t2[DIM];
      dbl vel1, vel2, t1mag, t2mag;
      int i, j;
-     dbl H, H_U, H_L, dH_U_dtime, dH_L_dtime, dH_U_dp, dH_U_ddh;
+     /* dbl H; */
+     dbl H_U, H_L, dH_U_dtime, dH_L_dtime, dH_U_dp, dH_U_ddh;
      dbl dH_U_dX[DIM], dH_L_dX[DIM];
-     dbl thetax, thetay, thetaz;
+     dbl thetax, thetay;
      dbl n2[DIM] = {0.0};
      dbl R[DIM][DIM];
 
@@ -823,10 +827,12 @@ velocity_function_model (double veloU[DIM],
       * situations.  Regardless, if dH_L_dX is zero, this function will work
       * in any situation.  If you need dH_L_dX on a curved surface
       * we really need to think about what dH_L_dX really means. --SAR */
-     H = height_function_model(&H_U, &dH_U_dtime, &H_L, &dH_L_dtime, dH_U_dX, dH_L_dX, &dH_U_dp, &dH_U_ddh, time, delta_t); 
+
+     /* H = height_function_model(&H_U, &dH_U_dtime, &H_L, &dH_L_dtime, dH_U_dX, dH_L_dX, &dH_U_dp, &dH_U_ddh, time, delta_t); */
+
+     height_function_model(&H_U, &dH_U_dtime, &H_L, &dH_L_dtime, dH_U_dX, dH_L_dX, &dH_U_dp, &dH_U_ddh, time, delta_t); 
      thetax = atan(dH_L_dX[1]);
      thetay =-atan(dH_L_dX[0]);
-     thetaz = 0.0;
      R[0][0] = cos(thetay);
      R[0][1] = 0.0;
      R[0][2] = sin(thetay);

--- a/mm_viscosity.c
+++ b/mm_viscosity.c
@@ -681,8 +681,6 @@ power_law_viscosity(struct Generalized_Newtonian *gn_local,
                     VISCOSITY_DEPENDENCE_STRUCT *d_mu )
 {
 
-  int err;
-  int dim;
   int a, b;
   int mdofs=0,vdofs;
 
@@ -701,7 +699,6 @@ power_law_viscosity(struct Generalized_Newtonian *gn_local,
   dbl offset;
   dbl mu = 0.;
 
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
 
   if ( pd->e[R_MESH1] )
@@ -710,7 +707,7 @@ power_law_viscosity(struct Generalized_Newtonian *gn_local,
     }
 
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   /* calculate power law viscosity
      mu = mu0 * (offset + gammadot)**(nexp-1))                 */
@@ -780,9 +777,6 @@ herschel_buckley_viscosity(struct Generalized_Newtonian *gn_local,
 			   dbl gamma_dot[DIM][DIM], /* strain rate tensor */
 			   VISCOSITY_DEPENDENCE_STRUCT *d_mu)
 {
-
-  int err;
-  int dim;
   int a, b;
   int mdofs=0,vdofs;
 
@@ -802,7 +796,6 @@ herschel_buckley_viscosity(struct Generalized_Newtonian *gn_local,
   dbl tau_y;
   dbl offset;
 
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
   
   if ( pd->e[R_MESH1] )
@@ -811,7 +804,7 @@ herschel_buckley_viscosity(struct Generalized_Newtonian *gn_local,
     }
   
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   /* calculate power law viscosity
      power law constants - make this migrate to input deck asap
@@ -893,9 +886,7 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
 		  VISCOSITY_DEPENDENCE_STRUCT *d_mu)
 {
 
-  int err;
-  int dim;
-  int a, b;
+    int a, b;
   int mdofs=0,vdofs;
 
 
@@ -916,7 +907,6 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
   dbl aexp;
   dbl lambda;
 
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
   
   if ( pd->e[R_MESH1] )
@@ -924,7 +914,7 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
       mdofs = ei->dof[R_MESH1];
     }
   
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   mu0 = gn_local->mu0;
   nexp = gn_local->nexp;
@@ -936,13 +926,13 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
-				       gn_local->u_mu0[2], &mu0, d_mu->F);
+	 level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
+			    gn_local->u_mu0[2], &mu0, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
-				       gn_local->u_mu0[2], &mu0, NULL);
+	 level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
+			    gn_local->u_mu0[2], &mu0, NULL);
        }
    }
 
@@ -950,13 +940,13 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
-				       gn_local->u_nexp[2], &nexp, d_mu->F);
+	 level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
+			    gn_local->u_nexp[2], &nexp, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
-				       gn_local->u_nexp[2], &nexp, NULL);
+	 level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
+			    gn_local->u_nexp[2], &nexp, NULL);
        }
    }
 
@@ -964,13 +954,13 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
-				       gn_local->u_muinf[2], &muinf, d_mu->F);
+	 level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
+			    gn_local->u_muinf[2], &muinf, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
-				       gn_local->u_muinf[2], &muinf, NULL);
+	 level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
+			    gn_local->u_muinf[2], &muinf, NULL);
        }
    }
 
@@ -978,13 +968,13 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
-				       gn_local->u_aexp[2], &aexp, d_mu->F);
+	 level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
+			    gn_local->u_aexp[2], &aexp, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
-				       gn_local->u_aexp[2], &aexp, NULL);
+	 level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
+			    gn_local->u_aexp[2], &aexp, NULL);
        }
    }
 	  
@@ -993,13 +983,13 @@ carreau_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
-				       gn_local->u_lam[2], &lambda, d_mu->F);
+	 level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
+			    gn_local->u_lam[2], &lambda, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
-				       gn_local->u_lam[2], &lambda, NULL);
+	 level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
+			    gn_local->u_lam[2], &lambda, NULL);
        }
    }  
 
@@ -1085,8 +1075,6 @@ bingham_viscosity(struct Generalized_Newtonian *gn_local,
 		  VISCOSITY_DEPENDENCE_STRUCT *d_mu)
 {
 
-  int err;
-  int dim;
   int a, b;
   int var;
   int mdofs=0,vdofs;
@@ -1119,7 +1107,7 @@ bingham_viscosity(struct Generalized_Newtonian *gn_local,
   dbl tmelt;
 #endif
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   mu0 = gn_local->mu0;
   nexp = gn_local->nexp;
@@ -1133,7 +1121,7 @@ bingham_viscosity(struct Generalized_Newtonian *gn_local,
  	}
    else if (gn_local->tau_yModel == USER )
  	{
- 	  err = usr_yield_stress(gn_local->u_tau_y, tran->time_value);
+ 	  usr_yield_stress(gn_local->u_tau_y, tran->time_value);
  	  tau_y = gn_local->tau_y;
  	}
    else
@@ -1151,7 +1139,6 @@ bingham_viscosity(struct Generalized_Newtonian *gn_local,
   tmelt = mp->melting_point_liquidus;
 #endif
 
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
   
   if ( pd->e[R_MESH1] )
@@ -1333,8 +1320,6 @@ bingham_wlf_viscosity(struct Generalized_Newtonian *gn_local,
 		      VISCOSITY_DEPENDENCE_STRUCT *d_mu)
 {
 
-  int err;
-  int dim;
   int a, b;
   int var;
   int mdofs=0,vdofs;
@@ -1365,7 +1350,7 @@ bingham_wlf_viscosity(struct Generalized_Newtonian *gn_local,
   dbl wlfc2, wlf_denom;
   dbl temp;
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   mu0 = gn_local->mu0;
   nexp = gn_local->nexp;
@@ -1386,7 +1371,7 @@ bingham_wlf_viscosity(struct Generalized_Newtonian *gn_local,
     }
   else if (gn_local->tau_yModel == USER )
     {
-      err = usr_yield_stress(gn_local->u_tau_y, tran->time_value);
+      usr_yield_stress(gn_local->u_tau_y, tran->time_value);
       tau_y = gn_local->tau_y;
     }
   else
@@ -1395,7 +1380,6 @@ bingham_wlf_viscosity(struct Generalized_Newtonian *gn_local,
     }
   fexp = gn_local->fexp;
   
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
   
   if ( pd->e[R_MESH1] )
@@ -1535,8 +1519,6 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
 		  VISCOSITY_DEPENDENCE_STRUCT *d_mu)
 {
 
-  int err;
-  int dim;
   int a, b;
 
   int var;
@@ -1567,7 +1549,7 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
   dbl wlfc2;
   dbl temp;
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
   mu0 = gn_local->mu0;
   nexp = gn_local->nexp;
@@ -1586,13 +1568,13 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
-				       gn_local->u_mu0[2], &mu0, d_mu->F);
+	 level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
+			    gn_local->u_mu0[2], &mu0, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
-				       gn_local->u_mu0[2], &mu0, NULL);
+	 level_set_property(gn_local->u_mu0[0], gn_local->u_mu0[1], 
+			    gn_local->u_mu0[2], &mu0, NULL);
        }
    }
 
@@ -1600,13 +1582,13 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
-				       gn_local->u_nexp[2], &nexp, d_mu->F);
+	 level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
+			    gn_local->u_nexp[2], &nexp, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
-				       gn_local->u_nexp[2], &nexp, NULL);
+	 level_set_property(gn_local->u_nexp[0], gn_local->u_nexp[1], 
+			    gn_local->u_nexp[2], &nexp, NULL);
        }
    }
 
@@ -1614,13 +1596,13 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
-				       gn_local->u_muinf[2], &muinf, d_mu->F);
+	 level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
+			    gn_local->u_muinf[2], &muinf, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
-				       gn_local->u_muinf[2], &muinf, NULL);
+	 level_set_property(gn_local->u_muinf[0], gn_local->u_muinf[1], 
+			    gn_local->u_muinf[2], &muinf, NULL);
        }
    }
 
@@ -1628,13 +1610,13 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
-				       gn_local->u_aexp[2], &aexp, d_mu->F);
+	 level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
+			    gn_local->u_aexp[2], &aexp, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
-				       gn_local->u_aexp[2], &aexp, NULL);
+	 level_set_property(gn_local->u_aexp[0], gn_local->u_aexp[1], 
+			    gn_local->u_aexp[2], &aexp, NULL);
        }
    }
 	  
@@ -1642,13 +1624,13 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_atexp[0], gn_local->u_atexp[1], 
-				       gn_local->u_atexp[2], &atexp, d_mu->F);
+	 level_set_property(gn_local->u_atexp[0], gn_local->u_atexp[1], 
+			    gn_local->u_atexp[2], &atexp, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_atexp[0], gn_local->u_atexp[1], 
-				       gn_local->u_atexp[2], &atexp, NULL);
+	 level_set_property(gn_local->u_atexp[0], gn_local->u_atexp[1], 
+			    gn_local->u_atexp[2], &atexp, NULL);
        }
    }
 
@@ -1656,13 +1638,13 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_wlfc2[0], gn_local->u_wlfc2[1], 
-				       gn_local->u_wlfc2[2], &wlfc2, d_mu->F);
+	 level_set_property(gn_local->u_wlfc2[0], gn_local->u_wlfc2[1], 
+			    gn_local->u_wlfc2[2], &wlfc2, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_wlfc2[0], gn_local->u_wlfc2[1], 
-				       gn_local->u_wlfc2[2], &wlfc2, NULL);
+	 level_set_property(gn_local->u_wlfc2[0], gn_local->u_wlfc2[1], 
+			    gn_local->u_wlfc2[2], &wlfc2, NULL);
        }
    }
 
@@ -1670,17 +1652,16 @@ carreau_wlf_viscosity(struct Generalized_Newtonian *gn_local,
    {
      if(d_mu != NULL)
        {
-	 err = level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
-				       gn_local->u_lam[2], &lambda, d_mu->F);
+	 level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
+			    gn_local->u_lam[2], &lambda, d_mu->F);
        }
      else
        {
-	 err = level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
-				       gn_local->u_lam[2], &lambda, NULL);
+	 level_set_property(gn_local->u_lam[0], gn_local->u_lam[1], 
+			    gn_local->u_lam[2], &lambda, NULL);
        }
    }  
 
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
   
   if ( pd->e[R_MESH1] )
@@ -1986,7 +1967,6 @@ carreau_suspension_viscosity(struct Generalized_Newtonian *gn_local,
 			     dbl gamma_dot[DIM][DIM], /* strain rate tensor  */
 			     VISCOSITY_DEPENDENCE_STRUCT *d_mu)
 {
-  int dim;
   int a, b;
   int var, var_offset;
   int w;
@@ -2018,11 +1998,9 @@ carreau_suspension_viscosity(struct Generalized_Newtonian *gn_local,
   int species;    /* species number for solid volume fraction tracking */
 
   int i, j;
-  int err;
+  
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
-
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
   
   if ( pd->e[R_MESH1] )
@@ -2195,7 +2173,6 @@ powerlaw_suspension_viscosity(struct Generalized_Newtonian *gn_local,
 			      dbl gamma_dot[DIM][DIM], /* strain rate tensor */
 			      VISCOSITY_DEPENDENCE_STRUCT *d_mu)
 {
-  int dim;
   int a, b;
   int var, var_offset;
   int w;
@@ -2224,11 +2201,9 @@ powerlaw_suspension_viscosity(struct Generalized_Newtonian *gn_local,
   int species;    /* species number for solid volume fraction tracking */
 
   int i, j;
-  int err;
 
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
 
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
   
   if ( pd->e[R_MESH1] )
@@ -3106,8 +3081,6 @@ carreau_wlf_conc_viscosity(struct Generalized_Newtonian *gn_local,
 		  const int const_eqn)
 {
  
-  int err;
-  int dim;
   int a, b;
  
   int var;
@@ -3141,7 +3114,7 @@ carreau_wlf_conc_viscosity(struct Generalized_Newtonian *gn_local,
   dbl nonvol_conc = 0.0;
   dbl temp;
  
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
  
   mu0 = gn_local->mu0;
   nexp = gn_local->nexp;
@@ -3154,7 +3127,6 @@ carreau_wlf_conc_viscosity(struct Generalized_Newtonian *gn_local,
   conc_exp = gn_local->fexp;
    
  
-  dim  = ei->ielem_dim;
   vdofs = ei->dof[VELOCITY1];
    
   if ( pd->e[R_MESH1] )

--- a/rd_pixel_image.c
+++ b/rd_pixel_image.c
@@ -99,7 +99,6 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
 
   /* variables for processing the image data */
   double minsepar, separ; // minimum separation, and separation to match data point to element center
-  int converge; //flag for find_xi() routine
 
   /* Least square fit variables and arrays */
   double *bf_mat, *f_rhs, *x_fit, *Atranspose_f_rhs;
@@ -119,7 +118,7 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
   /* Integers */
   int err, i, j, si;
   int elem_loc;
-  int ilnode, ignode, ielem, iblock, ielem_shape;  
+  int ilnode, ignode, ielem, ielem_shape;  
   int txt_num_pts;
   int icount;
 
@@ -291,8 +290,6 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
 	  ei->deforming_mesh = FALSE;
 	}
 
-      iblock = find_elemblock_index(ielem, exo);
-
       for ( ilnode = 0; ilnode < exo->eb_num_nodes_per_elem[ipix_blkid]; ilnode++)
          {
            // ignode = connectivity[ielem][ilnode] - 1;
@@ -303,7 +300,7 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
 	     }
          }
 
-      converge = find_xi(ielem, xyz_data[i], xi_data[i], ei->ielem_type, nodecoor, si, N_ext);
+      find_xi(ielem, xyz_data[i], xi_data[i], ei->ielem_type, nodecoor, si, N_ext);
       /* Now undo the mess if needed  */
       if(if_deform) ei->deforming_mesh = TRUE;
      }
@@ -425,8 +422,8 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
       'conversions' to accomodate the different pixel data structure the function expects
     */
    double resolution[3];
-   double pixorigin[3];
-   int pixsize[3], numpix;
+   /*   double pixorigin[3]; */
+   int pixsize[3];
    double ***pixdata;
    double minx, miny, maxx, maxy;
    double firstx = 0;
@@ -438,6 +435,7 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
    minx = miny = 1e20;
    maxx = maxy = -1e20;
    setres = 0;
+   resolution[0] = 0;
    resolution[1] = 0;
    for (i = 0; i < txt_num_pts; i++)
      {
@@ -452,13 +450,13 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
        }
      }   
    
-   pixorigin[0] = minx;
-   pixorigin[1] = miny;
-   pixorigin[2] = 0;
+   /*   pixorigin[0] = minx;
+	pixorigin[1] = miny;
+	pixorigin[2] = 0; 
+   */
    pixsize[0] = (int)((maxx-minx)/resolution[0]) + 1;
    pixsize[1] = (int)((maxy-miny)/resolution[1]) + 1;
    pixsize[2] = 1;
-   numpix = pixsize[0]*pixsize[1]*pixsize[2];
    pixdata = (double ***) malloc(pixsize[0]*pixsize[1]*pixsize[2] * sizeof(double **));
    for (i = 0; i < pixsize[0]; i++)
      {

--- a/rd_pixel_image2.c
+++ b/rd_pixel_image2.c
@@ -117,7 +117,7 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
   double resolution[3];         // Array form of above (easier to pass to function)
   int pixinterp = 0;            // Flag indicating pixel interpolation (0 - none; 1 - bi/trilinear)
   double x0, y0, z0;            // Coordinates of origin for pixel/voxel file
-  double pixorigin[3];           // Array form of above
+  /*  double pixorigin[3];           // Array form of above */
 
   float exoversion;
   int exoout;
@@ -152,11 +152,9 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
   //  double rmsd_error;
   double time0;
 
-  int first_time_field = TRUE; // Flag to check whether this is the first time mapping to the specified field 
+  /*  int first_time_field = TRUE; // Flag to check whether this is the first time mapping to the specified field */
 
   int my_N_ext; // Index of external field being mapped to. May not be what's passed to the function.
-
-  int lastpix = 0;  // Index of external field corresponding to last pixel field being mapped
 
   time0 = ust();
   my_N_ext = N_ext;
@@ -204,7 +202,6 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
     num_nod_vars = 0;
     for (i = 0; i < efv->Num_external_field; i++){
       if (efv->ipix[i] == 2){
-	lastpix = i;
 	dupflag = 0;
 	for (j = 0; j < num_nod_vars; j++){
 	  if (strcmp(nod_var_names_temp[j], efv->name[i]) == 0){
@@ -235,7 +232,7 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
     for (i = N_ext-1; i >= 0; i--){
       if (!strcmp(efv->name[i],efv->name[N_ext])){
 	my_N_ext = i;
-	first_time_field = FALSE;
+	/*	first_time_field = FALSE; */
 	break;
       }
     }
@@ -272,9 +269,10 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
   resolution[1] = resy;
   resolution[2] = resz;
 
-  pixorigin[0] = x0;
-  pixorigin[1] = y0;
-  pixorigin[2] = z0;
+  /*  pixorigin[0] = x0;
+      pixorigin[1] = y0;
+      pixorigin[2] = z0;
+  */
 
   if (pixdim != pd->Num_Dim) {
     printf("WARNING: Pixel file dimensionality is %d, problem dim. is %d\n",pixdim,pd->Num_Dim);
@@ -568,7 +566,7 @@ extern double calc_error(double ***pixdata,
 
   double sparam, tparam;
   double nodecoor[MDE][DIM];
-  double pixcoords[2];
+  double pixcoords[3];
   double xi_data[3];
 
   double phi_i;
@@ -760,13 +758,14 @@ static double tri_interp(double xg, double yg, double zg,
 /**************************************************************
 Routine for trilinear interpolation will go here. Same idea as above, but for 3D
 
-*/
+
 
   double dx, dy, dz;
 
   dx = resolution[0];
   dy = resolution[1];
   dz = resolution[2];
+*/
   return 0;
 }  
 

--- a/rf_element_storage.c
+++ b/rf_element_storage.c
@@ -115,7 +115,7 @@ init_element_storage(ELEM_BLK_STRUCT *eb_ptr)
       *
       *****************************************************************/
 {
-  int ielem_type, ip_total, i, numStorage;
+  int ip_total, i, numStorage;
   ELEMENT_STORAGE_STRUCT *s_ptr;
   double *d_ptr;
   double *base_ptr = NULL;
@@ -126,7 +126,6 @@ init_element_storage(ELEM_BLK_STRUCT *eb_ptr)
     /*
      * Determine the number of quadrature points
      */
-    ielem_type      = eb_ptr->Elem_Type;
     ip_total        = eb_ptr->IP_total;
     s_ptr = alloc_struct_1(ELEMENT_STORAGE_STRUCT, 
 			   eb_ptr->Num_Elems_In_Block);
@@ -208,7 +207,7 @@ set_init_Element_Storage(ELEM_BLK_STRUCT *eb_ptr, int mn)
       *
       *****************************************************************/
 {
-  int ielem_type, ip_total, i, j, ifound, ip;
+  int ip_total, i, j, ifound, ip;
   double sat_switch = 0.0, pc_switch = 0.0, Draining_curve, *ev_tmp;
   int error, num_dim, num_nodes;
   int num_elem, num_elem_blk, num_node_sets, num_side_sets, time_step;
@@ -226,8 +225,6 @@ set_init_Element_Storage(ELEM_BLK_STRUCT *eb_ptr, int mn)
     
   if(mp_glob[mn]->SaturationModel == TANH_HYST)
     {
-  
-      ielem_type      = eb_ptr->Elem_Type;
       ip_total        = eb_ptr->IP_total;
       Draining_curve   = mp_glob[mn]->u_saturation[8];
       if (Guess_Flag ==4 || Guess_Flag == 5)

--- a/rf_solve.c
+++ b/rf_solve.c
@@ -226,8 +226,9 @@ solve_problem(Exo_DB *exo,	 /* ptr to the finite element mesh database  */
   double time_print, i_print;
   double theta = 0.0, time;
   static double time1 = 0.0;     /* Current time that the simulation is trying  to find the solution for */
-
+#ifdef LIBRARY_MODE
   static double delta_t_save = 0.0;
+#endif
   double delta_t, delta_t_new = 0.0;
   double delta_t_old, delta_t_older, delta_t_oldest = 0.0;
   double timeValueRead = 0.0;    /* time value read from an exodus input file 
@@ -280,8 +281,9 @@ solve_problem(Exo_DB *exo,	 /* ptr to the finite element mesh database  */
 
   static int callnum = 1;	 /* solve_problem call counter */
   int last_call = TRUE;		 /* Indicates final rf_solve call */
+#ifdef LIBRARY_MODE
   int last_step = FALSE;	 /* Indicates final time step on this call */
-
+#endif
 
   static const char yo[]="solve_problem"; /* So my name is in a string.        */
 
@@ -1411,7 +1413,9 @@ DPRINTF(stderr,"new surface value = %g \n",pp_volume[i]->params[pd->Num_Species]
        * Calculate the absolute time for the current step, time1
        */
       time1 = time + delta_t;
+#ifdef LIBRARY_MODE
       delta_t_save = delta_t;
+#endif
       if (time1 > TimeMax) { 
 	DPRINTF(stderr, "\t\tLAST TIME STEP!\n"); 
 	time1 = TimeMax;
@@ -1419,11 +1423,14 @@ DPRINTF(stderr,"new surface value = %g \n",pp_volume[i]->params[pd->Num_Species]
 	tran->delta_t = delta_t;
 	tran->delta_t_avg = 0.25*(delta_t+delta_t_old+delta_t_older
 					+delta_t_oldest);
+#ifdef LIBRARY_MODE
         last_step = TRUE;
+#endif
       }
       tran->time_value = time1;
+#ifdef LIBRARY_MODE
       if (n == (MaxTimeSteps-1) ) last_step = TRUE;
-
+#endif
       /*
        * What is known at this exact point in the code:
        *
@@ -3233,7 +3240,6 @@ anneal_mesh(double x[], int tev, int tev_post, double *glob_vars_val,
   int ielem;
   int e_start, e_end;
   int *moved;
-  int e_type;
   /*  int num_local_nodes; */
   int gnn;
   int ln;
@@ -3311,7 +3317,6 @@ anneal_mesh(double x[], int tev, int tev_post, double *glob_vars_val,
   {
     load_elem_dofptr(ielem, exo, x, x_file, x, x, x, 1);
 
-    e_type =  ei->ielem_type;
     memset(d, 0, sizeof(double  )*DIM*MDE);
     memset(dofs, 0, sizeof(int)*DIM);
     

--- a/rf_util.c
+++ b/rf_util.c
@@ -1914,7 +1914,7 @@ void init_shell_normal_unknowns(double u[], const Exo_DB *exo,
 {
   int nxi, nyi, nn, inode;
   int has_normal = FALSE;
-  double dx, dy, dj, nx, ny, sx, sy, sumOld;
+  double dx, dy, dj, nx, ny, sumOld;
   nn = exo->num_nodes;
   /* Loop over shell nodes */
   for (inode = 0; inode < nn; inode++)
@@ -1938,8 +1938,6 @@ void init_shell_normal_unknowns(double u[], const Exo_DB *exo,
 	      /* Construct unit vector from the node pointing to the focal point */
 	      dx = Coor[0][inode] - xfocus;
 	      dy = Coor[1][inode] - yfocus;
-	      sx = SGN(dx);
-	      sy = SGN(dy);
 	      dj = sqrt(dx * dx + dy * dy);
 	      if (dj < 1.0E-12) 
 		{

--- a/sl_eggroll02.c
+++ b/sl_eggroll02.c
@@ -119,7 +119,7 @@ gevp_arnoldi_rc(int nj,
   static dbl tm, 
     w1, w2, w4, w5, w6, wa, wb, 
     xm, beta, hnorm, r_sigma, i_sigma,
-    r_ev_a, i_ev_a, r_ev_b, i_ev_b, res_a, res_b, 
+    r_ev_a, i_ev_a, r_ev_b, i_ev_b,
     *q1, *q2, 
     **hh, **rr;
   static EV ev;
@@ -512,7 +512,6 @@ l31:
 	wb = sqrt(SQUARE(r_ev_a)+SQUARE(i_ev_a));
 	if(wa < IDG_EPS * wb) 
 	  wa = 0.0;
-	res_a = sqrt(fabs(wa-wb))*sqrt(wa+wb);
 
 	/* RC flag set to 32: get v2 = M*v1
 	 */
@@ -558,7 +557,6 @@ l33:
 	wb = sqrt(SQUARE(r_ev_b)+SQUARE(i_ev_b));
 	if (wa < IDG_EPS * wb) 
 	  wa = 0.0;
-	res_b = sqrt(fabs(wa-wb))*sqrt(wa+wb);
 	tm = SQUARE(r_ev_b)+SQUARE(i_ev_b);
 	rev[i] = (r_ev_a*r_ev_b+i_ev_a*i_ev_b)/tm;
 	iev[i] = (i_ev_a*r_ev_b-r_ev_a*i_ev_b)/tm;

--- a/sl_eggrollwrap.c
+++ b/sl_eggrollwrap.c
@@ -94,9 +94,9 @@ eggrollwrap(int *istuff,	/* info for eigenvalue extraction */
     nev_want, nev_found, lead, 
     /*    read_form, soln_tech, push_mode, */
     push_mode, 
-    init_shft, cold_start, recycle;
+    init_shft, recycle;
   dbl
-    stol, fvector, ivector, msign, 
+    stol, ivector,
     dwork[20]; 
   dbl 
     *ev_e, *ev_i, *ev_r, *ev_x,  
@@ -121,14 +121,11 @@ eggrollwrap(int *istuff,	/* info for eigenvalue extraction */
   nnz_j      = istuff[2];
   filter     = istuff[3];
   recycle    = istuff[4];
-  cold_start = istuff[5];
   nev_want   = istuff[6];
   init_shft  = istuff[7];
   max_itr    = istuff[8];
   push_mode  = istuff[9];
   stol       = dstuff[0];
-  fvector    = dstuff[1];
-  msign      = dstuff[2];
   ivector    = dstuff[3];
 
   printf(" Initializing variables and allocating space... ");

--- a/sl_lu.c
+++ b/sl_lu.c
@@ -96,7 +96,9 @@ lu(const int N,
   int  error, type;
   int j, i, n, k, nzeros, ija_col;
   static spREAL **element, *b;
+#ifdef MATRIX_STATISTICS
   spREAL norm;
+#endif
 
 
   call++;
@@ -165,8 +167,9 @@ lu(const int N,
 
      } /* end of define and fill */
 
+#ifdef MATRIX_STATISTICS
      norm = spNorm(matrix);
-
+#endif
       if( first_time == TRUE && factor_flag == 1){
 
 /*         spFileMatrix(matrix,"matrix_file","channel",0,1,1); */

--- a/sl_lu_fill.c
+++ b/sl_lu_fill.c
@@ -100,7 +100,9 @@ luf (const int N,
   int  error, type;
   int j, i, n, k, nzeros, ija_col;
   static spREAL **element, *b;
+#ifdef MATRIX_STATISTICS
   spREAL norm;
+#endif
   static int call = 0;
 
   call++;
@@ -167,8 +169,9 @@ luf (const int N,
         if (n == 1) spClear(matrix);/* zero entries in graph */
 
      } /* end of define and fill */
-
+#ifdef MATRIX_STATISTICS
      norm = spNorm(matrix);
+#endif
 
       if( first_time_fill == TRUE && factor_flag == 1){
 

--- a/sl_matrix_util.c
+++ b/sl_matrix_util.c
@@ -105,11 +105,13 @@ print_msr_matrix(int n, int *ija, double *a, double *x)
      *************************************************************************/
 {
   static int num_call = 0;
-  int i, row, col, nnz;
+  int i, row, col;
   char filename[80];
   FILE *of;
 #ifdef PARALLEL
+#if 0
   char col_kind, row_kind;
+#endif
   int global_row, global_col;
 #endif  
 
@@ -118,8 +120,6 @@ print_msr_matrix(int n, int *ija, double *a, double *x)
   }
   sprintf(filename, "A%d_of_%d.%d", ProcID+1, Num_Proc, num_call);
   of = fopen(filename, "w");
-
-  nnz = ija[n];
 
   /*   fprintf(of, "# row col value \n");*/
   /* a[local_row, local_col] = A[global_row, global_col]\n"); */
@@ -134,6 +134,10 @@ print_msr_matrix(int n, int *ija, double *a, double *x)
 #endif
 #ifdef PARALLEL
     global_row = row;
+  
+    fprintf(of, "%d %d %23.16e %23.16e\n", global_row, global_row,
+	    a[row], x[row]);
+#if 0
     if (row < num_internal_dofs ) {
       row_kind = 'I';
     } else if (row < num_internal_dofs + num_boundary_dofs) {
@@ -141,9 +145,6 @@ print_msr_matrix(int n, int *ija, double *a, double *x)
     } else {
       row_kind = 'E';
     }
-    fprintf(of, "%d %d %23.16e %23.16e\n", global_row, global_row,
-	    a[row], x[row]);
-#if 0
     fprintf(of, "a[%d,%d] = %23.16e\t(A[%d,%d]) (%c,%c)\n", row, row, 
 	    a[row],
 	    global_row, global_row, row_kind, row_kind);
@@ -160,6 +161,9 @@ print_msr_matrix(int n, int *ija, double *a, double *x)
 #ifdef PARALLEL
       global_row = row;
       global_col = col;
+
+      fprintf(of, "%d %d %23.16e\n", global_row, global_col, a[i]);
+#if 0
       if (row < num_internal_dofs ) {
 	row_kind = 'I';
       } else if ( row < num_internal_dofs + num_boundary_dofs ) {
@@ -174,8 +178,6 @@ print_msr_matrix(int n, int *ija, double *a, double *x)
       } else {
 	col_kind = 'E';
       }
-      fprintf(of, "%d %d %23.16e\n", global_row, global_col, a[i]);
-#if 0
       fprintf(of, "a[%d,%d] = %23.16e (A[%d,%d]) (%c,%c)\n", row, col, a[i],
 	      global_row, global_col, row_kind, col_kind);
 #endif

--- a/user_bc.c
+++ b/user_bc.c
@@ -93,11 +93,12 @@ dbl velo_vary_fnc( velo_condition, x1, x2, x3, p, time)
 {
   /*  dbl v_max, gap, u, midpt, channel; */
   double f = 0.0;
-  double a1,a2;
+  /*  double a1,a2;
 
   a1 = p[0];
   a2 = p[1];
-  
+  */
+
   /*  radius = sqrt( x1*x1 + x2*x2 ); 
       
       if( velo_condition == UVARY_BC) 
@@ -113,7 +114,7 @@ dbl velo_vary_fnc( velo_condition, x1, x2, x3, p, time)
   
   if( velo_condition == UVARY_BC)
     {
-      if(time<900.)
+      /* if(time<900.)
 	{
 	  a1 = 0.002;
 	} 
@@ -137,6 +138,7 @@ dbl velo_vary_fnc( velo_condition, x1, x2, x3, p, time)
 	{
 	  a1 = 0.;
 	}
+      */
       f = -2.0*x2;
 
       /*  f = -a2*x2/radius; */
@@ -217,7 +219,8 @@ dbl dvelo_vary_fnc_d1( velo_condition, x1, x2, x3, p, time)
      const dbl time;
 {
   dbl f = 0.0;
-  dbl radius, drdx1,a2;
+  dbl a2;
+  /* dbl radius, drdx1; */
 
 
   /* Cylindrical swirling flow 
@@ -227,8 +230,8 @@ dbl dvelo_vary_fnc_d1( velo_condition, x1, x2, x3, p, time)
 
   a2 = p[1];
 
-  radius = sqrt( x1*x1 + x2*x2 );
-  drdx1  = x1/radius;
+  /* radius = sqrt( x1*x1 + x2*x2 );
+  drdx1  = x1/radius; */
 
   if( velo_condition == VVARY_BC)
     {
@@ -272,7 +275,8 @@ dbl dvelo_vary_fnc_d2( velo_condition, x1, x2, x3, p, time)
 /* for PI use M_PIE Constant from std.h include file. */
 
   dbl f=0.0;
-  dbl radius, drdx2, a1, a2;
+  dbl a2;
+  /* dbl a1, radius, drdx2; */
 
 
   /* Cylindrical swirling flow 
@@ -280,8 +284,8 @@ dbl dvelo_vary_fnc_d2( velo_condition, x1, x2, x3, p, time)
    * Velocity: a2
    */
 
-  radius = sqrt( x1*x1 + x2*x2 );
-  drdx2  = x2/radius;
+  /* radius = sqrt( x1*x1 + x2*x2 );
+     drdx2  = x2/radius; */
   
   a2 = p[1];
   
@@ -292,7 +296,7 @@ dbl dvelo_vary_fnc_d2( velo_condition, x1, x2, x3, p, time)
     }
   else if ( velo_condition == UVARY_BC )
     {
-      if(time<900.)
+      /* if(time<900.)
 	{
 	  a1 = 0.002;
 	} 
@@ -316,6 +320,7 @@ dbl dvelo_vary_fnc_d2( velo_condition, x1, x2, x3, p, time)
 	{
 	  a1 = 0.;
 	}
+      */
       f = -2.0;
 
       /*   f = ( 1. - x2*drdx2/radius)/radius; */
@@ -1487,7 +1492,7 @@ volt_user_surf (double func[DIM],
   int j, j_id, w1, var;
   double phi_j;
   double PHI;
-  double i, i0, ai0a, Ha, cH2, cH2ref, aa, ac, T, U0a;
+  double i, i0, ai0a, Ha, cH2, cH2ref, aa, ac, T;
   double cratio;
 
 /***************************** EXECUTION BEGINS *******************************/
@@ -1501,7 +1506,6 @@ volt_user_surf (double func[DIM],
     aa = p[4];
     ac = p[5];
     T = p[6];
-    U0a = p[7];
 
     RTF = R*T/F;
     cH2 = fv->c[0];

--- a/user_continuation.c
+++ b/user_continuation.c
@@ -269,7 +269,7 @@ update_user_TP_parameter(double lambda, double *x, double *xdot,
 
 {
 /* Actual function begins here (refer to previous example) */
-  static int first_tp = 1;
+  //static int first_tp = 1;
   // int first_cp = -1;
   // int n = 0;
   // int Type, BCID, DFID, MTID, MPID, MDID;
@@ -297,7 +297,7 @@ update_user_TP_parameter(double lambda, double *x, double *xdot,
 
 
 /* Done */
-  first_tp = 0;
+  //first_tp = 0;
   return;
 
 } /* END of routine update_user_TP_parameter */

--- a/user_mp.c
+++ b/user_mp.c
@@ -156,7 +156,7 @@ usr_thermal_conductivity(dbl *param, dbl time) /* user-defined parameter list */
   dbl dkdX[DIM];      /* thermal conductivity derivative wrt displacement*/
   dbl dkdC[MAX_CONC]; /* thermal conductivity derivative wrt concentration*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
+  /* dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
 
   int i;
 
@@ -185,9 +185,9 @@ usr_thermal_conductivity(dbl *param, dbl time) /* user-defined parameter list */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                            /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /**********************************************************/
 
@@ -220,7 +220,7 @@ usr_electrical_conductivity(dbl *param, dbl time)	/* user-defined parameter list
   dbl dkdX[DIM];      /* electrical conductivity derivative wrt displacement*/
   dbl dkdC[MAX_CONC]; /* electrical conductivity derivative wrt concentration*/
 
-  dbl X[DIM], T, C[MAX_CONC], V; /* Convenient local variables */
+  /* dbl X[DIM], T, C[MAX_CONC], V; */ /* Convenient local variables */
 
   int i;
 
@@ -249,10 +249,10 @@ usr_electrical_conductivity(dbl *param, dbl time)	/* user-defined parameter list
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                      /*Do not touch */
-  V = fv->V;                                      /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		  /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                     /*Do not touch */
+  /*  V = fv->V; */                                     /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		  /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /**********************************************************/
 
@@ -283,7 +283,7 @@ usr_density(dbl *param)         /* pointer to user-defined parameter list    */
   /* Local Variables */
   dbl rho, d_rho_dT;        /* density and its derivative wrt temperature*/
   dbl d_rho_dC[MAX_CONC];   /* density derivative wrt concentration*/
-  dbl T, C[MAX_CONC]; /* Convenient local variables */
+  /* dbl T, C[MAX_CONC]; */ /* Convenient local variables */
   int w;
 
   /* Begin Execution */
@@ -306,8 +306,8 @@ usr_density(dbl *param)         /* pointer to user-defined parameter list    */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                      /*Do not touch */
-  for(w=0; w<pd->Num_Species_Eqn; w++) C[w] = fv->c[w];  /*Do not touch */
+  /*  T = fv->T; */                                     /*Do not touch */
+  /*  for(w=0; w<pd->Num_Species_Eqn; w++) C[w] = fv->c[w]; */  /*Do not touch */
 
  /**********************************************************/
 
@@ -380,7 +380,7 @@ usr_heat_capacity(dbl *param, dbl time)	/* pt to user-defined parameter list */
   dbl dCpdX[DIM]; /* heat capacity derivative wrt displacement */
   dbl dCpdC[MAX_CONC]; /* heat capacity derivative wrt concentration*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
+  /* dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
 
   int i;
 
@@ -409,9 +409,9 @@ usr_heat_capacity(dbl *param, dbl time)	/* pt to user-defined parameter list */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                            /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		        /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; /*Do not touch */
+  /*  T = fv->T; */                                           /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		        /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */ /*Do not touch */
 
  /**********************************************************/
 
@@ -492,9 +492,10 @@ usr_heat_source(dbl *param, dbl time)	/* ptr to the user-defined parameter list 
   dbl dhdC[MAX_CONC]; /* heat source derivative wrt concentration*/
   dbl dhdX[DIM]; /* heat source derivative wrt displacement*/
 
-  dbl X[DIM], T, V, C[MAX_CONC]; /* Convenient local variables */
+  /* int i;
+     dbl X[DIM], T, V, C[MAX_CONC]; */ /* Convenient local variables */
 
-  int i;
+  
 
   /* Begin Execution */
 
@@ -518,10 +519,10 @@ usr_heat_source(dbl *param, dbl time)	/* ptr to the user-defined parameter list 
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  V = fv->V;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                             /*Do not touch */
+  /*  V = fv->V; */                                            /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /**********************************************************/
 
@@ -618,9 +619,8 @@ usr_species_source(int species_no, /* Current species number                 */
   dbl dsdC[MAX_CONC]; /* species source derivative wrt concentration*/
   dbl dsdX[DIM]; /* species source derivative wrt displacement*/
 
-  dbl X[DIM], T, V, C[MAX_CONC]; /* Convenient local variables */
-
-  int i;
+  /* int i;
+     dbl X[DIM], T, V, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -644,10 +644,10 @@ usr_species_source(int species_no, /* Current species number                 */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                              /*Do not touch */
-  V = fv->V;                                              /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];	                  /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];   /*Do not touch */
+  /*  T = fv->T; */                                             /*Do not touch */
+  /*  V = fv->V; */                                             /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */	                  /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */   /*Do not touch */
 
  /**********************************************************/
 
@@ -736,9 +736,8 @@ usr_current_source(dbl *param)	/* pointer to user-defined parameter list */
   dbl dhdC[MAX_CONC]; /* current source derivative wrt concentration*/
   dbl dhdX[DIM]; /* current source derivative wrt displacement*/
 
-  dbl X[DIM], T, V, C[MAX_CONC]; /* Convenient local variables */
-
-  int i;
+  /* int i;
+     dbl X[DIM], T, V, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -762,10 +761,10 @@ usr_current_source(dbl *param)	/* pointer to user-defined parameter list */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  V = fv->V;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                            /*Do not touch */
+  /*  V = fv->V; */                                            /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /**********************************************************/
 
@@ -850,7 +849,8 @@ usr_viscosity(dbl *param)	/* pointer to user-defined parameter list    */
   dbl dmudV[DIM]; /* heat source derivative wrt velocity*/
   dbl dmudC[MAX_CONC]; /* heat source derivative wrt concentration*/
   dbl dmudX[DIM]; /* heat source derivative wrt displacement*/
-  dbl X[DIM], F, T, C[MAX_CONC]; /* Convenient local variables */
+  
+  /* dbl X[DIM], F, T, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -874,10 +874,10 @@ usr_viscosity(dbl *param)	/* pointer to user-defined parameter list    */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                        /*Do not touch */
-  F = fv->F;                                        /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		    /*Do not touch */
-  for(a=0; a<pd->Num_Species_Eqn; a++) C[a] = fv->c[a];    /*Do not touch */
+  /*  T = fv->T; */                                        /*Do not touch */
+  /*  F = fv->F; */                                       /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		    /*Do not touch */
+  /*  for(a=0; a<pd->Num_Species_Eqn; a++) C[a] = fv->c[a]; */   /*Do not touch */
 
  /**********************************************************/
 
@@ -927,9 +927,8 @@ usr_surface_tension(dbl *param)	/* ptr to user-defined parameter list        */
   dbl dsigmadC[MAX_CONC]; /* heat source derivative wrt concentration*/
   dbl dsigmadX[DIM]; /* heat source derivative wrt displacement*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
-
-  int i;
+  /* int i;
+     dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -953,9 +952,9 @@ usr_surface_tension(dbl *param)	/* ptr to user-defined parameter list        */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                        /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		    /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];    /*Do not touch */
+  /*  T = fv->T; */                                       /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		    /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */    /*Do not touch */
 
  /*******Add property function and sensitivities here*******/
  /* An example:
@@ -1046,7 +1045,6 @@ int
 usr_momentum_source(dbl *param)	/* ptr to user-defined parameter list        */
 {
   int a, b;
-  int i;
   int w;
 
   dbl f[DIM], dfdT[DIM];   /* momentum sources and its derivative wrt temperature*/
@@ -1054,7 +1052,8 @@ usr_momentum_source(dbl *param)	/* ptr to user-defined parameter list        */
   dbl dfdC[DIM][MAX_CONC]; /* momentum source derivative wrt concentration*/
   dbl dfdX[DIM][DIM];      /* momentum source derivative wrt displacement*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
+  /* int i;
+     dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -1080,9 +1079,9 @@ usr_momentum_source(dbl *param)	/* ptr to user-defined parameter list        */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                             /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /**********************************************************/
 
@@ -1152,9 +1151,10 @@ usr_lame_mu(struct Elastic_Constitutive *ep, dbl *param)		/* ptr to user-defined
   dbl dfdC[MAX_CONC]; /* momentum source derivative wrt concentration*/
   dbl dfdX[DIM];      /* momentum source derivative wrt displacement*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
+  /* int i;
+     dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
+
   /*  dbl dist;*/
-  int i;
 
   /* Begin Execution */
 
@@ -1180,9 +1180,9 @@ usr_lame_mu(struct Elastic_Constitutive *ep, dbl *param)		/* ptr to user-defined
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                            /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /*******Add property function and sensitivities here*******/
   /* Example:
@@ -1300,9 +1300,8 @@ usr_lame_lambda(struct Elastic_Constitutive *ep, dbl *param)	/* ptr to user-defi
   dbl dfdC[MAX_CONC]; /* momentum source derivative wrt concentration*/
   dbl dfdX[DIM];      /* momentum source derivative wrt displacement*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
-
-  int i;
+  /* int i;
+     dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -1326,9 +1325,9 @@ usr_lame_lambda(struct Elastic_Constitutive *ep, dbl *param)	/* ptr to user-defi
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                            /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /**********************************************************/
 
@@ -1428,9 +1427,8 @@ usr_expansion(dbl *param, 	 /* ptr to user-defined parameter list        */
   dbl dfdC[MAX_CONC]; /* momentum source derivative wrt concentration*/
   dbl dfdX[DIM];      /* momentum source derivative wrt displacement*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
-
-  int i;
+  /* int i;
+     dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -1454,11 +1452,11 @@ usr_expansion(dbl *param, 	 /* ptr to user-defined parameter list        */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                            /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
-	f= param[0]*sin(param[1]*tran->time_value);
+  f= param[0]*sin(param[1]*tran->time_value);
 
  /**********************************************************/
 
@@ -1523,11 +1521,11 @@ usr_diffusivity(int species_no,	/* Species number of diffusivity etc. needed */
   dbl dDdX[DIM];      /* diffusivity derivative wrt displacement*/
   dbl dDdC[MAX_CONC]; /* diffusivity derivative wrt concentration*/
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
+  /* dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
 
   int i;
 
-  dbl a0, a1, a2, a3, a4;
+  /*  dbl a0, a1, a2, a3, a4; */
 
 
   /* Begin Execution */
@@ -1555,20 +1553,21 @@ usr_diffusivity(int species_no,	/* Species number of diffusivity etc. needed */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                             /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		         /*Do not touch */
-  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];  /*Do not touch */
+  /*  T = fv->T; */                                            /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		         /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i]; */  /*Do not touch */
 
  /**********************************************************/
 
  /*******Add property function and sensitivities here*******/
 
+  /*
  a0 = *param;
  a1 = *(param+1);
  a2 = *(param+2);
  a3 = *(param+3);
  a4 = *(param+4);
-
+  */
 /* Constant model 
  D = a0;
  dDdT = 0.0;
@@ -1618,7 +1617,8 @@ usr_FlowingLiquidViscosity(dbl *param) /* ptr to user-defined parameter list */
   dbl dmudV[DIM]; /* heat source derivative wrt velocity*/
   dbl dmudC[MAX_CONC]; /* heat source derivative wrt concentration*/
   dbl dmudX[DIM]; /* heat source derivative wrt displacement*/
-  dbl X[DIM], F, T, C[MAX_CONC]; /* Convenient local variables */
+
+  /*  dbl X[DIM], F, T, C[MAX_CONC]; */ /* Convenient local variables */
 
   /* Begin Execution */
 
@@ -1642,10 +1642,10 @@ usr_FlowingLiquidViscosity(dbl *param) /* ptr to user-defined parameter list */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                              /*Do not touch */
-  F = fv->F;                                              /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		          /*Do not touch */
-  for(a=0; a<pd->Num_Species_Eqn; a++) C[a] = fv->c[a];   /*Do not touch */
+  /*  T = fv->T; */                                             /*Do not touch */
+  /*  F = fv->F; */                                             /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		          /*Do not touch */
+  /*  for(a=0; a<pd->Num_Species_Eqn; a++) C[a] = fv->c[a]; */   /*Do not touch */
 
  /**********************************************************/
 
@@ -1786,12 +1786,14 @@ int
 usr_yield_stress(dbl *param, dbl time)	/* pointer to user-defined parameter list    */
 {
   /* Local Variables */
-  int a;
-  dbl tau_y, dtau_ydT;   /* thermal conductivity and its derivative wrt temperature*/
-  dbl dtau_ydV[DIM]; /* heat source derivative wrt velocity*/
-  dbl dtau_ydC[MAX_CONC]; /* heat source derivative wrt concentration*/
-  dbl dtau_ydX[DIM]; /* heat source derivative wrt displacement*/
-  dbl X[DIM], F, T, C[MAX_CONC]; /* Convenient local variables */
+  /*  int a; */
+  dbl tau_y;   /* thermal conductivity and its derivative wrt temperature*/
+  /*  dbl dtau_ydT; */
+  /*  dbl dtau_ydV[DIM]; */ /* heat source derivative wrt velocity*/
+  /*  dbl dtau_ydC[MAX_CONC]; */ /* heat source derivative wrt concentration*/
+  /*  dbl dtau_ydX[DIM]; */ /* heat source derivative wrt displacement*/
+
+  /*  dbl X[DIM], F, T, C[MAX_CONC]; */ /* Convenient local variables */
  
   /* Begin Execution */
  
@@ -1806,19 +1808,19 @@ usr_yield_stress(dbl *param, dbl time)	/* pointer to user-defined parameter list
  
  /************Initialize everything for saftey**************/
   tau_y = 0;                                  /*Do not touch */
-  dtau_ydT = 0;				  /*Do not touch */
-  for(a=0; a<DIM; a++) dtau_ydV[a]=0.; 	  /*Do not touch */
-  for(a=0; a<DIM; a++) dtau_ydX[a]=0.;       /*Do not touch */
-  for(a=0; a<MAX_CONC; a++) dtau_ydC[a]=0.;  /*Do not touch */
+  /*  dtau_ydT = 0; */				  /*Do not touch */
+  /*  for(a=0; a<DIM; a++) dtau_ydV[a]=0.; */	  /*Do not touch */
+  /*  for(a=0; a<DIM; a++) dtau_ydX[a]=0.; */      /*Do not touch */
+  /*  for(a=0; a<MAX_CONC; a++) dtau_ydC[a]=0.; */  /*Do not touch */
  /**********************************************************/
  
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
  
-  T = fv->T;                                        /*Do not touch */
-  F = fv->F;                                        /*Do not touch */
-  for(a=0; a<DIM; a++)X[a] = fv->x[a];		    /*Do not touch */
-  for(a=0; a<pd->Num_Species_Eqn; a++) C[a] = fv->c[a];    /*Do not touch */
+  /*  T = fv->T; */                                       /*Do not touch */
+  /*  F = fv->F; */                                       /*Do not touch */
+  /*  for(a=0; a<DIM; a++)X[a] = fv->x[a]; */		    /*Do not touch */
+  /*  for(a=0; a<pd->Num_Species_Eqn; a++) C[a] = fv->c[a]; */    /*Do not touch */
  
  /**********************************************************/
  

--- a/user_mp_gen.c
+++ b/user_mp_gen.c
@@ -111,16 +111,20 @@ usr_heat_source_gen(dbl *h,	/* volumetric heat source */
 		    dbl *param,	/* ptr to the user-defined parameter list */
 		    dbl time)
 {
-  int eqn, var;
-  int err;
+  int var;
+  
   int dim;
   int a, b;
 
-  dbl X[DIM], T, C[MAX_CONC]; /* Convenient local variables */
-  dbl rho, Cp, K;             /* Convenient property names  */
-  dbl dCpdT[MDE];
+  /*  int eqn */
+  /*  int err; */
+  /*  dbl X[DIM], T, C[MAX_CONC]; */ /* Convenient local variables */
+  /*  dbl rho, Cp, K; */            /* Convenient property names  */
 
-  int i, j;
+  /*  dbl dCpdT[MDE];*/
+
+  /*  int i; */
+  int j;
 
   /* Begin Execution */
  /**********************************************************/
@@ -132,24 +136,26 @@ usr_heat_source_gen(dbl *h,	/* volumetric heat source */
  /**********************************************************/
 
   dim   = pd->Num_Dim;
-  eqn   = R_ENERGY;			
+  /*  eqn   = R_ENERGY;	*/
 
   /**********************************************************/
   
   /***Load up convenient local variables and properties******/
   /*NB This ought to be done once for all fields at gauss pt*/
-  
+
+  /*  
   T = fv->T;                                       
   for(a=0; a<DIM; a++)X[a] = fv->x[a];		   
   for(i=0; i<pd->Num_Species_Eqn; i++) C[i] = fv->c[i];
 
   rho  = mp->density;
   K   = mp->thermal_conductivity;
-
+  */
   /* Accounting here must be made of potentially variable heat capacity */
+  /*
   if (mp->HeatCapacityModel == CONSTANT)
     {  
-      Cp = mp->heat_capacity;  
+      Cp = mp->heat_capacity;
     } 
   else if (mp->HeatCapacityModel == USER) 
     {
@@ -162,7 +168,7 @@ usr_heat_source_gen(dbl *h,	/* volumetric heat source */
 	  dCpdT[j]= mp->d_heat_capacity[var]*bf[var]->phi[j];
 	}
     }
-
+  */
   /**********************************************************/
 
   /*
@@ -370,10 +376,10 @@ usr_viscosity_gen(dbl *mu,
 		  dbl d_mu_dC[MAX_CONC][MDE],
 		  dbl *param)	/* user-defined parameter list               */
 {
-  int err;
   int a, b;
 
-  int var, var_offset;
+  int var;
+  /* int var_offset; */
   int w;
 
   int mdofs=0,vdofs;
@@ -421,7 +427,7 @@ usr_viscosity_gen(dbl *mu,
       mdofs = ei->dof[R_MESH1];
     }
   
-  err = calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
+  calc_shearrate(&gammadot, gamma_dot, d_gd_dv, d_gd_dmesh);
   
   
   if(gammadot != 0.)
@@ -507,7 +513,7 @@ usr_viscosity_gen(dbl *mu,
       for ( w=0; w<pd->Num_Species_Eqn; w++)
 	{
 	  var = MASS_FRACTION;
-	  var_offset = MAX_VARIABLE_TYPES + w;
+	  /*	  var_offset = MAX_VARIABLE_TYPES + w; */
 	  for ( j=0; j<ei->dof[var]; j++)
 	    {
 	      d_mu_dC[w][j] = dmudC * bf[var]->phi[j];

--- a/user_out_hkm.c
+++ b/user_out_hkm.c
@@ -424,10 +424,6 @@ static void SOLN_VALUES(int var_type, int sub_index, double soln[],
   int     ebi, i_eqn, num_nodes_mn = 0, g_solncomp_nodes, index, n, i;
   int     e_start, e_end, ielem, ielem_type, num_local_nodes, ndof = 0;
   int *i_been_there;
-  NODAL_VARS_STRUCT *nv;
-#ifdef PARALLEL
-  int retn;
-#endif
 
   int num_owned_nodes = DPI_ptr->num_internal_nodes +
                         DPI_ptr->num_boundary_nodes;
@@ -454,7 +450,6 @@ static void SOLN_VALUES(int var_type, int sub_index, double soln[],
 	  if (Nodes[i]->Type.Owned) {
 	    if (! i_been_there[i]) {
 	      i_been_there[i] = 1;
-	      nv = Nodes[i]->Nodal_Vars_Info;
 	
 	      /*
 	       * Find the max, min, and sum of the soln component on the
@@ -504,14 +499,14 @@ static void SOLN_VALUES(int var_type, int sub_index, double soln[],
 
   if (Num_Proc > 1) {
 #ifdef PARALLEL
-    retn = MPI_Allreduce(&s_max, g_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
-    retn = MPI_Allreduce(&s_min, g_min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
+    MPI_Allreduce(&s_max, g_max, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+    MPI_Allreduce(&s_min, g_min, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD);
     /*
      * Find the total number of nodes containing the soln component
      */
-    retn = MPI_Allreduce(&num_nodes_mn, &g_solncomp_nodes, 1, MPI_INT,
+    MPI_Allreduce(&num_nodes_mn, &g_solncomp_nodes, 1, MPI_INT,
 			 MPI_SUM, MPI_COMM_WORLD);
-    retn = MPI_Allreduce(&s_sum, &g_sum, 1, MPI_DOUBLE,
+    MPI_Allreduce(&s_sum, &g_sum, 1, MPI_DOUBLE,
 			 MPI_SUM, MPI_COMM_WORLD);
 #endif
   } else {

--- a/user_post.c
+++ b/user_post.c
@@ -87,11 +87,11 @@ user_post(dbl *param)		/* ptr to the user-defined parameter list */
   /* Local Variables */
   double post_value;
 
-  int a;
+  /* int a;
+     int i; */
 
-  dbl X[DIM], T, C[MAX_CONC], V[DIM], P; /* Convenient local variables */
+  /* dbl X[DIM], T, C[MAX_CONC], V[DIM], P; */ /* Convenient local variables */
 
-  int i;
 
   static int warning = 0;
 
@@ -114,11 +114,11 @@ user_post(dbl *param)		/* ptr to the user-defined parameter list */
  /***********Load up convenient local variables*************/
  /*NB This ought to be done once for all fields at gauss pt*/
 
-  T = fv->T;                                     /*Do not touch */
-  P = fv->P;                                     /*Do not touch */
-  for(a=0; a<DIM; a++) X[a] = fv->x[a];		 /*Do not touch */
-  for(a=0; a<DIM; a++) V[a] = fv->v[a];		 /*Do not touch */
-  for(i=0; i<pd->Num_Species; i++) C[i] = fv->c[i]; /*Do not touch */
+  /* T = fv->T; */                                    /*Do not touch */
+  /*  P = fv->P;  */                                   /*Do not touch */
+  /*  for(a=0; a<DIM; a++) X[a] = fv->x[a]; */		 /*Do not touch */
+  /*  for(a=0; a<DIM; a++) V[a] = fv->v[a]; */		 /*Do not touch */
+  /*  for(i=0; i<pd->Num_Species; i++) C[i] = fv->c[i]; */ /*Do not touch */
 
 /* All gradients of field variables are accesable through fv->?_grad[][]
  * and material properties are accesable through mp->?

--- a/user_pre.c
+++ b/user_pre.c
@@ -63,10 +63,11 @@ user_surf_object (int *int_params, dbl *param, dbl *r )
   double distance = 0;
   static int warning = 0;
 
+  /*
   int num_params;
 
   num_params = int_params[0];
-
+  */
 
  /**********************************************************/
 

--- a/user_print.c
+++ b/user_print.c
@@ -78,7 +78,7 @@ usr_print ( double *t,	            /* time value */
             double **post_proc_vect,
 	    int    var)               /* variable of post_proc_vect */
 {
-  static int status = 0;
+  /*  static int status = 0; */
   int retn = 0;
 
   /*
@@ -186,7 +186,7 @@ usr_print ( double *t,	            /* time value */
 
   /*  return(status); */
 
-  status = 2;
+  /*  status = 2; */
   return(retn);			/*  Phil's usual default behavior */
 
 } /* END of routine usr_print */

--- a/wr_dpi.c
+++ b/wr_dpi.c
@@ -906,7 +906,6 @@ define_dimension(const int unit,
 {
   int err;
   char err_msg[MAX_CHAR_ERR_MSG];
-  Spfrtn sr;
 
   /*
    * Dimensions with value zero are problematic, so filter them out.
@@ -921,14 +920,14 @@ define_dimension(const int unit,
   err  = nc_def_dim(unit, string, value, identifier);
   if ( err != NC_NOERR )
     {
-      sr = sprintf(err_msg, "nc_def_dim() on %s [<%d] id=%d", string, 
+      sprintf(err_msg, "nc_def_dim() on %s [<%d] id=%d", string, 
 		   value, *identifier);
       EH(-1, err_msg);
     }
 #endif
 #ifndef NO_NETCDF_2
   err  = ncdimdef(unit, string, value);
-  sr   = sprintf(err_msg, "ncdimdef() on %s [<%d] rtn %d", string, 
+  sprintf(err_msg, "ncdimdef() on %s [<%d] rtn %d", string, 
 		 value, err);
   EH(err, err_msg);
   *identifier = err;
@@ -965,7 +964,6 @@ define_variable(const int netcdf_unit,
   int err;
   int i;
   char err_msg[MAX_CHAR_ERR_MSG];
-  Spfrtn sr;
 
 #ifdef NO_NETCDF_2
   int dim[NC_MAX_VAR_DIMS];
@@ -986,7 +984,7 @@ define_variable(const int netcdf_unit,
 	{
 	  return;		/* Do not even create a variable. */
 	  /*
-	  sr = sprintf(err_msg, "Bad 1st netCDF dimension ID %d for %s\n",
+	  sprintf(err_msg, "Bad 1st netCDF dimension ID %d for %s\n",
 		       dimension_id_1, name_string);
 	  EH(-1, err_msg);
 	  */
@@ -1001,7 +999,7 @@ define_variable(const int netcdf_unit,
     {
       if ( dimension_id_2 < 0 )
 	{
-	  sr = sprintf(err_msg, "Bad 2nd netCDF dimension ID %d for %s\n",
+	  sprintf(err_msg, "Bad 2nd netCDF dimension ID %d for %s\n",
 		       dimension_id_1, name_string);
 	  EH(-1, err_msg);
 	}
@@ -1019,7 +1017,7 @@ define_variable(const int netcdf_unit,
 		      dim, identifier);
   if ( err != NC_NOERR )
     {
-      sr = sprintf(err_msg, "nc_def_var on %s (%d-D) id=%d", name_string, 
+      sprintf(err_msg, "nc_def_var on %s (%d-D) id=%d", name_string, 
 		   num_dimensions, *identifier);
       EH(-1, err_msg);
     }
@@ -1032,7 +1030,7 @@ define_variable(const int netcdf_unit,
 
   err    = ncvardef(netcdf_unit, name_string, netcdf_type, num_dimensions, 
 		    tim);
-  sr     = sprintf(err_msg, "ncvardef on %s (%d-D) id=%d", name_string, 
+  sprintf(err_msg, "ncvardef on %s (%d-D) id=%d", name_string, 
 		   num_dimensions, err);
   EH(err, err_msg);
   *identifier   = err;
@@ -1057,7 +1055,6 @@ put_variable(const int netcdf_unit,
   long start[NC_MAX_VAR_DIMS];
 #endif
   char err_msg[MAX_CHAR_ERR_MSG];
-  Spfrtn sr;
 
   /*
    * If a variable was really defined properly and doesn't have a valid
@@ -1076,7 +1073,7 @@ put_variable(const int netcdf_unit,
       err = nc_put_var_int(netcdf_unit, variable_identifier, variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_put_var_int() varid=%d", 
+	  sprintf(err_msg, "nc_put_var_int() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1087,7 +1084,7 @@ put_variable(const int netcdf_unit,
 			    variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_put_var_text() varid=%d", 
+	  sprintf(err_msg, "nc_put_var_text() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1098,7 +1095,7 @@ put_variable(const int netcdf_unit,
 			      variable_address);
       if ( err != NC_NOERR )
 	{
-	  sr = sprintf(err_msg, "nc_put_var_double() varid=%d", 
+	  sprintf(err_msg, "nc_put_var_double() varid=%d", 
 		       variable_identifier);
 	  EH(-1, err_msg);
 	}
@@ -1114,7 +1111,7 @@ put_variable(const int netcdf_unit,
   
   if ( num_dimensions < 0 || num_dimensions > 2 )
     {
-      sr = sprintf(err_msg, "Bad or too large dimension value %d", 
+      sprintf(err_msg, "Bad or too large dimension value %d", 
 		   num_dimensions);
       EH(-1, err_msg);
     }
@@ -1135,7 +1132,7 @@ put_variable(const int netcdf_unit,
 	   */
 	  return;
 	  /*
-	  sr = sprintf(err_msg, 
+	  sprintf(err_msg, 
 	  "Data type %s (%d dimensional) has dimension values = %d %d",
 		       string_type(netcdf_type), num_dimensions, 
 		       dimension_val_1, dimension_val_2);
@@ -1157,7 +1154,7 @@ put_variable(const int netcdf_unit,
 	   */
 	  return;
 	  /*
-	  sr = sprintf(err_msg, 
+	  sprintf(err_msg, 
 	  "Data type %s (%d dimensional) has dimension values = %d %d",
 		       string_type(netcdf_type), num_dimensions, 
 		       dimension_val_1, dimension_val_2);

--- a/wr_exo.c
+++ b/wr_exo.c
@@ -1185,8 +1185,6 @@ add_qa_stamp(Exo_DB *exo)
   int k;
   int n;
 
-  Strcpy_rtn strcpy_rtn;
-
   /*  char *new[MAX_QA][4];*/
 
   QA_Record *Q;
@@ -1227,7 +1225,7 @@ add_qa_stamp(Exo_DB *exo)
     {
       for ( j=0; j<4; j++)
 	{
-	  strcpy_rtn = strcpy(Q[i][j], exo->qa_record[i][j]);
+	  strcpy(Q[i][j], exo->qa_record[i][j]);
 	}
     }
 
@@ -1247,8 +1245,8 @@ add_qa_stamp(Exo_DB *exo)
    * Concoct a new record.
    */
 
-  strcpy_rtn = strcpy(Q[n][0], "GOMA");
-  strcpy_rtn = strcpy(Q[n][1], VERSION); /* def'd in std.h for now */
+  strcpy(Q[n][0], "GOMA");
+  strcpy(Q[n][1], VERSION); /* def'd in std.h for now */
   get_date(Q[n][2]);
   get_time(Q[n][3]);
 
@@ -1289,11 +1287,9 @@ add_qa_stamp(Exo_DB *exo)
 void
 add_info_stamp(Exo_DB *exo)
 {
-  int err;
   int i;
   int k;
   int n;
-  char *tmp;
   char **a;
   char buf[MAX_LINE_LENGTH+1];
   time_t now, then;
@@ -1301,7 +1297,6 @@ add_info_stamp(Exo_DB *exo)
   struct passwd *pwe;
 #endif
   struct utsname utsname;
-  Strcpy_rtn strcpy_rtn;
   INFO_Record *I;
 
   n = exo->num_info;
@@ -1335,7 +1330,7 @@ add_info_stamp(Exo_DB *exo)
 
   for ( i=0; i<n; i++)
     {
-      strcpy_rtn = strcpy(I[i], exo->info[i]);
+      strcpy(I[i], exo->info[i]);
     }
 
   /*
@@ -1354,7 +1349,7 @@ add_info_stamp(Exo_DB *exo)
    * Fill in the new records with information about this run.
    */
 
-  strcpy_rtn = strcpy(I[n], "____");
+  strcpy(I[n], "____");
 
   /*
    * -9 -- the command line issued for this simulation
@@ -1390,15 +1385,15 @@ add_info_stamp(Exo_DB *exo)
 	}
     }
 
-  strcpy_rtn = strcpy(I[n+1], buf);
+  strcpy(I[n+1], buf);
 
   /*
    * -8 -- the date and time of the simulation
    */
 
   now = time(&then);
-  err = strftime(buf, MAX_LINE_LENGTH, "%C", localtime(&now));
-  strcpy_rtn = strcpy(I[n+2], buf);
+  strftime(buf, MAX_LINE_LENGTH, "%C", localtime(&now));
+  strcpy(I[n+2], buf);
 
   /*
    * -7 -- current working directory
@@ -1406,14 +1401,14 @@ add_info_stamp(Exo_DB *exo)
 
   if ( ProcID < 8 )		/* too much I/O overhead for many procs */
     {
-      tmp = getcwd(buf, MAX_LINE_LENGTH+1);
+      getcwd(buf, MAX_LINE_LENGTH+1);
     }
   else
     {
-      strcpy_rtn = strcpy(buf, ".");
+      strcpy(buf, ".");
     }
 
-  strcpy_rtn = strcpy(I[n+3], buf);
+  strcpy(I[n+3], buf);
 
   /*
    * -6 -- the name of the user
@@ -1423,24 +1418,24 @@ add_info_stamp(Exo_DB *exo)
 
 #ifdef NO_LEAKY_GETPWUID
   pwe = getpwuid(getuid());
-  strcpy_rtn = strcpy(buf, pwe->pw_name);
+  strcpy(buf, pwe->pw_name);
 #endif
 
-  strcpy_rtn = strcpy(I[n+4], buf);
+  strcpy(I[n+4], buf);
 
   /*
    * -5 through -1 -- the POSIX system information
    */
 
-  err = uname(&utsname);
+  uname(&utsname);
   
   /* Lets be on the safe side put one char less than MAX_LINE_LENGTH into the info buffers */
 
-  strcpy_rtn = strncpy(I[n+5], utsname.sysname, MAX_LINE_LENGTH-1);
-  strcpy_rtn = strncpy(I[n+6], utsname.nodename, MAX_LINE_LENGTH-1);
-  strcpy_rtn = strncpy(I[n+7], utsname.release, MAX_LINE_LENGTH-1);
-  strcpy_rtn = strncpy(I[n+8], utsname.version, MAX_LINE_LENGTH-1);
-  strcpy_rtn = strncpy(I[n+9], utsname.machine, MAX_LINE_LENGTH-1);
+  strncpy(I[n+5], utsname.sysname, MAX_LINE_LENGTH-1);
+  strncpy(I[n+6], utsname.nodename, MAX_LINE_LENGTH-1);
+  strncpy(I[n+7], utsname.release, MAX_LINE_LENGTH-1);
+  strncpy(I[n+8], utsname.version, MAX_LINE_LENGTH-1);
+  strncpy(I[n+9], utsname.machine, MAX_LINE_LENGTH-1);
 
   /*
    * Free the old beast and assign the new one.


### PR DESCRIPTION
Greatly reduces warnings especially on -O2 with MAX_CONC >= 4

Mostly removal of variables that were being set but not used (made sure to keep function calls that were changing arrays/globals and other values)

Also rearranged some code into preprocessor defines as they were only being used in those defines and were throwing errors because of it.

Initialized some variables because gcc was unsure if they were going to be initialized (-Wmaybe-unitialized)

Passes all GUTS in the same fashion as current goma master

Some error variables were removed as they weren't used but keeping a listing of error variables that need to be checked would probably be a good idea and I should be able to make one based off this commit
