### PR TITLE
Fixed log-conformation terms in FLOW_STRESSNOBC

### DIFF
--- a/src/mm_ns_bc.c
+++ b/src/mm_ns_bc.c
@@ -6731,7 +6731,7 @@ flow_n_dot_T_nobc(double func[DIM],
 	    }
 	}
 
-      if ( pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F) )
+      if ( pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F || vn->evssModel == LOG_CONF) )
 	{
 	  for (p=0; p<pd->Num_Dim; p++)
 	    {
@@ -6744,7 +6744,7 @@ flow_n_dot_T_nobc(double func[DIM],
 			  var = v_g[b][c];
 			  for ( j=0; j<ei->dof[var]; j++)
 			    {
-			      d_func[p][var][j] += fv->snormal[q]*d_Pi->g[p][q][b][c][j];
+			      d_func[p][var][j] -= fv->snormal[q]*d_Pi->g[p][q][b][c][j];
 			    }
 			}
 		    }


### PR DESCRIPTION
Fixes for the log-conformation tensor for the boundary condition FLOW_STRESSNOBC, in the function flow_n_dot_T_nobc.