### PR TITLE
Added Lame MU CONTACT_LINE2 model.

### DIFF
--- a/include/mm_mp_const.h
+++ b/include/mm_mp_const.h
@@ -355,11 +355,12 @@ extern int Num_Var_Init_Mat[MAX_NUMBER_MATLS];	/* number of variables to overwri
 /* Modulus parameters */
 /*#define POWER_LAW    4  - defined rf_fem_const.h*/
 #define CONTACT_LINE    5
+#define CONTACT_LINE2   11
 #define SHEAR_HARDEN    6
 #define EXPONENTIAL     7
 #define DENSE_POWER_LAW 8
 #define POISSON_RATIO   9
-#define SHRINKAGE      10
+#define SHRINKAGE       10
 
 /* Diffusion Constitutive equation parameters */
 #define FICKIAN	3
@@ -609,6 +610,8 @@ extern int Num_Var_Init_Mat[MAX_NUMBER_MATLS];	/* number of variables to overwri
 #define TAGC_LAME_MU_CONTACT_LINE_G0       6001
 #define TAGC_LAME_MU_CONTACT_LINE_G1       6002
 #define TAGC_LAME_MU_CONTACT_LINE_R0       6003
+#define TAGC_LAME_MU_CONTACT_LINE_G2       6004
+#define TAGC_LAME_MU_CONTACT_LINE_R1       6005
 #define TAGC_LAME_LAMBDA                   6100
 #define TAGC_BEND_STIFFNESS                6110
 #define TAGC_CONV_LAG_VELX                 6201

--- a/include/rf_solve.h
+++ b/include/rf_solve.h
@@ -91,6 +91,7 @@ extern void bc_matrl_index(Exo_DB *);
 extern int find_MaxMatrlPerNode(void);
 extern void setup_external_nodal_matrls(Exo_DB *, Dpi *, Comm_Ex *);
 extern int create_periodic_acs(Exo_DB *);
+extern void check_nodesets_on_lame_mu_contact_line_models(Dpi *);
 
 /*
  * main.c function prototypes

--- a/src/ac_update_parameter.c
+++ b/src/ac_update_parameter.c
@@ -728,15 +728,23 @@ update_MT_parameter(double lambda, /* Parameter value */
       break;
 
     case TAGC_LAME_MU_CONTACT_LINE_G0:
-      *(elc_glob[mn]->u_mu+1) = lambda;
+      elc_glob[mn]->u_mu[1] = lambda;
       break;
 
     case TAGC_LAME_MU_CONTACT_LINE_G1:
-      *(elc_glob[mn]->u_mu+2) = lambda;
+      elc_glob[mn]->u_mu[2] = lambda;
       break;
 
     case TAGC_LAME_MU_CONTACT_LINE_R0:
-      *(elc_glob[mn]->u_mu+3) = lambda;
+      elc_glob[mn]->u_mu[3] = lambda;
+      break;
+
+    case TAGC_LAME_MU_CONTACT_LINE_G2:
+      elc_glob[mn]->u_mu[5] = lambda;
+      break;
+
+    case TAGC_LAME_MU_CONTACT_LINE_R1:
+      elc_glob[mn]->u_mu[6] = lambda;
       break;
 
     case TAGC_LAME_LAMBDA:
@@ -1531,15 +1539,23 @@ retrieve_MT_parameter(double *lambda, /* Parameter value */
       break;
 
     case TAGC_LAME_MU_CONTACT_LINE_G0:
-      *lambda = *(elc_glob[mn]->u_mu+1);
+      *lambda = elc_glob[mn]->u_mu[1];
       break;
 
     case TAGC_LAME_MU_CONTACT_LINE_G1:
-      *lambda = *(elc_glob[mn]->u_mu+2);
+      *lambda = elc_glob[mn]->u_mu[2];
       break;
 
     case TAGC_LAME_MU_CONTACT_LINE_R0:
-      *lambda = *(elc_glob[mn]->u_mu+3);
+      *lambda = elc_glob[mn]->u_mu[3];
+      break;
+
+    case TAGC_LAME_MU_CONTACT_LINE_G2:
+      *lambda = elc_glob[mn]->u_mu[5];
+      break;
+
+    case TAGC_LAME_MU_CONTACT_LINE_R1:
+      *lambda = elc_glob[mn]->u_mu[6];
       break;
 
     case TAGC_LAME_LAMBDA:

--- a/src/mm_augc_util.c
+++ b/src/mm_augc_util.c
@@ -448,15 +448,23 @@ load_extra_unknownsAC(int iAC,    /* ID NUMBER OF AC'S */
 	break;
 
       case TAGC_LAME_MU_CONTACT_LINE_G0:
-	xa[iAC] = *(elc_glob[mn]->u_mu+1);
+	xa[iAC] = elc_glob[mn]->u_mu[1];
 	break;
 
       case TAGC_LAME_MU_CONTACT_LINE_G1:
-	xa[iAC] = *(elc_glob[mn]->u_mu+2);
+	xa[iAC] = elc_glob[mn]->u_mu[2];
 	break;
 
       case TAGC_LAME_MU_CONTACT_LINE_R0:
-	xa[iAC] = *(elc_glob[mn]->u_mu+3);
+	xa[iAC] = elc_glob[mn]->u_mu[3];
+	break;
+
+      case TAGC_LAME_MU_CONTACT_LINE_G2:
+	xa[iAC] = elc_glob[mn]->u_mu[5];
+	break;
+
+      case TAGC_LAME_MU_CONTACT_LINE_R1:
+	xa[iAC] = elc_glob[mn]->u_mu[6];
 	break;
 
       case TAGC_LAME_LAMBDA:
@@ -1180,15 +1188,23 @@ update_parameterAC(int iAC,      /* ID NUMBER OF The AC */
 	break;
 
       case TAGC_LAME_MU_CONTACT_LINE_G0:
-	*(elc_glob[mn]->u_mu+1) = lambda;
+	elc_glob[mn]->u_mu[1] = lambda;
 	break;
 
       case TAGC_LAME_MU_CONTACT_LINE_G1:
-	*(elc_glob[mn]->u_mu+2) = lambda;
+	elc_glob[mn]->u_mu[2] = lambda;
 	break;
 
       case TAGC_LAME_MU_CONTACT_LINE_R0:
-	*(elc_glob[mn]->u_mu+3) = lambda;
+	elc_glob[mn]->u_mu[3] = lambda;
+	break;
+
+      case TAGC_LAME_MU_CONTACT_LINE_G2:
+	elc_glob[mn]->u_mu[5] = lambda;
+	break;
+
+      case TAGC_LAME_MU_CONTACT_LINE_R1:
+	elc_glob[mn]->u_mu[6] = lambda;
 	break;
 
       case TAGC_LAME_LAMBDA:

--- a/src/mm_input_mp.c
+++ b/src/mm_input_mp.c
@@ -895,6 +895,21 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 	    }
 	  elc_glob[mn]->len_u_mu = num_const;	  
 	}
+      else if ( !strcmp(model_name, "CONTACT_LINE2"))
+	{
+	  elc_glob[mn]->lame_mu_model = CONTACT_LINE2;
+	  num_const = read_constants(imp, &(elc_glob[mn]->u_mu), NO_SPECIES);
+	  if ( num_const < 7) 
+	    {
+	      sr = sprintf(err_msg, 
+		   "Matl %s expected at least 7 constants for %s %s model.\n",
+			   pd_glob[mn]->MaterialName, 
+			   "Lame MU", 
+			   "CONTACT_LINE2");
+	      EH(-1, err_msg);
+	    }
+	  elc_glob[mn]->len_u_mu = num_const;	  
+	}
       else if ( !strcmp(model_name, "SHEAR_HARDEN"))
 	{
 	  elc_glob[mn]->lame_mu_model = SHEAR_HARDEN;
@@ -1392,6 +1407,22 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 			       pd_glob[mn]->MaterialName, 
 			       "Lame MU", 
 			       "CONTACT_LINE");
+		  EH(-1, err_msg);
+		}
+	      elc_glob[mn]->len_u_mu = num_const;	
+	      SPF_DBL_VEC(endofstring(es), num_const,elc_glob[mn]->u_mu );
+	    }
+	  else if ( !strcmp(model_name, "CONTACT_LINE2"))
+	    {
+	      elc_glob[mn]->lame_mu_model = CONTACT_LINE2;
+	      num_const = read_constants(imp, &(elc_glob[mn]->u_mu), NO_SPECIES);
+	      if ( num_const < 7) 
+		{
+		  sr = sprintf(err_msg, 
+			       "Matl %s expected at least 7 constants for %s %s model.\n",
+			       pd_glob[mn]->MaterialName, 
+			       "Lame MU", 
+			       "CONTACT_LINE2");
 		  EH(-1, err_msg);
 		}
 	      elc_glob[mn]->len_u_mu = num_const;	


### PR DESCRIPTION

Based on the Lame CONTACT_LINE model, this adds a second region of localized mesh stiffening. It makes mu (shear modulus) become very large near two critical points, and decay to a lower value radially from those points. This helps keep elements near the critical points from shearing excessively while elements far away won't dilate much.

The model is applied in the material file under the "Lame MU" card as "CONTACT_LINE2" and has 7 inputs:
Lame MU = CONTACT_LINE2 {float1} {float2} {float3} {float4} {float5} {float6} {float7}
{float1} node set number for point one
{float2} minimum value of the shear modulus
{float3} maximum value of the shear modulus for point one
{float4} decay length for point one
{float5} node set number for point two
{float6} maximum value of the shear modulus for point two
{float7} decay length for point two