### PR TITLE
Fix parallel issue with p_C_T_U problem

### DIFF
--- a/src/mm_sol_nonlinear.c
+++ b/src/mm_sol_nonlinear.c
@@ -823,6 +823,10 @@ int solve_nonlinear_problem(struct Aztec_Linear_Solver_System *ams,
 	    }
 	  }
 
+          /* Exchange dof before matrix fill so parallel information
+             is properly communicated */
+          exchange_dof(cx,dpi, x);
+
 	  if (Linear_Solver == FRONT)
 	    {
 	      zero	  = 0;


### PR DESCRIPTION
This solves the change in residuals and number of newton iterations on the p_C_T_U problem.

It appears that the default Dirichlet boundary condition behavior (BC_relax == -1.0) in bc_dirich.c does not have enough information when run in parallel.

The problem seemed to stem from the fact that when brk splits the exodus files the nodesets are removed from the ghost (or external) nodes as this problem didn''t seem to occur when BC's are applied on nodesets that are not along the break.

Maybe this will also affect #39
