### PR TITLE
Global exodus variable support in parallel and automatic fix in continuation

### DIFF
--- a/docs/parallel_integration.md
+++ b/docs/parallel_integration.md
@@ -67,3 +67,17 @@ Following are sample cards:
     # Fix every 5 prints
     Fix Frequency = 5
 ```
+
+### Continuation Specifications
+
+    -- After Continuation Printing Frequency in input file
+
+#### Continuation Fix Frequency
+
+```
+Continuation Fix Frequency = <integer>
+```
+
+##### Description/Usage
+
+See Fix Frequency

--- a/include/mm_as_structs.h
+++ b/include/mm_as_structs.h
@@ -1075,6 +1075,7 @@ struct Continuation_Information
   dbl eps;
   int use_var_norm[MAX_VARIABLE_TYPES];
   int print_freq;
+  int fix_freq;
   double print_delt;
   double print_delt2_path;
   double print_delt2;

--- a/src/brkfix/fix_exo_file.c
+++ b/src/brkfix/fix_exo_file.c
@@ -483,6 +483,42 @@ fix_exo_file(int num_procs, char* exo_mono_name)
 	      t, mono->nv_time_indeces[0]);
 #endif
       wr_result_exo(mono, monolith_file_name, 0);
+      
+      if ( mono->num_glob_vars > 0 ) {
+	int status;
+	
+	mono->cmode = EX_WRITE;
+
+
+	mono->io_wordsize   = 0;	/* i.e., query */
+	mono->comp_wordsize = sizeof(dbl);
+	mono->exoid         = ex_open(mono->path, 
+				   mono->cmode, 
+				   &mono->comp_wordsize, 
+				   &mono->io_wordsize, 
+				   &mono->version);
+
+	/*status = ex_put_var_param(mono->exoid, "g", mono->num_glob_vars);
+	EH(status, "ex_put_var_param(g)");
+	*/
+	status = ex_put_var_names(mono->exoid, "g", mono->num_glob_vars,
+				  mono->glob_var_names);
+	EH(status, "ex_put_var_names(g)");
+
+
+
+	for (i = 0; i < mono->num_gv_time_indeces; i++) {
+	  status = ex_put_glob_vars(mono->exoid, mono->gv_time_indeces[i],
+			   mono->num_glob_vars,
+			   mono->gv[i]);
+	  EH(status, "ex_put_glob_vars");
+	}
+
+	status = ex_close(mono->exoid);
+	EH(status, "ex_close()");
+
+      }
+      
       zero_base(mono);
     }
 

--- a/src/dp_vif.c
+++ b/src/dp_vif.c
@@ -1269,6 +1269,7 @@ noahs_ark()
       ddd_add_member(n, &cont->eps,               1, MPI_DOUBLE);
       ddd_add_member(n,  cont->use_var_norm, MAX_VARIABLE_TYPES, MPI_INT);
       ddd_add_member(n, &cont->print_freq,        1, MPI_INT);
+      ddd_add_member(n, &cont->fix_freq, 1, MPI_INT);
       ddd_add_member(n, &cont->print_delt,        1, MPI_DOUBLE);
       ddd_add_member(n, &cont->print_delt2_path,  1, MPI_DOUBLE);
       ddd_add_member(n, &cont->print_delt2,       1, MPI_DOUBLE);

--- a/src/mm_input.c
+++ b/src/mm_input.c
@@ -3258,6 +3258,19 @@ rd_track_specs(FILE *ifp,
       cont->print_freq = print_freq;
 	  SPF(echo_string,"%s = %d", input, print_freq); ECHO(echo_string,echo_file);
 
+      cont->fix_freq = 0;
+      if (Num_Proc > 1) {
+        iread = look_for_optional(ifp,"Continuation Fix Frequency",input,'=');
+        if (iread == 1) {
+          cont->fix_freq = read_int(ifp, "Continuation Fix Frequency");
+          if (cont->fix_freq < 0) {
+            EH(-1, "Expected Fix Frequency > 0");
+          }
+          SPF(echo_string, "%s = %d", "Continuation Fix Frequency", cont->fix_freq); ECHO(echo_string, echo_file);
+        }
+      }
+
+
       if (Continuation == LOCA)
         {
         

--- a/src/rf_util.c
+++ b/src/rf_util.c
@@ -1427,7 +1427,7 @@ init_vec(double u[], Comm_Ex *cx, Exo_DB *exo, Dpi *dpi, double uAC[],
      * As of Mar 18, 2002, brkfix doesn't support global variables, hence, this
      * capability does not exist for parallel operations.
      */
-    if( nAC > 0 && Num_Proc == 1)  
+    if( nAC > 0 )
       {
 	int ngv;
 
@@ -1475,7 +1475,7 @@ init_vec(double u[], Comm_Ex *cx, Exo_DB *exo, Dpi *dpi, double uAC[],
      * capability does not exist for parallel operations.
      */
 	
-    if( nAC > 0 && Num_Proc == 1) 
+    if( nAC > 0 )
       {
 	int ngv;
 

--- a/src/wr_exo.c
+++ b/src/wr_exo.c
@@ -807,9 +807,6 @@ wr_global_result_exo( Exo_DB *exo,
    * brkfix doesn't support global variables, when this
    * changes this restriction should be removed. TAB 3/2002 */
 
-  if( Num_Proc != 1 ) return;  /* Return if not running serial */
-
-
   if( u == NULL ) return ; /* Do nothing if this is NULL */
 
   exo->cmode = EX_WRITE;


### PR DESCRIPTION
Add global exodus variable support for automatic brk and fix as well as reading in augmenting conditions as initial guess in parallel.

Also added Continuation Fix Frequency for parallel continuation problems

In parallel with goma/brkfix#4