### PR TITLE
Update Fix Frequency to match print frequency output

### DIFF
--- a/src/rf_solve.c
+++ b/src/rf_solve.c
@@ -296,7 +296,10 @@ solve_problem(Exo_DB *exo,	 /* ptr to the finite element mesh database  */
   fprintf(stderr, "P_%d solve_problem() begins...\n",ProcID);
 #endif /* DEBUG */
 
-  step_fix = tran->fix_freq;
+  /* Set step_fix only if parallel run and only if fix freq is enabled*/
+  if (Num_Proc > 1 && tran->fix_freq > 0) {
+    step_fix = 1; /* Always fix on the first timestep to match print frequency */
+  }
 
   tran->time_value = time1;
 


### PR DESCRIPTION
Always fix on first timestep if fix frequency is defined

Fixes #54

Passes Test Suite.

Looking more at how printing is behaving, it looks like the print frequency might be the only thing that writes to the exodus file, if so should the Fix Frequency be relative to the printing frequency?

 e.g. if you have a print frequency of 5 and a Fix Frequency of 2, every 5 timesteps it would print and every 10 timesteps it would fix

Right now it would fix every 2 timesteps and then print every 5 so you would have unnecessary fixes if nothing else writes to the exodus file.

Or am I missing something else that prints to the Exodus file.
