### PR TITLE
Use trilinos export makefile rather than manually specifying libraries

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -176,25 +176,13 @@ SEACAS_LIB ?= -L$(SEACAS_TOP)/lib  $(EXODUSII_LIB)  $(NETCDF_LIB) \
 # Trilinos install directory (include, lib)
 TRILINOS_TOP ?= $(GOMA_LIBS)/trilinos-11.8.1-Built
 
-# KOMPLEX library (not included by default)
-KOMPLEX_LIB ?=
 
-# AZTEC library
-# Aztecoo is required.
-AZTEC_LIB ?=  -laztecoo -lifpack 
-
-# AMESOS library
-
-AMESOS_LIB ?= -lamesos -lepetraext -lepetra 
-
-# TEUCHOS library
-
-TEUCHOS_LIB ?= -lteuchoscomm -lteuchoscore -lteuchosnumerics -lteuchosparameterlist -lteuchosremainder
+include $(TRILINOS_TOP)/include/Makefile.export.Trilinos
 
 # Trilinos includes and libraries
-TRILINOS_INC ?= -isystem $(TRILINOS_TOP)/include
-TRILINOS_LIB ?= -L$(TRILINOS_TOP)/lib  $(AZTEC_LIB) \
-                 $(KOMPLEX_LIB)  $(AMESOS_LIB) $(TEUCHOS_LIB)
+TRILINOS_INC ?= $(subst -I, -isystem, $(Trilinos_INCLUDE_DIRS) $(Trilinos_TPL_INCLUDE_DIRS))
+TRILINOS_LIB ?= $(Trilinos_LIBRARY_DIRS) $(Trilinos_TPL_LIBRARY_DIRS) \
+		$(Trilinos_LIBRARIES) $(Trilinos_TPL_LIBRARIES)
 
 # ARPACK
 # ------
@@ -315,7 +303,8 @@ FFLAGS = $(CCFLAGS) $(F_WARN_FLAGS) $(DEFINES) $(INCLUDES)
 CFLAGS = $(CCFLAGS) $(C_WARN_FLAGS) $(DEFINES) $(INCLUDES)
 
 # C++ compiler flags
-CXXFLAGS = $(CCFLAGS) $(C_WARN_FLAGS) $(DEFINES) $(INCLUDES) -Wno-deprecated
+CXXSTD ?= 
+CXXFLAGS = $(CCFLAGS) $(C_WARN_FLAGS) $(DEFINES) $(INCLUDES) -Wno-deprecated $(CXXSTD)
 
 # linker flags
 LD_FLAGS = $(CCFLAGS)


### PR DESCRIPTION
Allows Trilinos 10-12 to be used without setting libraries manually and instead uses the Makefile export that cmake creates

CXXSTD can be set in settings.mk to use trilinos 12 which requires c++11:

    CXXSTD = -std=c++11