### PR TITLE
Change checkfinite to return with error on non-finite entry, printing once

### DIFF
--- a/include/mm_fill.h
+++ b/include/mm_fill.h
@@ -51,7 +51,7 @@ PROTO((struct Aztec_Linear_Solver_System *,
        dbl *));     /* estifm - element stiffness Matrix for frontal solver */
 
 
-EXTERN void matrix_fill
+EXTERN int matrix_fill
 PROTO((struct Aztec_Linear_Solver_System *,	
        double [],		/* x - Solution vector                       */
        double [],		/* resid_vector - Residual vector            */
@@ -84,7 +84,7 @@ PROTO((struct Aztec_Linear_Solver_System *,
 				 * frontal solver                            */
        int ));                  /* zeroCA */
 
-EXTERN void checkfinite
+EXTERN int checkfinite
 PROTO((const char * const,      /* file                                      */
        const int ,	       	/* line                                      */
        const char * const));	/* message                                   */


### PR DESCRIPTION
Change the checkfinite function to return an error code and only print 1 NaN

Only print 1 nan found (we were getting 60GB-400GB log files of NaNs on Peixi's problem) but the problem could still continue after it failed that timestep

Passed test suite and passed testing with NaN's (both on Peixi's problem and small test problems with NaN's artificially added)

Seems like the previous behavior (printing all NaN's) is from when an exit on NaN was wanted.