### PR TITLE
Fix subtree allocation that was causing invalid (out of bounds) reads and writes

### DIFF
--- a/src/mm_fill_ls.c
+++ b/src/mm_fill_ls.c
@@ -8111,7 +8111,7 @@ divide_shape_fcn_tree ( NTREE *parent,
 	  parent->subtrees[index]->subtrees = NULL;
 
 	  parent->subtrees[index]->xi  = ( double (*)[DIM] ) smalloc( num_verts*sizeof(double)*DIM) ;
-	  parent->subtrees[index]->phi = ( double (*)[MDE] ) smalloc( parent->num_fcns*sizeof(double)*MDE) ;
+	  parent->subtrees[index]->phi = ( double (*)[MDE] ) smalloc( num_verts*sizeof(double)*MDE) ;
 
 
 


### PR DESCRIPTION
phi is now allocated the same size as the parent tree node phi. This was causing out of bounds read and writes because num_fcns was less than num_verts but it was indexing as if it were num_verts size.

Passes test suite.

Fixes #57 
