### PR TITLE
Oct28

### DIFF
--- a/include/rf_bc_const.h
+++ b/include/rf_bc_const.h
@@ -1183,6 +1183,7 @@ struct Boundary_Condition {
   dbl   BC_Data_Float[MAX_BC_FLOAT_DATA];
   int   len_u_BC;		/* number of elements in the user constant 
 				   list (0 most of the time) */
+  int   max_DFlt;
   int   Storage_ID;             /* ID of the quadature point storage for this bc 
 				 * Must be positive for it to exist. zero means
 				 * that it does not yet exist 

--- a/src/ac_update_parameter.c
+++ b/src/ac_update_parameter.c
@@ -86,7 +86,6 @@ update_parameterC(int iCC,       /* CONDITION NUMBER */
 
   int ic, mn, mpr;
   int ibc, idf;
-  //struct Boundary_Condition *BC_Type;
 
 #ifdef DEBUG
   static const char yo[] = "update_parameterC";
@@ -203,7 +202,6 @@ update_parameterTP(int iTC,       /* CONDITION NUMBER */
 
   int ic, mn, mpr;
   int ibc, idf;
-  //struct Boundary_Condition *BC_Type;
 
 #ifdef DEBUG
   static const char yo[] = "update_parameterTP";
@@ -285,7 +283,6 @@ update_parameterHC(int iHC,      /* Hunting condition number */
 
   int ic, mn, mpr;
   int ibc, idf;
-  //struct Boundary_Condition *BC_Type;
 
 #ifdef DEBUG
   static const char yo[] = "update_parameterHC";
@@ -305,7 +302,8 @@ update_parameterHC(int iHC,      /* Hunting condition number */
   if (hunt[iHC].Type == 1) {
     ibc = hunt[iHC].BCID;
     idf = hunt[iHC].DFID;
-    update_BC_parameter(lambda, ibc, idf, cx, exo, dpi);
+    if(ibc > -1)
+	{ update_BC_parameter(lambda, ibc, idf, cx, exo, dpi); }
   }
 
   /*
@@ -367,7 +365,6 @@ update_parameterS(double lambda, /* PARAMETER VALUE */
 
   int ic, mn, mpr;
   int ibc, idf;
-  //struct Boundary_Condition *BC_Type;
 
 #ifdef DEBUG
   static const char yo[] = "update_parameterS";
@@ -1072,7 +1069,6 @@ retrieve_parameterS(double *lambda, /* PARAMETER VALUE */
   int ic;
   int mn,mpr;
   int ibc, idf;
-  //struct Boundary_Condition *BC_Type;
   
 #ifdef DEBUG
   static const char yo[]="retrieve_parameterS";

--- a/src/bc_colloc.c
+++ b/src/bc_colloc.c
@@ -746,7 +746,6 @@ f_fillet (int ielem_dim,
         const int num_const)           /* number of passed parameters   */
 {    
 /**************************** EXECUTION BEGINS *******************************/
-  int  i;
   double xpt, ypt, theta1, theta2, rad, xcen , ycen, alpha;
   double theta;
 

--- a/src/dp_vif.c
+++ b/src/dp_vif.c
@@ -931,6 +931,7 @@ noahs_ark()
       ddd_add_member(n, BC_Types[i].BC_Data_Float, MAX_BC_FLOAT_DATA, 
 		     MPI_DOUBLE);
       ddd_add_member(n, &BC_Types[i].len_u_BC, 1, MPI_INT);            
+      ddd_add_member(n, &BC_Types[i].max_DFlt, 1, MPI_INT);            
 
       /* double u_BC delivered by Dove...*/
 

--- a/src/mm_bc.c
+++ b/src/mm_bc.c
@@ -2356,6 +2356,7 @@ initialize_Boundary_Condition (struct Boundary_Condition *bc_ptr)
    * transporting this list across processors.
    */
   bc_ptr->len_u_BC = 0;
+  bc_ptr->max_DFlt = 0;
 
   /*
    * Also, the majority of boundary conditions may rely upon

--- a/src/mm_input_bc.c
+++ b/src/mm_input_bc.c
@@ -720,6 +720,7 @@ rd_bc_specs(FILE *ifp,
 		      yo, BC_Types[ibc].desc->name1);
 	      EH(-1, err_msg);
 	    }
+            BC_Types[ibc].max_DFlt = 2;
 	    
 	    SPF(endofstring(echo_string), " %.4g", BC_Types[ibc].BC_Data_Float[0]);
 	    
@@ -814,6 +815,7 @@ rd_bc_specs(FILE *ifp,
 	    }
 
 	  SPF_DBL_VEC(endofstring(echo_string), 3,  BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 3;
 
           break;
 
@@ -839,6 +841,7 @@ rd_bc_specs(FILE *ifp,
 	    }
 
 	  SPF_DBL_VEC(endofstring(echo_string), 3,  BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 3;
 
 	  /* Try reading the optional integer. */
 	  if (fscanf(ifp, "%d", &BC_Types[ibc].BC_Data_Int[0]) != 1)
@@ -909,6 +912,7 @@ rd_bc_specs(FILE *ifp,
 	      EH(-1, err_msg);
 	    }
 
+          BC_Types[ibc].max_DFlt = 4;
 	  SPF_DBL_VEC(endofstring(echo_string), 4,  BC_Types[ibc].BC_Data_Float);
           break;
 	  /*
@@ -929,6 +933,7 @@ rd_bc_specs(FILE *ifp,
  	    }
  	  else
  	    {
+          BC_Types[ibc].max_DFlt = 4;
 	  SPF_DBL_VEC(endofstring(echo_string), 4,  BC_Types[ibc].BC_Data_Float);
 	      /* Scan for the optional int. If not present, put a -1 in second data position */ 
 	      /* This is to ensure a nonzero entry in BC_Data_Int[2] for CA */
@@ -963,6 +968,7 @@ rd_bc_specs(FILE *ifp,
 #ifdef USE_CGM
 	  BC_Types[ibc].cgm_plane_handle = NULL;
 #endif
+          BC_Types[ibc].max_DFlt = 4;
 	  SPF_DBL_VEC(endofstring(echo_string), 4,  BC_Types[ibc].BC_Data_Float);
 
           break;
@@ -989,6 +995,7 @@ rd_bc_specs(FILE *ifp,
 	      EH(-1, err_msg);
 	    }
 
+          BC_Types[ibc].max_DFlt = 4;
 	  SPF_DBL_VEC(endofstring(echo_string), 4,  BC_Types[ibc].BC_Data_Float);
 
 	  if ( fscanf(ifp, "%d %lf", 
@@ -1000,6 +1007,7 @@ rd_bc_specs(FILE *ifp,
 	    }
 	  else
 	    SPF(endofstring(echo_string)," %d %.4g", BC_Types[ibc].BC_Data_Int[0],BC_Types[ibc].BC_Data_Float[4]); 
+          BC_Types[ibc].max_DFlt = 5;
 
 
 	  break;
@@ -1043,6 +1051,7 @@ rd_bc_specs(FILE *ifp,
 		      BC_Types[ibc].BC_Data_Float[8] = 0.0;
 	    }
 
+          BC_Types[ibc].max_DFlt = 9;
 	  SPF_DBL_VEC(endofstring(echo_string), 9,  BC_Types[ibc].BC_Data_Float);
 
 	  break;
@@ -1078,6 +1087,7 @@ rd_bc_specs(FILE *ifp,
 		      BC_Types[ibc].BC_Data_Float[6] = 0.0;
 	    }
 
+          BC_Types[ibc].max_DFlt = 7;
 	  SPF_DBL_VEC(endofstring(echo_string), 7,  BC_Types[ibc].BC_Data_Float);
 
 	  break;
@@ -1104,6 +1114,7 @@ rd_bc_specs(FILE *ifp,
 
 	  SPF_INT_VEC(endofstring(echo_string), 3,  BC_Types[ibc].BC_Data_Int);
 	  SPF_DBL_VEC(endofstring(echo_string), 5,  BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 5;
 
           break;
 
@@ -1177,6 +1188,7 @@ rd_bc_specs(FILE *ifp,
 	      BC_Types[ibc].BC_Data_Float[4]=0.;
 	    }
  
+           BC_Types[ibc].max_DFlt = 5;
 	   BC_Types[ibc].species_eq = BC_Types[ibc].BC_Data_Int[0];
 
 	   break;
@@ -1255,6 +1267,7 @@ rd_bc_specs(FILE *ifp,
 
 	   SPF(endofstring(echo_string)," %s %d", input,BC_Types[ibc].BC_Data_Int[0]);
 	   SPF_DBL_VEC(endofstring(echo_string), 10,  BC_Types[ibc].BC_Data_Float);
+           BC_Types[ibc].max_DFlt = 10;
 	    
 	   break; 
 
@@ -1710,6 +1723,7 @@ rd_bc_specs(FILE *ifp,
 	      EH(-1, err_msg);
 	    }			   
 	  BC_Types[ibc].len_u_BC = num_const;
+	  BC_Types[ibc].max_DFlt = num_const;
 	  
 	  for(i=0;i<num_const;i++) SPF(endofstring(echo_string)," %.4g", BC_Types[ibc].u_BC[i]);
 
@@ -2002,6 +2016,7 @@ rd_bc_specs(FILE *ifp,
 
           SPF(endofstring(echo_string)," %d", BC_Types[ibc].BC_Data_Int[0]);
           SPF_DBL_VEC(endofstring(echo_string),7, BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 7;
           break;
 
           /*
@@ -2033,6 +2048,7 @@ rd_bc_specs(FILE *ifp,
 
           SPF(endofstring(echo_string)," %d", BC_Types[ibc].BC_Data_Int[0]);
           SPF_DBL_VEC(endofstring(echo_string),8, BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 8;
           break;
 
           /*
@@ -2065,6 +2081,7 @@ rd_bc_specs(FILE *ifp,
 
           SPF(endofstring(echo_string)," %d", BC_Types[ibc].BC_Data_Int[0]);
           SPF_DBL_VEC(endofstring(echo_string),9, BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 9;
           break;
 
           /*
@@ -2096,6 +2113,7 @@ rd_bc_specs(FILE *ifp,
 
           SPF(endofstring(echo_string)," %d", BC_Types[ibc].BC_Data_Int[0]);
           SPF_DBL_VEC(endofstring(echo_string),10, BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 10;
           break;
 
         case YFLUX_BV2_BC:
@@ -2122,6 +2140,7 @@ rd_bc_specs(FILE *ifp,
 
 	  SPF(endofstring(echo_string)," %d", BC_Types[ibc].BC_Data_Int[0]);
 	  SPF_DBL_VEC(endofstring(echo_string),9, BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 9;
 
           break;
 
@@ -2143,6 +2162,7 @@ rd_bc_specs(FILE *ifp,
 
 	  SPF(endofstring(echo_string)," %d", BC_Types[ibc].BC_Data_Int[0]);
 	  SPF_DBL_VEC(endofstring(echo_string),2, BC_Types[ibc].BC_Data_Float);
+          BC_Types[ibc].max_DFlt = 2;
 
           break;
 	  
@@ -2863,6 +2883,7 @@ rd_bc_specs(FILE *ifp,
 		  EH(-1, err_msg);
 		}
 	      SPF_DBL_VEC(endofstring(echo_string), 1, BC_Types[ibc].BC_Data_Float);
+              BC_Types[ibc].max_DFlt = 1;
 	      break;
 	    case GD_LINEAR_BC:
 	    case GD_INVERSE_BC:
@@ -2877,6 +2898,7 @@ rd_bc_specs(FILE *ifp,
 		  EH(-1, err_msg);
 		}
 
+              BC_Types[ibc].max_DFlt = 2;
 	      SPF_DBL_VEC(endofstring(echo_string), 2, BC_Types[ibc].BC_Data_Float);
 	      break;
 	    case GD_PARAB_BC:
@@ -2893,6 +2915,7 @@ rd_bc_specs(FILE *ifp,
 		  EH(-1, err_msg);
 		}
 
+              BC_Types[ibc].max_DFlt = 3;
 	      SPF_DBL_VEC(endofstring(echo_string), 3, BC_Types[ibc].BC_Data_Float);
 
 	      break;
@@ -2910,6 +2933,7 @@ rd_bc_specs(FILE *ifp,
 		  EH(-1, err_msg);
 		}
 
+              BC_Types[ibc].max_DFlt = 4;
 	      SPF_DBL_VEC(endofstring(echo_string), 4, BC_Types[ibc].BC_Data_Float);
 
 	      break;
@@ -2931,6 +2955,7 @@ rd_bc_specs(FILE *ifp,
 		  EH(-1, err_msg);
 		}
 
+              BC_Types[ibc].max_DFlt = 7;
 	      SPF_DBL_VEC(endofstring(echo_string), 7, BC_Types[ibc].BC_Data_Float);
 	      break;
 
@@ -2947,6 +2972,7 @@ rd_bc_specs(FILE *ifp,
 				   BC_Types[ibc].BC_ID);
 		      EH(-1, err_msg);
 		    }
+                  BC_Types[ibc].max_DFlt = 2;
 		  SPF_DBL_VEC(endofstring(echo_string), 2, BC_Types[ibc].BC_Data_Float);
 		}
 	      else
@@ -3251,6 +3277,31 @@ rd_bc_specs(FILE *ifp,
       BC_consistency( &BC_Types[ibc] );
 
       ECHO(echo_string, echo_file);
+
+      /* check hunting BC data floats for out-of-bounds*/
+      if(nHC)
+       {
+       for(i=0 ; i<nHC ; i++)
+         {
+         if(hunt[i].Type == 1 && hunt[i].BCID == ibc)
+             {
+              if(hunt[i].DFID >= BC_Types[ibc].max_DFlt)
+                  WH(-1,"Whoa.... hunting data float outside range\n");
+             }
+         }
+       }
+      /* check loca BC data floats for out-of-bounds*/
+      if(nCC)
+       {
+       for(i=0 ; i<nCC ; i++)
+         {
+         if(cpcc[i].Type == 1 && cpcc[i].BCID == ibc)
+             {
+              if(cpcc[i].DFID >= BC_Types[ibc].max_DFlt)
+                  WH(-1,"Whoa.... loca data float outside range\n");
+             }
+         }
+       }
 
     }
 


### PR DESCRIPTION
Enabled checking of the continuation parameter BC data float identity to make sure it is in-bounds.  i.e. prevents unintentional over-writing during the continuation process.