### PR TITLE
Fix VELO_SLIP BC in parallel when using a reference node to measure distance

### DIFF
--- a/include/mm_bc.h
+++ b/include/mm_bc.h
@@ -109,4 +109,6 @@ extern int find_bc_unk_offset(struct Boundary_Condition *, int,
 
 extern int search_bc_dup_list(const int, int *);
 extern void set_up_BC_connectivity(void);
+
+int exchange_bc_info(void);
 #endif /* _MM_BC_H */

--- a/include/mm_ns_bc.h
+++ b/include/mm_ns_bc.h
@@ -190,22 +190,20 @@ PROTO((double [],		/* func                                      */
 				 * method from BE(0) to CN(1/2) to FE(1)     */
        const dbl ));		/* dt - current value of the time step size  */
 
-EXTERN void fvelo_slip_bc	/* mm_ns_bc.c                                */
-PROTO((double [MAX_PDIM],	/* func                                      */
-       double [MAX_PDIM][MAX_VARIABLE_TYPES + MAX_CONC][MDE], /* d_func      */
-       double [],               /* solution vector x */
-       const int ,		/* type - whether rotational or not          */
-       double ,			/* beta - Navier slip coefficient input deck */
-       const double ,		/* vsx                                       */
-       const double ,		/* vsy                                       */
-       const double ,		/* vsz - velocity components of solid surface
-				 * in which slip condition is applied        */
-       const int ,		/* DCL node id          */
-       const double ,		/* slip extent */
-       const double [MAX_PDIM], /*gauss point coordinates   **/
-       const double ,           /* tt - parameter to vary time integration
-                                 * method from BE(0) to CN(1/2) to FE(1)     */
-       const double ));         /* dt - current value of the time step size  */
+void
+fvelo_slip_bc(double func[MAX_PDIM],
+	      double d_func[MAX_PDIM][MAX_VARIABLE_TYPES + MAX_CONC][MDE],
+	      double x[],
+	      const int type,    /* whether rotational or not */
+              double bc_float[MAX_BC_FLOAT_DATA],
+	      const int dcl_node,/*   node id for DCL  */
+	      const double xsurf[MAX_PDIM], /* coordinates of surface Gauss  *
+					     * point, i.e. current position  */
+	      const double tt,   /* parameter in time stepping alg           */
+	      const double dt);   /* current time step value                  */
+
+int
+exchange_fvelo_slip_bc_info(int ibc /* Index into BC_Types for VELO_SLIP_BC */);
 
 
 EXTERN void fvelo_slip_level

--- a/src/bc_integ.c
+++ b/src/bc_integ.c
@@ -681,12 +681,8 @@ apply_integrated_bc(
  	case VELO_SLIP_ROT_FILL_BC:
 	  fvelo_slip_bc(func, d_func, x, 
 			(int) bc->BC_Name,
-			bc->BC_Data_Float[0],
-			bc->BC_Data_Float[1], 
-			bc->BC_Data_Float[2], 
-			bc->BC_Data_Float[3],
+			bc->BC_Data_Float,
 			(int) bc->BC_Data_Int[0],
-			bc->BC_Data_Float[4],
 			xsurf, theta, delta_t);
 	  break;  
 

--- a/src/mm_bc.c
+++ b/src/mm_bc.c
@@ -1262,6 +1262,9 @@ set_up_Surf_BC(struct elem_side_bc_struct *First_Elem_Side_BC_Array[ ],
       if (poinbc != 0 && poinbc != -1) {    /*the -1 case is another new
 					      velo_tangent retaining case, 
 					      prs 8/98 */
+        /* Set to Flag for node not found */
+        inode = -2;
+
 	for (ins = 0; ins < exo->num_node_sets; ins++) {
 	  if (exo->ns_id[ins] == poinbc) {
 	    for (i = 0; i < exo->ns_num_nodes[ins]; i++) {
@@ -2866,6 +2869,44 @@ set_up_BC_connectivity(void)
       break;
     }
   }
+}
+
+/*************************************************************************/
+/*************************************************************************/
+/*************************************************************************/
+
+/**
+ * Exchange needed boundary condition information that is only
+ * present on one processor but needed on all or some of the other
+ * processors.
+ *
+ * Runs in serial as well so calculations that are shared can be moved
+ * to this exchange
+ *
+ * Called from setup_problem(), only called before solve
+ * Returns 0 if success
+ *
+ * Return -1 if error
+ */
+int exchange_bc_info(void)
+{
+  int ibc;
+  int error = 0;
+
+  /* loop over boundary conditions */
+  for (ibc = 0; ibc < Num_BC; ibc++) {
+    /* check if BC needs special exchange information */
+    switch (BC_Types[ibc].BC_Name) {
+    case VELO_SLIP_BC:
+      exchange_fvelo_slip_bc_info(ibc);
+      break;
+    default:
+      break;
+    }
+
+  } /* end loop over BC_Types */
+
+  return error;
 }
 /************************************************************************/
 /*			END of mm_bc.c			                */

--- a/src/mm_ns_bc.c
+++ b/src/mm_ns_bc.c
@@ -3077,13 +3077,8 @@ fvelo_slip_bc(double func[MAX_PDIM],
 	      double d_func[MAX_PDIM][MAX_VARIABLE_TYPES + MAX_CONC][MDE],
 	      double x[],
 	      const int type,    /* whether rotational or not */
-	      double beta,       /* Navier slip coefficient from input deck */
-	      const double vsx,
-	      const double vsy,
-	      const double vsz,	 /* velocity components of solid surface on 
-				  * which slip condition is applied          */
+              double bc_float[MAX_BC_FLOAT_DATA],
 	      const int dcl_node,/*   node id for DCL  */
-	      double alpha,      /* extent of slip  */
 	      const double xsurf[MAX_PDIM], /* coordinates of surface Gauss  *
 					     * point, i.e. current position  */
 	      const double tt,   /* parameter in time stepping alg           */
@@ -3105,6 +3100,13 @@ fvelo_slip_bc(double func[MAX_PDIM],
       *            Revised: 6/1/95 RAC
       ************************************************************************/
 {
+  double beta = bc_float[0];   /* Navier slip coefficient from input deck */
+  /* velocity components of solid surface on
+   * which slip condition is applied */
+  double vsx = bc_float[1];
+  double vsy = bc_float[2];
+  double vsz = bc_float[3];
+  double alpha = bc_float[4];
   int a, j, var, jvar, p, dim;
   double phi_j, vs[MAX_PDIM];
   double slip_dir[MAX_PDIM], vslip[MAX_PDIM], vrel[MAX_PDIM], vrel_dotn;
@@ -3112,8 +3114,6 @@ fvelo_slip_bc(double func[MAX_PDIM],
   
   int icount;
   double dist;                  /* distance btw current position and dynamic CL */
-  double xdcl[MAX_PDIM];        /* coordinates of dynamic contact lines         */
-  double disp;                  /* DCL point displacement */
   double betainv;		/* inverse of slip coefficient */
   /* double dot_prod; */
   double d_betainv_dvslip_mag, d_betainv_dP;
@@ -3286,15 +3286,13 @@ fvelo_slip_bc(double func[MAX_PDIM],
    *                     COMPUTE SLIP PARAMETER
    *
    * This section is for position dependent slip. Calculate position
-   * of dynamic contact line from dcl_node do the distance calculation
+   * of dynamic contact line from reference node do the distance calculation
    * based on undeformed geometry... This saves us Jacobian entries in
    * uncharted sections of the A matrix
    *
-   *      xdcl[icount] = (Coor[icount][dcl_node]);
-   *
    * Calculate distance from dcl to current Gauss point.  Turn this
    * off if we don't have position depend slip.  alpha will be zero,
-   * so dist and xdcl can be anything as long as they are
+   * so dist can be anything as long as it is
    * defined. Protect exponentially decaying slip from underflow far
    * away from the singularity.
    *
@@ -3311,18 +3309,14 @@ fvelo_slip_bc(double func[MAX_PDIM],
         }
       else
         {
-          /* find displacement of reference node */
-          for (icount = 0; icount < pd->Num_Dim; icount ++) {
-	    disp	 = x[Index_Solution(dcl_node, MESH_DISPLACEMENT1+icount, 0, 0, -1)];
-	    xdcl[icount] = (Coor[icount][dcl_node] + disp);
-	  }
-            
+          /* Coord position in bc_float, from BC_Data_Float */
+          int float_offset = 5;
           dist = 0.;
           for(icount=0; icount < pd->Num_Dim; icount ++)
             {
-              /**UNDEFORMED*dist += (xsurf[icount]-Coor[icount][dcl_node])*(xsurf[icount]-Coor[icount][dcl_node]); */
-              /**DEFORMED*dist += (fv->x[icount]-xdcl[icount])*(fv->x[icount]-xdcl[icount]); */
-              dist += (xsurf[icount]-Coor[icount][dcl_node])*(xsurf[icount]-Coor[icount][dcl_node]);
+              /* Uses undeformed node position */
+              dist += (xsurf[icount]-bc_float[icount + float_offset]) *
+                (xsurf[icount]-bc_float[icount + float_offset]);
             }
           dist = sqrt(dist);
         }
@@ -3330,7 +3324,6 @@ fvelo_slip_bc(double func[MAX_PDIM],
   else 
     {
       dist    = 1.0;
-      xdcl[0] = xdcl[1] = xdcl[2] = 0.0;
     }
   
   /* for exponentially decaying slip, max out betainv when equivalent to 
@@ -3574,6 +3567,72 @@ fvelo_slip_bc(double func[MAX_PDIM],
   return;
 
 } /* END of routine fvelo_slip_bc  */
+
+/**
+ * Exchanges coordinates for the reference node needed for calculation
+ * in fvelo_slip_bc()
+ *
+ * Returns 0 if success
+ * Returns -1 if error
+ */
+int
+exchange_fvelo_slip_bc_info(int ibc /* Index into BC_Types for VELO_SLIP_BC */)
+{
+  int i;
+#ifdef PARALLEL
+  int mpi_error;
+#endif
+  /* if velo slip has */
+  int velo_slip_root = 0;
+  /* Offset for where to place coordinates in BC_Data_Float */
+  int float_offset = 5;
+  double node_coord[pd->Num_Dim]; /* temporary buffer for node coordinates */
+
+  /* Skip this if calculation is not needed */
+  if (BC_Types[ibc].BC_Data_Int[0] == -1 || BC_Types[ibc].BC_Data_Int[0] == 0) {
+    return 0;
+  }
+
+  /* find which processor has the right data */
+  if (BC_Types[ibc].BC_Data_Int[0] != -2) {
+    velo_slip_root = ProcID;
+  }
+
+#ifdef PARALLEL
+  mpi_error = MPI_Allreduce(MPI_IN_PLACE, &velo_slip_root, 1,
+                            MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+  if (mpi_error != MPI_SUCCESS) {
+    EH(-1, "Error in MPI Allreduce");
+    return -1;
+  }
+#endif /* #ifdef PARALLEL */
+
+  if (ProcID == velo_slip_root) {
+    int node = BC_Types[ibc].BC_Data_Int[0];
+    /* find coordinate position of reference node */
+    for (i = 0; i < pd->Num_Dim; i++) {
+      node_coord[i] = Coor[i][node];
+    }
+  }
+
+#ifdef PARALLEL
+  /* Communicate the new values in BC_Data_Float */
+  mpi_error = MPI_Bcast(&node_coord, pd->Num_Dim, MPI_DOUBLE,
+                        velo_slip_root, MPI_COMM_WORLD);
+
+  if (mpi_error != MPI_SUCCESS) {
+    EH(-1, "Error in MPI Allreduce");
+    return -1;
+  }
+#endif
+
+  /* set BC_Data_Float values */
+  for (i = 0; i < pd->Num_Dim; i++) {
+    BC_Types[ibc].BC_Data_Float[float_offset + i] = node_coord[i];
+  }
+  return 0;
+}
+
 /****************************************************************************/
 /****************************************************************************/
 /****************************************************************************/
@@ -11388,12 +11447,8 @@ q_velo_slip_bc(double func[MAX_PDIM],
   /* use fvelo_slip to evaluate slip and derivatives */
   fvelo_slip_bc(slip_stress, d_slip_stress, x, 
                 (int) BC_Types[ibc].BC_Name,
-                BC_Types[ibc].BC_Data_Float[0],
-                BC_Types[ibc].BC_Data_Float[1], 
-                BC_Types[ibc].BC_Data_Float[2], 
-                BC_Types[ibc].BC_Data_Float[3],
+                BC_Types[ibc].BC_Data_Float,
                 (int) BC_Types[ibc].BC_Data_Int[0],
-                BC_Types[ibc].BC_Data_Float[4],
                 xsurf, tt, dt);
                 
   if (af->Assemble_Jacobian) 

--- a/src/rf_setup_problem.c
+++ b/src/rf_setup_problem.c
@@ -285,6 +285,9 @@ int setup_problem(Exo_DB *exo,	/* ptr to the finite element mesh database */
    */
   init_shell_element_blocks(exo);
 
+  /* Communicate non-shared but needed BC information */
+  exchange_bc_info();
+
   return 0;
 }
 /************************************************************************/


### PR DESCRIPTION
Adds new functions to communicate boundary condition data that is needed in parallel.

The new function executes in serial as well so the needed node coordinates could be specified in BC_Data_Float and not have a conditional inside of fvelo_slip_bc checking if it was a parallel run.

The function only runs once in problem_setup as fvelo_slip_bc was not actually using the mesh displacement but was calculating based off of undeformed node position

exchange_bc_info could be re-purposed to run more often if BC's are found that need to exchange information based on data that was previously solved for (like if velo_slip was changed to use deformed mesh node coordinates).

Allows beaker problem to work properly in parallel as beaker used the reference node (N_cl) input for VELO_SLIP

Passes Test suite.

Fixes #52
