### PR TITLE
Fix memory issue with wrong array allocation size

### DIFF
--- a/include/mm_mp_structs.h
+++ b/include/mm_mp_structs.h
@@ -668,7 +668,6 @@ struct Material_Properties
   dbl lubmomsource[DIM];
   dbl d_lubmomsource[DIM][MAX_VARIABLE_TYPES + MAX_CONC];
   int len_lubmomsource;
-  dbl *u_lubmomsource_function_constants;
   int LubMomSourceModel;
 
   dbl FilmEvap;

--- a/src/dp_vif.c
+++ b/src/dp_vif.c
@@ -2997,8 +2997,6 @@ ark_landing()
 	      m->    u_dcaL_function_constants); 
       dalloc( m->len_lubsource, 
 	      m->    u_lubsource_function_constants); 
-      dalloc( m->len_lubmomsource, 
-	      m->    u_lubmomsource_function_constants); 
       /*
        * special usage models for porous shell
        */
@@ -3382,8 +3380,6 @@ noahs_dove()
 	  m->    u_dcaL_function_constants);
     crdv( m->len_lubsource, 
     	  m->    u_lubsource_function_constants);
-    crdv( m->len_lubmomsource, 
-	  m->    u_lubmomsource_function_constants);
     /* 
      * some more specialized constants (PorousShell)
      */

--- a/src/mm_input_mp.c
+++ b/src/mm_input_mp.c
@@ -8708,7 +8708,6 @@ ECHO("\n----Acoustic Properties\n", echo_file);
 		  EH(-1,"Lubrication momentum source constant model expects 3 flts");
 		}
 	      num_const = mp_glob[mn]->len_lubmomsource = 3;
-	      mat_ptr->u_lubmomsource_function_constants = alloc_dbl_1(1,0.0);
 
 	      SPF_DBL_VEC(endofstring(es), num_const,  mat_ptr->lubmomsource );
 


### PR DESCRIPTION
removes an unused material property, passes test suite, showed up under valgrind on one of Kris's problems

