### PR TITLE
Fix Parallel bug caused by uninitialized variable access in gn_glob[]

### DIFF
--- a/src/mm_as_alloc.c
+++ b/src/mm_as_alloc.c
@@ -314,11 +314,23 @@ int gn_alloc(void)
   sz = sizeof(struct Generalized_Newtonian *);
   gn_glob = (struct Generalized_Newtonian **) array_alloc(1, MAX_NUMBER_MATLS, sz);
 
+  if ( gn_glob == NULL)
+    {
+      status = -1;
+      EH( status, "Problem getting memory for Generalized_Newtonian");
+    }
+
   sz = sizeof(struct Generalized_Newtonian);
 
   for(mn = 0; mn < MAX_NUMBER_MATLS; mn++)
     {
       gn_glob[mn] = (struct Generalized_Newtonian *) array_alloc(1, 1, sz);
+
+      if (gn_glob[mn] == NULL) {
+        status = -1;
+        EH( status, "Problem getting memory for Generalized_Newtonian material");
+      }
+      memset(gn_glob[mn], 0, sz);
 
     }
   
@@ -326,12 +338,6 @@ int gn_alloc(void)
     {
       DPRINTF(stdout, "%s: Generalized_Newtonian @ %p has %d bytes", 
 	      yo, gn, sz);
-    }
-
-  if ( gn_glob == NULL)
-    {
-      status = -1;
-      EH( status, "Problem getting memory for Generalized_Newtonian");
     }
 
   return(status);


### PR DESCRIPTION
Because `gn_glob[]` elements were never initialized on runs with certain numbers of processors elements in `gn_glob[i]` would be garbage. (on my machine the error was caused by gn_glob[i]->len_u_aexp being > 0 when the structure was NULL)

This caused the communication between processors for the Noahs_Dove struct to have differing sizes between ProcID 0 and all other processors which when Bcast was causing memory addresses in Noahs_Dove to be assigned the wrong values.

It seems there is an `init_Generalized_Newtonian` function in `mm_as_alloc.c` but it is outdated and was not even used in `gn_alloc`, so this uses the memset method used in other parts of the code.

Running the test suite now.
