### PR TITLE
Fix bug where scripts would not create directory, and update trilinos links

### DIFF
--- a/scripts/build-TPL-experimental.sh
+++ b/scripts/build-TPL-experimental.sh
@@ -45,6 +45,15 @@ if [ -z "$1" ]
     exit 1
 fi
 
+mkdir -p $1
+
+# check that we were able to make that directory
+if [ ! -d $1 ] 
+    then
+    echo "ERROR: could not create directory $1"
+    exit 1
+fi
+        
 cd $1
 GOMA_LIB=`pwd`
 export GOMA_LIB
@@ -95,7 +104,7 @@ ARCHIVE_NAMES=("arpack96.tar.gz" \
 "sparse.tar.gz" 
 "superlu_dist_5.0.0.tar.gz" \
 "y12m-1.0.tar.gz" \
-"trilinos-12.6.3-Source.tar.bz2" \
+"trilinos-12.6.4-Source.tar.bz2" \
 "scalapack-2.0.2.tgz" \
 "MUMPS_5.0.1.tar.gz" \
 "SuiteSparse-4.4.4.tar.gz" \
@@ -113,7 +122,7 @@ ARCHIVE_MD5SUMS=("fffaa970198b285676f4156cebc8626e" \
 "1566d914d1035ac17b73fe9bc0eed02a" \
 "2b53baf1b0ddbd9fcf724992577f0670" \
 "eed01310baca61f22fb8a88a837d2ae3" \
-"d94e31193559b334fd41d05eb22f9285" \
+"b4edf20a997caa1ca88340f6e3dab514" \
 "2f75e600a2ba155ed9ce974a1c4b536f" \
 "b477573fdcc87babe861f62316833db0" \
 "e0af74476935c9ff6d971df8bb6b82fc" \
@@ -128,10 +137,10 @@ ARCHIVE_URLS=("http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz" \
 "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.1.tar.gz" \
 "http://www.open-mpi.org/software/ompi/v1.6/downloads/openmpi-1.6.4.tar.gz" \
 "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz" \
-"http://sourceforge.net/projects/sparse/files/sparse/sparse1.4b/sparse1.4b.tar.gz/download" \
+"http://downloads.sourceforge.net/project/sparse/sparse/sparse1.4b/sparse1.4b.tar.gz" \
 "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_5.0.0.tar.gz" \
 "http://sisyphus.ru/cgi-bin/srpm.pl/Branch5/y12m/getsource/0" \
-"http://trilinos.csbsju.edu/download/files/trilinos-12.6.3-Source.tar.bz2" \
+"https://trilinos.org/oldsite/download/files/trilinos-12.6.4-Source.tar.bz2" \
 "http://www.netlib.org/scalapack/scalapack-2.0.2.tgz" \
 "http://graal.ens-lyon.fr/MUMPS/MUMPS_5.0.1.tar.gz" \
 "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz" \
@@ -743,9 +752,9 @@ fi
 
 #continue_check
 #make trilinos
-rm -rf $GOMA_LIB/trilinos-12.6.3-Temp
-mkdir $GOMA_LIB/trilinos-12.6.3-Temp
-cd $GOMA_LIB/trilinos-12.6.3-Temp
+rm -rf $GOMA_LIB/trilinos-12.6.4-Temp
+mkdir $GOMA_LIB/trilinos-12.6.4-Temp
+cd $GOMA_LIB/trilinos-12.6.4-Temp
 
 rm -f CMakeCache.txt
 
@@ -762,7 +771,7 @@ export PATH=$GOMA_LIB/cmake-2.8.12.2/bin:$PATH
 
 MPI_LIBS="-LMPI_BASE_DIR/lib -lmpi_f90 -lmpi_f77 -lmpi"
 # Install directory
-TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.6.3-Built
+TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.6.4-Built
 #continue_check
 
 
@@ -847,7 +856,7 @@ cmake \
 -D Amesos_ENABLE_UMFPACK:BOOL=ON \
 -D Amesos_ENABLE_MUMPS:BOOL=ON \
 $EXTRA_ARGS \
-$GOMA_LIB/trilinos-12.6.3-Source
+$GOMA_LIB/trilinos-12.6.4-Source
 
 
 

--- a/scripts/build-goma-dep-trilinos-12-noc++11.sh
+++ b/scripts/build-goma-dep-trilinos-12-noc++11.sh
@@ -44,6 +44,15 @@ if [ -z "$1" ]
     exit 1
 fi
 
+mkdir -p $1
+
+# check that we were able to make that directory
+if [ ! -d $1 ] 
+    then
+    echo "ERROR: could not create directory $1"
+    exit 1
+fi
+        
 cd $1
 GOMA_LIB=`pwd`
 export GOMA_LIB
@@ -91,7 +100,7 @@ ARCHIVE_NAMES=("arpack96.tar.gz" \
 "sparse.tar.gz" 
 "superlu_dist_2.3.tar.gz" \
 "y12m-1.0.tar.gz" \
-"trilinos-12.2.1-Source.tar.bz2" \
+"trilinos-12.2.2-Source.tar.bz2" \
 "scalapack-2.0.2.tgz" \
 "MUMPS_4.10.0.tar.gz" \
 "SuiteSparse-4.4.4.tar.gz" \
@@ -109,7 +118,7 @@ ARCHIVE_MD5SUMS=("fffaa970198b285676f4156cebc8626e" \
 "1566d914d1035ac17b73fe9bc0eed02a" \
 "8cf8cb964bb25ff6981f994b7e794f29" \
 "eed01310baca61f22fb8a88a837d2ae3" \
-"760f14cbce482b4b9a41d1c18297b531" \
+"90bbb175505b55878401a51a1d17463c" \
 "2f75e600a2ba155ed9ce974a1c4b536f" \
 "959e9981b606cd574f713b8422ef0d9f" \
 "e0af74476935c9ff6d971df8bb6b82fc" \
@@ -124,10 +133,10 @@ ARCHIVE_URLS=("http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz" \
 "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.1.tar.gz" \
 "http://www.open-mpi.org/software/ompi/v1.6/downloads/openmpi-1.6.4.tar.gz" \
 "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/OLD/ParMetis-3.1.1.tar.gz" \
-"http://sourceforge.net/projects/sparse/files/sparse/sparse1.4b/sparse1.4b.tar.gz/download" \
+"http://downloads.sourceforge.net/project/sparse/sparse/sparse1.4b/sparse1.4b.tar.gz" \
 "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_2.3.tar.gz" \
 "http://sisyphus.ru/cgi-bin/srpm.pl/Branch5/y12m/getsource/0" \
-"http://trilinos.csbsju.edu/download/files/trilinos-12.2.1-Source.tar.bz2" \
+"https://trilinos.org/oldsite/download/files/trilinos-12.2.2-Source.tar.bz2" \
 "http://www.netlib.org/scalapack/scalapack-2.0.2.tgz" \
 "http://mumps.enseeiht.fr/MUMPS_4.10.0.tar.gz" \
 "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz" \
@@ -145,7 +154,7 @@ ARCHIVE_DIR_NAMES=("ARPACK" \
 "sparse" \
 "SuperLU_DIST_2.3" \
 "y12m-1.0" \
-"trilinos-12.2.1-Source" \
+"trilinos-12.2.2-Source" \
 "scalapack-2.0.2" \
 "MUMPS_4.10.0" \
 "SuiteSparse" \
@@ -760,9 +769,9 @@ fi
 
 #continue_check
 #make trilinos
-rm -rf $GOMA_LIB/trilinos-12.2.1-Temp
-mkdir $GOMA_LIB/trilinos-12.2.1-Temp
-cd $GOMA_LIB/trilinos-12.2.1-Temp
+rm -rf $GOMA_LIB/trilinos-12.2.2-Temp
+mkdir $GOMA_LIB/trilinos-12.2.2-Temp
+cd $GOMA_LIB/trilinos-12.2.2-Temp
 
 rm -f CMakeCache.txt
 
@@ -780,7 +789,7 @@ export PATH=$GOMA_LIB/cmake-2.8.12.2/bin:$PATH
 MPI_LIBS="-LMPI_BASE_DIR/lib -lmpi_f90 -lmpi_f77 -lmpi"
 SEACAS_LIBS="-L${GOMA_LIB}/hdf5-1.8.15/lib -lhdf5_hl -lhdf5 -lz -lm"
 # Install directory
-TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.2.1-Built
+TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.2.2-Built
 #continue_check
 
 
@@ -863,7 +872,7 @@ cmake \
 -D Amesos_ENABLE_UMFPACK:BOOL=ON \
 -D Amesos_ENABLE_MUMPS:BOOL=ON \
 $EXTRA_ARGS \
-$GOMA_LIB/trilinos-12.2.1-Source
+$GOMA_LIB/trilinos-12.2.2-Source
 
 
 

--- a/scripts/build-goma-dep-trilinos-12.sh
+++ b/scripts/build-goma-dep-trilinos-12.sh
@@ -44,6 +44,15 @@ if [ -z "$1" ]
     exit 1
 fi
 
+mkdir -p $1
+
+# check that we were able to make that directory
+if [ ! -d $1 ] 
+    then
+    echo "ERROR: could not create directory $1"
+    exit 1
+fi
+	
 cd $1
 GOMA_LIB=`pwd`
 export GOMA_LIB
@@ -91,7 +100,7 @@ ARCHIVE_NAMES=("arpack96.tar.gz" \
 "sparse.tar.gz" 
 "superlu_dist_5.0.0.tar.gz" \
 "y12m-1.0.tar.gz" \
-"trilinos-12.6.3-Source.tar.bz2" \
+"trilinos-12.6.4-Source.tar.bz2" \
 "scalapack-2.0.2.tgz" \
 "MUMPS_5.0.1.tar.gz" \
 "SuiteSparse-4.4.4.tar.gz" \
@@ -109,7 +118,7 @@ ARCHIVE_MD5SUMS=("fffaa970198b285676f4156cebc8626e" \
 "1566d914d1035ac17b73fe9bc0eed02a" \
 "2b53baf1b0ddbd9fcf724992577f0670" \
 "eed01310baca61f22fb8a88a837d2ae3" \
-"d94e31193559b334fd41d05eb22f9285" \
+"b4edf20a997caa1ca88340f6e3dab514" \
 "2f75e600a2ba155ed9ce974a1c4b536f" \
 "b477573fdcc87babe861f62316833db0" \
 "e0af74476935c9ff6d971df8bb6b82fc" \
@@ -124,10 +133,10 @@ ARCHIVE_URLS=("http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz" \
 "ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4.3.3.1.tar.gz" \
 "http://www.open-mpi.org/software/ompi/v1.6/downloads/openmpi-1.6.4.tar.gz" \
 "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz" \
-"http://sourceforge.net/projects/sparse/files/sparse/sparse1.4b/sparse1.4b.tar.gz/download" \
+"http://downloads.sourceforge.net/project/sparse/sparse/sparse1.4b/sparse1.4b.tar.gz" \
 "http://crd-legacy.lbl.gov/~xiaoye/SuperLU/superlu_dist_5.0.0.tar.gz" \
 "http://sisyphus.ru/cgi-bin/srpm.pl/Branch5/y12m/getsource/0" \
-"http://trilinos.csbsju.edu/download/files/trilinos-12.6.3-Source.tar.bz2" \
+"https://trilinos.org/oldsite/download/files/trilinos-12.6.4-Source.tar.bz2" \
 "http://www.netlib.org/scalapack/scalapack-2.0.2.tgz" \
 "http://graal.ens-lyon.fr/MUMPS/MUMPS_5.0.1.tar.gz" \
 "http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-4.4.4.tar.gz" \
@@ -145,7 +154,7 @@ ARCHIVE_DIR_NAMES=("ARPACK" \
 "sparse" \
 "SuperLU_DIST_5.0.0" \
 "y12m-1.0" \
-"trilinos-12.6.3-Source" \
+"trilinos-12.6.4-Source" \
 "scalapack-2.0.2" \
 "MUMPS_5.0.1" \
 "SuiteSparse" \
@@ -397,7 +406,6 @@ read -d '' SUPERLU_PATCH << "EOF"
 EOF
 SUPERLU_PATCH=${SUPERLU_PATCH/__GOMA_LIB2__/$GOMA_LIB}
 
-mkdir -p $GOMA_LIB
 cd $GOMA_LIB
 
 function mychecksum {
@@ -852,9 +860,9 @@ fi
 
 #continue_check
 #make trilinos
-rm -rf $GOMA_LIB/trilinos-12.6.3-Temp
-mkdir $GOMA_LIB/trilinos-12.6.3-Temp
-cd $GOMA_LIB/trilinos-12.6.3-Temp
+rm -rf $GOMA_LIB/trilinos-12.6.4-Temp
+mkdir $GOMA_LIB/trilinos-12.6.4-Temp
+cd $GOMA_LIB/trilinos-12.6.4-Temp
 
 rm -f CMakeCache.txt
 
@@ -870,7 +878,7 @@ export LD_LIBRARY_PATH=$MPI_BASE_DIR/lib:$LD_LIBRARY_PATH
 MPI_LIBS="-LMPI_BASE_DIR/lib -lmpi_f90 -lmpi_f77 -lmpi"
 SEACAS_LIBS="-L${GOMA_LIB}/hdf5-1.8.15/lib -lhdf5_hl -lhdf5 -lz -lm"
 # Install directory
-TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.6.3-Built
+TRILINOS_INSTALL=$GOMA_LIB/trilinos-12.6.4-Built
 #continue_check
 
 
@@ -960,7 +968,7 @@ cmake \
 -D Amesos_ENABLE_UMFPACK:BOOL=ON \
 -D Amesos_ENABLE_MUMPS:BOOL=ON \
 $EXTRA_ARGS \
-$GOMA_LIB/trilinos-12.6.3-Source
+$GOMA_LIB/trilinos-12.6.4-Source
 
 
 

--- a/settings.mk-example
+++ b/settings.mk-example
@@ -59,7 +59,7 @@ SEACAS_TOP = $(GOMA_LIBS)/SEACAS-2013-12-03
 
 # Trilinos install directory (include, lib)
 
-TRILINOS_TOP = $(GOMA_LIBS)/trilinos-12.2.1-Built
+TRILINOS_TOP = $(GOMA_LIBS)/trilinos-12.2.2-Built
 
 # Install location
 # will install files in $PREFIX/include/goma, $PREFIX/lib, $PREFIX/bin


### PR DESCRIPTION
Change sparse/trilinos links as they were no longer working.

Updated trilinos versions, it appears noc++11 needs to stay 12.2 for now as seacas breaks without c++11

all scripts built and ran on the test suite.

