### PR TITLE
Fix aggressive loop optimization warning

### DIFF
--- a/src/mm_input.c
+++ b/src/mm_input.c
@@ -10884,12 +10884,14 @@ set_mp_to_unity(const int mn)
       mp_glob[mn]->porous_latent_heat_fusion[w] = 1.;
       mp_glob[mn]->PorousVaporPressureModel[w] = CONSTANT;
       mp_glob[mn]->porous_vapor_pressure[w] = 1.;
-      for ( v=0; v<MAX_PMV + MAX_CONC + MAX_VARIABLE_TYPES; v++)
-	{
-	  mp_glob[mn]->d_porous_diffusivity[w][v] = 0.;
-	  mp_glob[mn]->d_porous_vapor_pressure[w][v] = 0.;
-	}
     }
+
+  for ( w=0; w < MAX_PMV; w++) {
+    for ( v = 0; v < MAX_CONC + MAX_VARIABLE_TYPES; v++) {
+      mp_glob[mn]->d_porous_diffusivity[w][v] = 0.;
+      mp_glob[mn]->d_porous_vapor_pressure[w][v] = 0.;
+    }
+  }
 
   mp_glob[mn]->Spwt_func = 0.;
   mp_glob[mn]->Spwt_funcModel=GALERKIN;


### PR DESCRIPTION
Looking at #17 again this should be setting all values to 0 so this was just a malformed loop. Function is only ever used in mm_input when setting the initial mp values.

Fixes #17
