### PR TITLE
Fix valgrind uninitialized access in SL_UMF

### DIFF
--- a/src/sl_umf.c
+++ b/src/sl_umf.c
@@ -110,6 +110,14 @@ SL_UMF ( int system_id,
 
   int i, j, k, umf_option = 0;
   int hit_diag, err;
+
+  for (i = 0; i < UMFPACK_CONTROL; i++) {
+    Control[i] = 0;
+  }
+
+  for (i = 0; i < UMFPACK_INFO; i++) {
+    Info[i] = 0;
+  }
           
 #ifdef DEBUG_SL_UMF
   fprintf(stderr, "SL_UMF: system_id = %d, *first = %d, *fact_optn = %d\n",


### PR DESCRIPTION
This does not pass the test suite in the same manner, it drastically changes LSA_cayley and overset_ball

However all this is doing is initializing arrays to prevent uninitialized access in the umfpack solver.
