### PR TITLE
Increase buffer sizes to fix buffer overflow in test suite

### DIFF
--- a/include/mm_as_structs.h
+++ b/include/mm_as_structs.h
@@ -54,9 +54,9 @@
 				/* component is set =0.*/
 
 #ifndef _CK_NAME_DEF
-typedef char CK_NAME[16];       /* Typedefs for common names used for naming
+typedef char CK_NAME[64];       /* Typedefs for common names used for naming
 				   domains and species */
-typedef char CK_NAME_STR[17];
+typedef char CK_NAME_STR[64];
 #define     _CK_NAME_DEF
 #endif
 

--- a/include/mm_mp_structs.h
+++ b/include/mm_mp_structs.h
@@ -57,9 +57,9 @@
 
 #ifndef _CK_NAME_DEF
 #define _CK_NAME_DEF
-typedef char CK_NAME[16];       /* Typedefs for common names used for naming
+typedef char CK_NAME[64];       /* Typedefs for common names used for naming
                                    domains and species */
-typedef char CK_NAME_STR[17];
+typedef char CK_NAME_STR[64];
 #endif
 
 

--- a/src/rf_solve.c
+++ b/src/rf_solve.c
@@ -429,7 +429,7 @@ solve_problem(Exo_DB *exo,	 /* ptr to the finite element mesh database  */
 
   if ( nAC > 0   )
   {
-    char name[7];
+    char name[10];
 
     for( i = 0 ; i < nAC ; i++ )
       {


### PR DESCRIPTION
Increases CK_NAME to accommodate material names up to 63 chars,

Increases an augmenting condition string size to allow nodal vars
of multi-digit augmenting conditions (instead of AUGC_0-9).

Test suite now passes on Ubuntu 14.04