### PR TITLE
Fix for G Jacobian term when using PSPG

### DIFF
--- a/src/mm_fill_terms.c
+++ b/src/mm_fill_terms.c
@@ -5252,13 +5252,12 @@ assemble_continuity(dbl time_value,   /* current time */
 	  var = VELOCITY_GRADIENT11;
 	  if ( PSPG && pdv[var] )
 	    {
-	      pvar = upd->vp[var];
-
 	      for ( p=0; p<VIM; p++)
 		{
 		  for ( q=0; q<VIM; q++)
 		    {
 		      var = v_g[p][q];
+		      pvar = upd->vp[var];
 		      if ( pd->v[var] )
 			{
 			  for ( j=0; j<ei->dof[var]; j++)


### PR DESCRIPTION
I found a small Jacobian bug when using the PSPG terms with VE problems.  Before, PSPG terms wrt Gij were all placed in the G11 term.  Now, this properly cycles through the Gij contributions to the Jacobian.

This passes the test suite.