### PR TITLE
MPI_Barrier Addition for automatic fix

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -867,6 +867,10 @@ main(int argc, char **argv)
     break;
   }
 
+#ifdef PARALLEL
+   MPI_Barrier(MPI_COMM_WORLD);
+#endif
+
   if (ProcID == 0 && Brk_Flag == 1 && Num_Proc > 1) {
     fix_output();
   }


### PR DESCRIPTION
MPI_Barrier addition in main.c before call to fix_output. This ensures that the Exodus output file has contributions from all processors.