### PR TITLE
PSPG fixes

### DIFF
--- a/src/mm_fill.c
+++ b/src/mm_fill.c
@@ -737,7 +737,7 @@ matrix_fill(
 	}
     }
 
-  if ((PSPG || Cont_GLS) && pde[R_PRESSURE] && pde[R_MOMENTUM1]) {
+  if (PSPG && pde[R_PRESSURE] && pde[R_MOMENTUM1]) {
     xi[0] = 0.0;
     xi[1] = 0.0;
     xi[2] = 0.0;  
@@ -751,6 +751,23 @@ matrix_fill(
 	element_velocity(pg_data.v_avg, pg_data.dv_dnode, exo);
       }
   }
+
+  if(Cont_GLS && pde[R_PRESSURE] && pde[R_MOMENTUM1]) 
+    {
+    xi[0] = 0.0;
+    xi[1] = 0.0;
+    xi[2] = 0.0;  
+    (void) load_basis_functions(xi, bfd);
+    pg_data.mu_avg = element_viscosity();
+    pg_data.rho_avg = density(NULL, time_value);
+
+    if(Cont_GLS==2)
+      {
+	h_elem_siz(pg_data.hsquared, pg_data.hhv, pg_data.dhv_dxnode, pde[R_MESH1]);
+	element_velocity(pg_data.v_avg, pg_data.dv_dnode, exo);
+      }
+    }
+
   if(pde[FILL] || pde[PHASE1])      /* UMR fix for non-FILL problems */
     {
       if(ls != NULL)


### PR DESCRIPTION
Hi all,

These changes fix a couple of issues with the PSPG implementation.

Issue 1: The previous implementation divided through by density, and it was possible to do a divide by zero when density is zero.  We should allow for PSPG to be used with a zero Reynolds number, so I reworked the PSPG parameter to not perform this division.

Issue 2: The PSPG stability parameter somehow got double defined when it is local.  The Jacobian checker showed inconsistencies as well, so I went through and resolved this.

I also made some changes to the Continuity GLS stuff, but those were mostly stylistic things.

I ran some Jacobian checker tests and the test suite on it, and everything looks good.  I would still like for a second set of eyes to have a look and let me know if anything looks funny.

Daniel