### PR TITLE
Remove redefined typedef's from brkfix header

### DIFF
--- a/include/brkfix/brkfix.h
+++ b/include/brkfix/brkfix.h
@@ -15,8 +15,8 @@
  * Created: 1997/04/12 10:19 MDT pasacki@sandia.gov
  */
 
-#ifndef _STD_H
-#define _STD_H
+#ifndef _BRKFIX_STD_H
+#define _BRKFIX_STD_H
 
 #ifndef FILENAME_MAX_ACK
 #define FILENAME_MAX_ACK		1024
@@ -126,31 +126,11 @@
  * #endif
  */
 
-#ifdef SPRINTF_RETURNS_INT
-typedef int	Spfrtn;
-#endif
-
-#ifndef SPRINTF_RETURNS_INT	/* Probably a ptr to char, then, eh? */
-typedef char   *Spfrtn;
-#endif
-
 /*
  * strcpy() returns different types on different machines...
  */
 
 #define STRCPY_RTN_IS_STRING
-
-#ifdef STRCPY_RTN_IS_STRING
-typedef char *Strcpy_rtn;
-#endif
-#ifdef STRCPY_RTN_IS_INT
-typedef int  Strcpy_rtn;
-#endif
-
-#ifndef _DBL_TYPEDEF
-#define _DBL_TYPEDEF
-typedef double dbl;
-#endif
 
 #ifndef _FLT_TYPEDEF
 #define _FLT_TYPEDEF

--- a/src/brkfix/bbb.c
+++ b/src/brkfix/bbb.c
@@ -44,6 +44,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "goma.h"
 #include "brkfix/brkfix.h"		/* useful general stuff */
 #include "mm_eh.h"			/* error handling */
 #include "rf_allo.h"		/* multi-dim array allocation */

--- a/src/brkfix/ppi.c
+++ b/src/brkfix/ppi.c
@@ -30,7 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
+#include "goma.h"
 #include "brkfix/brkfix.h"
 #include "mm_eh.h"
 #include "brkfix/ppi.h"

--- a/src/brkfix/wr_coords.c
+++ b/src/brkfix/wr_coords.c
@@ -27,6 +27,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "goma.h"
+
 #include "brkfix/brkfix.h"
 #include "mm_eh.h"
 #include "exo_struct.h"

--- a/src/brkfix/wr_graph_file.c
+++ b/src/brkfix/wr_graph_file.c
@@ -32,6 +32,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "goma.h"
+
 #include "brkfix/brkfix.h"
 #include "mm_eh.h"
 #include "brkfix/wr_graph_file.h"


### PR DESCRIPTION
Passes test suite.

Causes error on gcc compilers below 4.6
