### PR TITLE
Better handle on negative lubrication height and zero element volume

### DIFF
--- a/include/std.h
+++ b/include/std.h
@@ -498,6 +498,19 @@ extern int parallel_err_global;
 extern int neg_elem_volume;
 extern int neg_elem_volume_global;
 
+
+/*
+ * This particular error is triggered by moving mesh problems in shell that get
+ * too enthusiastic and require spending the night in the drunk tank -
+ * let the whole town know.
+ */
+
+extern int neg_lub_height;
+extern int neg_lub_height_global;
+extern int zero_detJ;
+extern int zero_detJ_global;
+
+
 /***************************************************************************/
 /*                       std.h end                                         */
 /***************************************************************************/

--- a/src/mm_fill.c
+++ b/src/mm_fill.c
@@ -172,9 +172,12 @@ int matrix_fill_full(struct Aztec_Linear_Solver_System *ams,
    *    Then allocate memory here for common data elements
    */
   neg_elem_volume = FALSE;
+  neg_lub_height = FALSE;
+  zero_detJ = FALSE;
+
   e_start = exo->eb_ptr[0];
   e_end   = exo->eb_ptr[exo->num_elem_blocks];
-  for (ielem = e_start, ebn = 0; ielem < e_end && !neg_elem_volume; ielem++) {
+  for (ielem = e_start, ebn = 0; ielem < e_end && !neg_elem_volume && !neg_lub_height && !zero_detJ; ielem++) {
 
     /*First we must calculate the material-referenced element
      *number so as to be compatible with the ElemStorage struct
@@ -197,6 +200,17 @@ int matrix_fill_full(struct Aztec_Linear_Solver_System *ams,
       log_msg("Negative elem det J in element (%d)", ielem+1);
       if ( ls != NULL && ls->SubElemIntegration ) subelement_mesh_output(x, exo);
     }
+
+    if (neg_lub_height)
+      {
+       log_msg("Negative lubrication height in element (%d)", ielem+1);
+      }
+
+    if (zero_detJ)
+      {
+       log_msg("Zero determinant of Jacobian of transformation (%d)", ielem+1);
+      }
+
   }
 
   /*
@@ -205,13 +219,22 @@ int matrix_fill_full(struct Aztec_Linear_Solver_System *ams,
   global_qp_storage_destroy();
   
   /*
-   * Now coordinate the processors so that they all know about a negative
-   * volume in an element
+   * Now coordinate the processors so that they all know about a negative or zero
+   * volume in an element and negative lubrication height
    */
 #ifdef PARALLEL
   MPI_Allreduce(&neg_elem_volume, &neg_elem_volume_global, 1,
 		MPI_INT, MPI_MAX, MPI_COMM_WORLD);
   neg_elem_volume = neg_elem_volume_global;
+
+  MPI_Allreduce(&neg_lub_height, &neg_lub_height_global, 1,
+                MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  neg_lub_height = neg_lub_height_global;
+
+  MPI_Allreduce(&zero_detJ, &zero_detJ_global, 1,
+                MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  zero_detJ = zero_detJ_global;
+
 #endif
 
   /*
@@ -231,6 +254,9 @@ int matrix_fill_full(struct Aztec_Linear_Solver_System *ams,
 #endif
   
   if (neg_elem_volume) return -1;
+  if (neg_lub_height) return -1;
+  if (zero_detJ) return -1;
+
   return 0;
 }
 /*****************************************************************************/
@@ -992,6 +1018,7 @@ matrix_fill(
 	  err = beer_belly();
 	  EH( err, "beer_belly");
 	  if( neg_elem_volume ) return;
+          if( zero_detJ ) return;
       
 	  /*
 	   * Load up field variable values at this Gauss point, but not
@@ -1293,6 +1320,7 @@ matrix_fill(
       err = beer_belly();
       EH(err, "beer_belly");
       if (neg_elem_volume) return;
+      if( zero_detJ ) return;
       
       /*
        * Load up field variable values at this Gauss point, but not
@@ -1662,6 +1690,7 @@ matrix_fill(
 #ifdef CHECK_FINITE
           CHECKFINITE("assemble_lubrication");
 #endif
+          if (neg_lub_height) return;
         }
 
       if( pde[R_LUBP_2] )
@@ -1671,6 +1700,7 @@ matrix_fill(
 #ifdef CHECK_FINITE
           CHECKFINITE("assemble_lubrication");
 #endif
+          if (neg_lub_height) return;
         }
 
       if( pde[R_MAX_STRAIN] )

--- a/src/mm_fill_shell.c
+++ b/src/mm_fill_shell.c
@@ -6644,6 +6644,22 @@ assemble_lubrication(const int EQN,     /* equation type: either R_LUBP or R_LUB
     break;
   }
 
+  /* Check for nehative lubrication height, if so, get out */
+  if(H <= 0.0)
+   {
+    neg_lub_height = TRUE;
+
+#ifdef PARALLEL
+    fprintf(stderr,"\nP_%d: Lubrication height =  %e\n",ProcID,H);
+#else
+    fprintf(stderr,"\n Lubrication height =  %e\n",H);
+#endif
+
+    status = 2;
+    return(status);
+   }
+
+
   /* Lubrication wall velocity from model */
   velocity_function_model(veloU, veloL, time, dt);
 

--- a/src/mm_fill_util.c
+++ b/src/mm_fill_util.c
@@ -355,7 +355,17 @@ beer_belly(void)
 	+ MapBf->J[0][2] * ( MapBf->J[1][0] * MapBf->J[2][1]
 			     -MapBf->J[2][0] * MapBf->J[1][1]);
 
-      if(fabs(MapBf->detJ) < 1.e-10) EH(-1, "Uh-oh.  You shells are not robust.  Talk to PRS");
+      if(fabs(MapBf->detJ) < 1.e-10)
+       	{
+         zero_detJ = TRUE;
+#ifdef PARALLEL
+         fprintf(stderr,"\nP_%d: Uh-oh, detJ =  %e\n",ProcID, fabs(MapBf->detJ));
+#else
+         fprintf(stderr,"\n Uh-oh, detJ =  %e\n",fabs(MapBf->detJ));
+#endif
+         return(2);
+        }
+
     }
   
   

--- a/src/mm_sol_nonlinear.c
+++ b/src/mm_sol_nonlinear.c
@@ -154,6 +154,12 @@ PROTO((double ,			/* lambda - parameter                        */
 int neg_elem_volume        = FALSE;
 int neg_elem_volume_global = FALSE;
 
+int neg_lub_height        = FALSE;
+int neg_lub_height_global = FALSE;
+
+int zero_detJ        = FALSE;
+int zero_detJ_global = FALSE;
+
 /*
    
    GOMA NON-LINEAR EQUATION SOLVER

--- a/src/mm_std_models_shell.c
+++ b/src/mm_std_models_shell.c
@@ -540,10 +540,6 @@ height_function_model (double *H_U,
    }
 
  H = *H_U - *H_L;
- if(H <= 0.0) 
-   {
-     EH(-1, "Negative Lubrication Gap");
-   }
 
  return(H);
 


### PR DESCRIPTION
This pull request is to better handling lubrication height and zero detJ. Before, this was done with EH and it halts the calculation. Now, they are handled in similar manner as negative detJ in mesh equation: Under-relax Newton's method in steady state problem or decrease time step in transient problem
