### PR TITLE
Move setting of STRESS_CONT to index_post to after it is checked

### DIFF
--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -8208,11 +8208,13 @@ load_nodal_tkn (struct Results_Description *rd, int *tnv, int *tnv_post)
 
   if (STRESS_CONT != -1 && (Num_Var_In_Type[POLYMER_STRESS11]  ))
     {
+      int index_post_save = index_post;
+
       if (STRESS_CONT == 2)
         {
           EH(-1, "Post-processing vectors cannot be exported yet!");
         }
-      STRESS_CONT = index_post;
+
       for ( mode=0; mode<MAX_MODES; mode++)
 	{
 	  for ( a=0; a<VIM; a++)
@@ -8241,6 +8243,8 @@ load_nodal_tkn (struct Results_Description *rd, int *tnv, int *tnv_post)
 		}
 	    }
 	}
+
+      STRESS_CONT = index_post_save;
 
       check = 0;
       for (i = 0; i < upd->Num_Mat; i++)


### PR DESCRIPTION
This fixes a bug in the post processing "Stress contours". There was a check of STRESS_CONT == 2 after it was set to index_post.

This moves setting of STRESS_CONT to the initial index_post until after it is checked.

This came up in a multimode problem where index_post happened to be set to 2 when it got to STRESS_CONT, the code was executing as if STRESS_CONT was an external field in

                           if (STRESS_CONT == 2)
                             {
                               Export_XP_ID[index_post_export] = index_post;
                               index_post_export++;
                             }