### PR TITLE
Finite Differencing upgrade & extraneous print

### DIFF
--- a/include/std.h
+++ b/include/std.h
@@ -233,6 +233,10 @@
 #ifndef DBL_MAX
 #define DBL_MAX 1.0E300
 #endif
+/* finite difference stepsize  */
+#ifndef FD_FACTOR
+#define FD_FACTOR 1.0E-05
+#endif
 
 /*
  * This definition has a result of true if the double precision argument is

--- a/src/ac_loca_interface.c
+++ b/src/ac_loca_interface.c
@@ -1055,7 +1055,6 @@ int do_loca (Comm_Ex *cx,  /* array of communications structures */
 
   /* This is for a single steady state followed by LSA */
     case LOCA_LSA_ONLY:
-fprintf(stderr,"LOCA LSA ONLY\n");
       con.general_info.method = LOCA_LSA_ONLY;
       con.general_info.param = 0.0;
       con.stepping_info.max_steps = 0;

--- a/src/bc_contact.c
+++ b/src/bc_contact.c
@@ -1267,9 +1267,9 @@ apply_embedded_bc (
     }
     
   fplus = 0.8 * fmax;
-  if ( fplus > 1.e-4 * h_elem ) fplus = 1.e-4 * h_elem;
+  if ( fplus > FD_FACTOR * h_elem ) fplus = FD_FACTOR * h_elem;
   fminus = 0.8 * fmin;
-  if ( fminus < -1.e-4 * h_elem ) fminus = -1.e-4 * h_elem;
+  if ( fminus < -FD_FACTOR * h_elem ) fminus = -FD_FACTOR * h_elem;
   
 #if 0
   if ( fplus > -fminus )

--- a/src/bc_special.c
+++ b/src/bc_special.c
@@ -1630,9 +1630,9 @@ apply_sharp_integrated_bc(
     }
     
   fplus = 0.8 * fmax;
-  if ( fplus > 1.e-4 * h_elem ) fplus = 1.e-4 * h_elem;
+  if ( fplus > FD_FACTOR * h_elem ) fplus = FD_FACTOR * h_elem;
   fminus = 0.8 * fmin;
-  if ( fminus < -1.e-4 * h_elem ) fminus = -1.e-4 * h_elem;
+  if ( fminus < -FD_FACTOR * h_elem ) fminus = -FD_FACTOR * h_elem;
   
 #if 0
   if ( fplus > -fminus )

--- a/src/mm_augc_util.c
+++ b/src/mm_augc_util.c
@@ -1224,7 +1224,7 @@ user_aug_cond(int iAC,
   const int Jac_state = af->Assemble_Jacobian;
 
   double p_save, dp_save = 0.0;
-  double fd_factor=1.0E-05;
+  double fd_factor=FD_FACTOR;
 
   double *res_p, *res_m, xm, *x = mf_args->x;
  
@@ -1278,7 +1278,7 @@ user_aug_cond(int iAC,
       p_save = x_AC[iAC];
       /*  */
       dp_save = fd_factor*p_save;
-      dp_save = dp_save == 0.0 ? fd_factor : dp_save;
+      dp_save = (fabs(dp_save) < fd_factor ? fd_factor : dp_save);
       /*  */
       x_AC[iAC] = p_save+dp_save;
 
@@ -1436,7 +1436,7 @@ user_aug_cond(int iAC,
 	  p_save = x_AC[jAC];
 	  
 	  dp_save = fd_factor*p_save;
- 	  dp_save = dp_save == 0.0 ? fd_factor : dp_save;
+          dp_save = (fabs(dp_save) < fd_factor ? fd_factor : dp_save);
 	  /*  */
 	  x_AC[jAC] = p_save+dp_save;
 
@@ -2166,7 +2166,7 @@ estimate_bAC(  int iAC,
 	       MF_Args *mf_args)
 {
   double p_save, dp_save;
-  double fd_factor=1.0E-05;
+  double fd_factor=FD_FACTOR;
 
   double *res_p, *res_m, xm;
   int  err=-99;
@@ -2178,7 +2178,7 @@ estimate_bAC(  int iAC,
   p_save = x_AC[iAC];
       /*  */
   dp_save = fd_factor*p_save;
-  dp_save = dp_save == 0.0 ? fd_factor : dp_save;
+  dp_save = (fabs(dp_save) < fd_factor ? fd_factor : dp_save);
 	  /*  */
   x_AC[iAC] = p_save+dp_save;
 
@@ -2303,7 +2303,7 @@ estimate_dAC_LSvel(  int iAC,
   static char *yo = "estimate_dAC";
 
   double p_save, dp_save;
-  double fd_factor=1.0E-05;
+  double fd_factor=FD_FACTOR;
 
   double inventory_p, inventory_m, xm, *x = mf_args->x;
   /*  int ielem, err=-99;
@@ -2322,7 +2322,7 @@ estimate_dAC_LSvel(  int iAC,
 	  p_save = x_AC[jAC];
       
 	  dp_save = fd_factor*p_save;
-	  dp_save = dp_save == 0.0 ? fd_factor : dp_save;
+          dp_save = (fabs(dp_save) < fd_factor ? fd_factor : dp_save);
 	  /*  */
 
 	  x_AC[jAC] = p_save+dp_save;
@@ -2376,7 +2376,7 @@ estimate_dAC_ALC(int iAC,
  */
 {
   double p_save, dp_save;
-  double fd_factor=1.0E-05;
+  double fd_factor=FD_FACTOR;
 
   double *res_p, *res_m,  *x = mf_args->x, *xdot = mf_args->xdot;
   int jAC;
@@ -2397,7 +2397,7 @@ estimate_dAC_ALC(int iAC,
 /* Set perturbation to continuation parameter (in x_AC) */
   p_save = x_AC[iAC];
   dp_save = fd_factor * p_save;
-  if (p_save == 0.0) dp_save = fd_factor;
+  dp_save = (fabs(dp_save) < fd_factor ? fd_factor : dp_save);
 
 /* Apply positive perturbation */
   x_AC[iAC] = p_save + dp_save;

--- a/src/mm_input.c
+++ b/src/mm_input.c
@@ -4764,6 +4764,7 @@ rd_ac_specs(FILE *ifp,
                 if( fscanf(ifp,"%lf",&augc_initial_value[iAC]) != 1 )
                       {
           fprintf(stderr,"%s:\tError reading augc_initial_value[%d]\n", yo, iAC);
+          fprintf(stderr,"\tAdd AC value after initialize?\n");
                       }
               }
         }

--- a/src/mm_sol_nonlinear.c
+++ b/src/mm_sol_nonlinear.c
@@ -3389,7 +3389,7 @@ soln_sens ( double lambda,  /*  parameter */
   double time_local =0.0;
   double time_global=0.0;
 
-  double fd_factor=1.0E-06;	/*  finite difference step */
+  double fd_factor=FD_FACTOR;	/*  finite difference step */
 
 #ifdef LOG_HUNTING_PLEASE
   int		log_hunt = TRUE;
@@ -3425,8 +3425,7 @@ soln_sens ( double lambda,  /*  parameter */
   a_start = ut();
 
   dlambda = fd_factor*lambda;
-  if (dlambda == 0.0) 
-    { dlambda = fd_factor; }
+  dlambda = (fabs(dlambda) < fd_factor ? fd_factor : dlambda);
 
   /*
    * GET RESIDUAL SENSITIVITY


### PR DESCRIPTION
Bugfix for AC conditions when x_AC is near zero but not zero, i.e. before FD steps on the order of 10E-200 were allowed resulting in singular AC matrices.  I consolidated most finite difference steps with a FD_FACTOR define in std.h.  Also removed an extraneous print statement from a previous commit.

GUTS results were the same except for p_lub_pore which now converges faster - good thing?