### PR TITLE
Rename isort to integer_sort to avoid conflict with superlu_dist 4.0

### DIFF
--- a/include/rd_mesh.h
+++ b/include/rd_mesh.h
@@ -109,7 +109,7 @@ EXTERN int Elem_Type		/* rd_mesh.c */
 PROTO((const Exo_DB *exo,	/* the mesh */
        const int ));		/* element - the element number on this proc */
 
-EXTERN void isort		/* rd_mesh.c */
+EXTERN void integer_sort		/* rd_mesh.c */
 PROTO((int ,			/* length - of the integer vector */
        int *));			/* array - the vector to be sorted */
 

--- a/src/exo_conn.c
+++ b/src/exo_conn.c
@@ -395,7 +395,7 @@ build_node_node(Exo_DB *exo)
        * Sort the list before appending to the big concatenated list...
        */
 
-      isort(curr_list_size, list);
+      integer_sort(curr_list_size, list);
 
       /*
        * No, we're assuming we're never in danger of overrunning the buffer
@@ -1756,7 +1756,7 @@ brk_build_node_node(Exo_DB *exo)
        * Sort the list before appending to the big concatenated list...
        */
 
-      isort(curr_list_size, list);
+      integer_sort(curr_list_size, list);
 
       /*
        * No, we're assuming we're never in danger of overrunning the buffer

--- a/src/rd_mesh.c
+++ b/src/rd_mesh.c
@@ -715,7 +715,7 @@ setup_old_exo(Exo_DB *e)
      if ((hi-lo) < 1) {
        EH(-1, "Bad side node index listing!");
      }
-     isort((hi-lo), snl_std);
+     integer_sort((hi-lo), snl_std);
 
      /*
       * Now look at the 2nd through last elem/sides nodegroups for any match,
@@ -743,7 +743,7 @@ setup_old_exo(Exo_DB *e)
 		   side, lo, side+1, hi);
 	   EH(-1, err_msg);
 	 }
-	 isort((hi-lo), snl_cmp);
+	 integer_sort((hi-lo), snl_cmp);
 	 equal_vectors = TRUE;
 	 for (l = 0; l < (hi-lo); l++) {
 	   equal_vectors &= (snl_cmp[l] == snl_std[l]);
@@ -1938,7 +1938,7 @@ Elem_Type(const Exo_DB *exo,
 /************************************************************************/
 /************************************************************************/
 /*
- * isort() -- sort a list of integers
+ * integer_sort() -- sort a list of integers
  *
  *
  * This makes use of the qsort "quick sort" that is part of the standard C
@@ -1959,7 +1959,7 @@ integer_compare(const void *arg1, const void *arg2)
 }
 
 void 
-isort(int length, int *array)
+integer_sort(int length, int *array)
 {
   if (length < 1) {
       EH(-1, "Negative or zero length array to sort?");


### PR DESCRIPTION
Trilinos now supports newer versions of superlu_dist, this fixes a symbol conflict with superlu 4.0

The new version of superlu_dist also passes the test suite.
