### PR TITLE
Fix checkfinite macro for newer compilers, add missing checkfinite guard

### DIFF
--- a/include/mm_fill.h
+++ b/include/mm_fill.h
@@ -99,7 +99,7 @@ PROTO((double pf_constraint,
 #if  defined (CHECK_FINITE)  || defined (DEBUG_NAN) || defined (DEBUG_INF)
 #define CHECKFINITE(MESSAGE)	checkfinite(__FILE__, __LINE__, MESSAGE)
 #else
-#define CHECKFINITE(MESSAGE)	{}
+#define CHECKFINITE(MESSAGE)	0
 #endif
 
 #endif /* _MM_FILL_H */

--- a/src/mm_fill.c
+++ b/src/mm_fill.c
@@ -2285,7 +2285,9 @@ matrix_fill(
 	      if ( ls->Length_Scale == 0. || Do_Overlap )
 		{
 		  apply_embedded_bc( ielem, x, delta_t, theta, time_value, &pg_data, -1, NULL, NULL, NULL, exo );
+#ifdef CHECK_FINITE
 		  err = CHECKFINITE("apply_embedded_bc"); 
+#endif
 		  if (err) return -1;
 		}
 	      else


### PR DESCRIPTION
For when goma is compiled without checkfinite defined