### PR TITLE
Fix compiler warnings from #98 and #100 update

### DIFF
--- a/src/ac_hunt.c
+++ b/src/ac_hunt.c
@@ -131,7 +131,7 @@ hunt_problem(Comm_Ex *cx,	/* array of communications structures */
   double        *lambda=NULL, *lambdaEnd=NULL;
   double	hunt_par, dhunt_par, hunt_par_old;	/* hunting continuation parameter */
   double        dhunt_par_max=1.0, dhunt_par_min=0., dhunt_par_0=0.1;
-  double        dhunt_par_new, dhunt_par_old;
+  double        dhunt_par_new = 0.0, dhunt_par_old;
 #ifdef LOG_HUNTING_PLEASE
   int		log_hunt = TRUE;
 #else

--- a/src/ac_loca_interface.c
+++ b/src/ac_loca_interface.c
@@ -1349,7 +1349,7 @@ int nonlinear_solver_conwrap(double *x, void *con_ptr, int step_num,
   int nits=0; /* num_modnewt_its=0;  */
   int i, iAC;
   int iCC = 0, iTC = 0, iUC = 0, nCC = 0;
-  double theta;
+  double theta = 0.0;
   double evol_local=0.0;
 #ifdef PARALLEL
   double evol_global=0.0;

--- a/src/bc_special.c
+++ b/src/bc_special.c
@@ -121,7 +121,7 @@ apply_special_bc (struct Aztec_Linear_Solver_System *ams,
   double dwall_velo_dx[MAX_PDIM][MDE],dvelo_dx[MAX_PDIM][MAX_PDIM];
   int found_wall_velocity;
   /* HKM - worried that jflag shouldn't be initialized all the way up here */
-  int jcnt, jflag=-1, local_node_id, matID_apply;
+  int jcnt, jflag=-1, local_node_id = -1, matID_apply;
   int GD_count; 
   int Gibbs = 1;
   int iapply = 0;


### PR DESCRIPTION
Someone may want to double check that these warnings were not meaningful and a better fix needed.

    bc_special.c: In function ‘apply_special_bc’:
    bc_special.c:874:31: warning: ‘local_node_id’ may be used uninitialized in this function [-Wmaybe-uninitialized]
              fapply_moving_CA_sinh(func,
                                   ^
    ac_loca_interface.c: In function ‘nonlinear_solver_conwrap’:
    ac_loca_interface.c:1572:12: warning: ‘theta’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         DPRINTF(stderr,
                ^
    ac_hunt.c: In function ‘hunt_problem’:
    ac_hunt.c:1397:7: warning: ‘dhunt_par_new’ may be used uninitialized in this function [-Wmaybe-uninitialized]
      v1add(numProcUnknowns, &x[0], dhunt_par, &x_sens[0]);
           ^

