### PR TITLE
Add scripts to build Trilinos 12 and add more info to scripts/README.md

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,4 +1,54 @@
-# Goma Dependincies build script
+# Goma dependencies build scripts
+
+These build scripts exist to alleviate the pain of building the
+libraries goma needs to run.
+
+There are 3 options to choose from:
+
+`build-goma-dependencies.sh`: This script is known to work with the
+most platforms and older compiler versions.
+
+`build-goma-dep-trilinos-12.sh`: This script builds with the newest
+trilinos and expects gcc 4.8 or gcc 4.9.
+
+`build-goma-dep-trilinos-12-noc++11.sh`: This script builds with the
+newest trilinos but disables support for c++11 to support older
+compilers.
+
+Dependencies for these scripts are:
+
+* gcc
+* g++
+* gfortran
+* zlib library
+* libX11 library             
+
+# Additional Requirements
+
+openmpi should be added to your path and library path:
+
+    export LD_LIBRARY_PATH="/[path to gomalibs]/openmpi-1.6.4/lib:$LD_LIBRARY_PATH"
+    export PATH="/[path to gomalibs]/openmpi-1.6.4/bin:$PATH"
+
+SEACAS tools from Trilinos (e.g. aprepro and blot) should be added to
+your path
+
+    export PATH="/[path to gomalibs]/trilinos-11.8.1-Build/bin:$PATH"  
+
+Or for Trilinos 12:
+
+    export PATH="/[path to gomalibs]/trilinos-12.0.1-Build/bin:$PATH"
+
+After that adjust your settings.mk to point to the proper gomalibs
+and Trilinos location (examples available in the main goma directory).
+
+If you built Trilinos 12 with c++11 (not the noc++11 script) you also
+need to declare the CXXSTD in your settings.mk:
+
+    CXXSTD=-std=c++11
+
+
+## Goma Dependencies build script usage
 
 Name
 
@@ -10,9 +60,11 @@ Synopsis
 
 Description
 
-	This script attemps to download, compile and organize all the dependencies of goma.
-	They are downloaded into [library install path]/tars and extracted into [library install path].
-	No attempt is made by the script to place any file outside of [library install path].
+	This script attemps to download, compile and organize all the
+	dependencies of goma.  They are downloaded into [library
+	install path]/tars and extracted into [library install path].
+	No attempt is made by the script to place any file outside of
+	[library install path].
 
 	The minumum requirements for this process to succeed are:
 	    
@@ -22,12 +74,15 @@ Description
 	    - zlib
 	    - libX11
 
-	A command such as 'yum install gcc-c++ gcc-gfortran zlib-static libX11-devel' would ensure these
-	packages are available on an enterprise linux distribution (e.g. CentOS, Redhat, Fedora, etc.).
+	A command such as 'yum install gcc-c++ gcc-gfortran
+	zlib-static libX11-devel' would ensure these packages are
+	available on an enterprise linux distribution (e.g. CentOS,
+	Redhat, Fedora, etc.).
 
 Options
 
         -jN  N : Number of make jobs to run.
-                 Several packages do not possess sufficient Make configurations
-                 to run in parallel, so these are made with one make job.
+                 Several packages do not possess sufficient Make
+                 configurations to run in parallel, so these are made
+                 with one make job.
 

--- a/scripts/build-goma-dep-trilinos-12-noc++11.sh
+++ b/scripts/build-goma-dep-trilinos-12-noc++11.sh
@@ -5,7 +5,6 @@
 # 2014, July: Created by Cory Miner based off of notes by Scott Roberts
 # 2014: Weston Ortiz modified to include blacs, scalapack and mumps support in trilinos
 # 2015, February: Andrew Cochrane modified to handle recent changes to SEACAS-latest and hdf5, also added some logic to help with troubleshooting
-# 2015, June: Andrew and Weston handled switch to SuiteSparse and the SEACAS that is shipped with Trilinos
 
 # This script tries to build all of the libraries needed for goma
 # in the specified directories.
@@ -68,6 +67,7 @@ FORTRAN_LIBS=-lgfortran
 
 OPENMPI_TOP=$GOMA_LIB/openmpi-1.6.4
 export PATH=$OPENMPI_TOP/bin:$PATH
+export LD_LIBRARY_PATH=$OPENMPI_TOP/lib:$LD_LIBRARY_PATH
 FORTRAN_COMPILER=$OPENMPI_TOP/bin/mpif90
 
 export MPI_BASE_DIR=$OPENMPI_TOP
@@ -88,7 +88,7 @@ ARCHIVE_NAMES=("arpack96.tar.gz" \
 "sparse.tar.gz" 
 "superlu_dist_2.3.tar.gz" \
 "y12m-1.0.tar.gz" \
-"trilinos-11.8.1-Source.tar.gz" \
+"trilinos-12.0.1-Source.tar.bz2" \
 "scalapack-2.0.2.tgz" \
 "MUMPS_4.10.0.tar.gz" \
 "SuiteSparse-4.4.4.tar.gz" \
@@ -106,7 +106,7 @@ ARCHIVE_MD5SUMS=("fffaa970198b285676f4156cebc8626e" \
 "1566d914d1035ac17b73fe9bc0eed02a" \
 "8cf8cb964bb25ff6981f994b7e794f29" \
 "eed01310baca61f22fb8a88a837d2ae3" \
-"3c9465b6d63d824e9dc0365ca73c3370" \
+"19efcadf25c80b834f7c910ccfcca290" \
 "2f75e600a2ba155ed9ce974a1c4b536f" \
 "959e9981b606cd574f713b8422ef0d9f" \
 "e0af74476935c9ff6d971df8bb6b82fc" \
@@ -124,7 +124,7 @@ ARCHIVE_URLS=("http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz" \
 "http://sourceforge.net/projects/sparse/files/sparse/sparse1.4b/sparse1.4b.tar.gz/download" \
 "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_2.3.tar.gz" \
 "http://sisyphus.ru/cgi-bin/srpm.pl/Branch5/y12m/getsource/0" \
-"http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.gz" \
+"http://trilinos.csbsju.edu/download/files/trilinos-12.0.1-Source.tar.bz2" \
 "http://www.netlib.org/scalapack/scalapack-2.0.2.tgz" \
 "http://mumps.enseeiht.fr/MUMPS_4.10.0.tar.gz" \
 "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz" \
@@ -409,7 +409,7 @@ for i in ${ARCHIVE_NAMES[@]}; do
     count=$(( $count + 1 ))
 
     if ! tar tf $i &> /dev/null; then
-      tar -xzf tars/$i
+      tar -xf tars/$i
     fi
     cd tars
 done
@@ -490,7 +490,7 @@ else
     mkdir hdf5-1.8.15
     mv tmpdir hdf5-1.8.15/src
     cd hdf5-1.8.15/src
-    ./configure --enable-shared=off --prefix=$GOMA_LIB/hdf5-1.8.15
+    CC=$OPENMPI_TOP/bin/mpicc ./configure --enable-parallel --enable-shared=off --prefix=$GOMA_LIB/hdf5-1.8.15
     make -j$MAKE_JOBS
     make install
     cd ../..
@@ -528,7 +528,7 @@ else
     export LDFLAGS=-L$GOMA_LIB/hdf5-1.8.15/lib 
     echo $CPPFLAGS
     echo $LDFLAGS
-    ./configure --prefix=$GOMA_LIB/netcdf-4.3.3.1 --enable-shared=off --disable-dap
+    CC=mpicc ./configure --prefix=$GOMA_LIB/netcdf-4.3.3.1 --enable-shared=off --disable-dap --enable-parallel-tests
     make -j$MAKE_JOBS
     make install
     cd ../..
@@ -733,9 +733,9 @@ fi
 
 #continue_check
 #make trilinos
-rm -rf $GOMA_LIB/trilinos-11.8.1-Temp
-mkdir $GOMA_LIB/trilinos-11.8.1-Temp
-cd $GOMA_LIB/trilinos-11.8.1-Temp
+rm -rf $GOMA_LIB/trilinos-12.0.1-Temp
+mkdir $GOMA_LIB/trilinos-12.0.1-Temp
+cd $GOMA_LIB/trilinos-12.0.1-Temp
 
 rm -f CMakeCache.txt
 
@@ -753,7 +753,7 @@ export PATH=$GOMA_LIB/cmake-2.8.12.2/bin:$PATH
 MPI_LIBS="-LMPI_BASE_DIR/lib -lmpi_f90 -lmpi_f77 -lmpi"
 SEACAS_LIBS="-L${GOMA_LIB}/hdf5-1.8.15/lib -lhdf5_hl -lhdf5 -lz -lm"
 # Install directory
-TRILINOS_INSTALL=$GOMA_LIB/trilinos-11.8.1-Built
+TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.0.1-Built
 #continue_check
 
 
@@ -765,6 +765,7 @@ cmake \
 -D CMAKE_C_COMPILER:FILEPATH=$MPI_BASE_DIR/bin/mpicc \
 -D CMAKE_Fortran_COMPILER:FILEPATH=$MPI_BASE_DIR/bin/mpif90 \
 -D CMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
+-D Trilinos_ENABLE_CXX11=OFF \
 -D Trilinos_ENABLE_Triutils:BOOL=ON \
 -D Trilinos_ENABLE_SEACAS:BOOL=ON \
 -D Trilinos_ENABLE_Amesos:BOOL=ON \
@@ -835,12 +836,12 @@ cmake \
 -D Amesos_ENABLE_UMFPACK:BOOL=ON \
 -D Amesos_ENABLE_MUMPS:BOOL=ON \
 $EXTRA_ARGS \
-$GOMA_LIB/trilinos-11.8.1-Source
+$GOMA_LIB/trilinos-12.0.1-Source
 
 
 
 #continue_check
 make -j$MAKE_JOBS
-continue_check
+#continue_check
 make install
 

--- a/scripts/build-goma-dep-trilinos-12.sh
+++ b/scripts/build-goma-dep-trilinos-12.sh
@@ -5,7 +5,6 @@
 # 2014, July: Created by Cory Miner based off of notes by Scott Roberts
 # 2014: Weston Ortiz modified to include blacs, scalapack and mumps support in trilinos
 # 2015, February: Andrew Cochrane modified to handle recent changes to SEACAS-latest and hdf5, also added some logic to help with troubleshooting
-# 2015, June: Andrew and Weston handled switch to SuiteSparse and the SEACAS that is shipped with Trilinos
 
 # This script tries to build all of the libraries needed for goma
 # in the specified directories.
@@ -68,6 +67,7 @@ FORTRAN_LIBS=-lgfortran
 
 OPENMPI_TOP=$GOMA_LIB/openmpi-1.6.4
 export PATH=$OPENMPI_TOP/bin:$PATH
+export LD_LIBRARY_PATH=$OPENMPI_TOP/lib:$LD_LIBRARY_PATH
 FORTRAN_COMPILER=$OPENMPI_TOP/bin/mpif90
 
 export MPI_BASE_DIR=$OPENMPI_TOP
@@ -88,7 +88,7 @@ ARCHIVE_NAMES=("arpack96.tar.gz" \
 "sparse.tar.gz" 
 "superlu_dist_2.3.tar.gz" \
 "y12m-1.0.tar.gz" \
-"trilinos-11.8.1-Source.tar.gz" \
+"trilinos-12.0.1-Source.tar.bz2" \
 "scalapack-2.0.2.tgz" \
 "MUMPS_4.10.0.tar.gz" \
 "SuiteSparse-4.4.4.tar.gz" \
@@ -106,7 +106,7 @@ ARCHIVE_MD5SUMS=("fffaa970198b285676f4156cebc8626e" \
 "1566d914d1035ac17b73fe9bc0eed02a" \
 "8cf8cb964bb25ff6981f994b7e794f29" \
 "eed01310baca61f22fb8a88a837d2ae3" \
-"3c9465b6d63d824e9dc0365ca73c3370" \
+"19efcadf25c80b834f7c910ccfcca290" \
 "2f75e600a2ba155ed9ce974a1c4b536f" \
 "959e9981b606cd574f713b8422ef0d9f" \
 "e0af74476935c9ff6d971df8bb6b82fc" \
@@ -124,7 +124,7 @@ ARCHIVE_URLS=("http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz" \
 "http://sourceforge.net/projects/sparse/files/sparse/sparse1.4b/sparse1.4b.tar.gz/download" \
 "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_2.3.tar.gz" \
 "http://sisyphus.ru/cgi-bin/srpm.pl/Branch5/y12m/getsource/0" \
-"http://trilinos.sandia.gov/download/files/trilinos-11.8.1-Source.tar.gz" \
+"http://trilinos.csbsju.edu/download/files/trilinos-12.0.1-Source.tar.bz2" \
 "http://www.netlib.org/scalapack/scalapack-2.0.2.tgz" \
 "http://mumps.enseeiht.fr/MUMPS_4.10.0.tar.gz" \
 "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz" \
@@ -409,7 +409,7 @@ for i in ${ARCHIVE_NAMES[@]}; do
     count=$(( $count + 1 ))
 
     if ! tar tf $i &> /dev/null; then
-      tar -xzf tars/$i
+      tar -xf tars/$i
     fi
     cd tars
 done
@@ -490,7 +490,7 @@ else
     mkdir hdf5-1.8.15
     mv tmpdir hdf5-1.8.15/src
     cd hdf5-1.8.15/src
-    ./configure --enable-shared=off --prefix=$GOMA_LIB/hdf5-1.8.15
+    CC=$OPENMPI_TOP/bin/mpicc ./configure --enable-parallel --enable-shared=off --prefix=$GOMA_LIB/hdf5-1.8.15
     make -j$MAKE_JOBS
     make install
     cd ../..
@@ -528,7 +528,7 @@ else
     export LDFLAGS=-L$GOMA_LIB/hdf5-1.8.15/lib 
     echo $CPPFLAGS
     echo $LDFLAGS
-    ./configure --prefix=$GOMA_LIB/netcdf-4.3.3.1 --enable-shared=off --disable-dap
+    CC=mpicc ./configure --prefix=$GOMA_LIB/netcdf-4.3.3.1 --enable-shared=off --disable-dap --enable-parallel-tests
     make -j$MAKE_JOBS
     make install
     cd ../..
@@ -733,9 +733,9 @@ fi
 
 #continue_check
 #make trilinos
-rm -rf $GOMA_LIB/trilinos-11.8.1-Temp
-mkdir $GOMA_LIB/trilinos-11.8.1-Temp
-cd $GOMA_LIB/trilinos-11.8.1-Temp
+rm -rf $GOMA_LIB/trilinos-12.0.1-Temp
+mkdir $GOMA_LIB/trilinos-12.0.1-Temp
+cd $GOMA_LIB/trilinos-12.0.1-Temp
 
 rm -f CMakeCache.txt
 
@@ -753,7 +753,7 @@ export PATH=$GOMA_LIB/cmake-2.8.12.2/bin:$PATH
 MPI_LIBS="-LMPI_BASE_DIR/lib -lmpi_f90 -lmpi_f77 -lmpi"
 SEACAS_LIBS="-L${GOMA_LIB}/hdf5-1.8.15/lib -lhdf5_hl -lhdf5 -lz -lm"
 # Install directory
-TRILINOS_INSTALL=$GOMA_LIB/trilinos-11.8.1-Built
+TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.0.1-Built
 #continue_check
 
 
@@ -835,12 +835,12 @@ cmake \
 -D Amesos_ENABLE_UMFPACK:BOOL=ON \
 -D Amesos_ENABLE_MUMPS:BOOL=ON \
 $EXTRA_ARGS \
-$GOMA_LIB/trilinos-11.8.1-Source
+$GOMA_LIB/trilinos-12.0.1-Source
 
 
 
 #continue_check
 make -j$MAKE_JOBS
-continue_check
+#continue_check
 make install
 


### PR DESCRIPTION
Adds two scripts to build goma libs with Trilinos 12 with and without c++11 support.

Goma's test suite does not change with Trilinos 12. The readme in the scripts directory was updated as if Trilinos 12 is built with c++11 support another setting (CXXSTD=-std=c++11) must be changed in settings.mk

The Trilinos 12 scripts seem to work fine on ubuntu 14.04 and centos 6/7 but centos 6 does need to be built without c++11 support.

Also fix slight mistake in the 11.8.1 build script