### PR TITLE
Fix SEACAS deprecated and some compiler warnings

### DIFF
--- a/include/dp_types.h
+++ b/include/dp_types.h
@@ -87,6 +87,7 @@ struct Derived_Datatype_Description
   MPI_Datatype  new_type;
 
   MPI_Aint extent;              /* extent of new derived data type */
+  MPI_Aint lb;
   /*  int count;                        count of new derived data type */
   int size;                     /* size of new derived data type */
 };    

--- a/include/std.h
+++ b/include/std.h
@@ -374,10 +374,12 @@ typedef int MPI_Aint;
 
 #ifdef PARALLEL
 #  define DPRINTF if ( ProcID == 0 ) fprintf
+#  define DFPUTS if ( ProcID == 0 ) fputs
 #  define P0PRINTF if (ProcID == 0) printf
 #else
 #  define DPRINTF fprintf
 #  define P0PRINTF printf
+#  define DFPUTS fputs
 #endif
 
 

--- a/src/ac_hunt.c
+++ b/src/ac_hunt.c
@@ -157,7 +157,8 @@ hunt_problem(Comm_Ex *cx,	/* array of communications structures */
   double	*gvec=NULL;
   double        ***gvec_elem;
   FILE          *file=NULL;
-  double 	toler_org[3],damp_org;
+  double 	toler_org[3];
+  /*  double damp_org; */
   
   struct Results_Description  *rd=NULL;
   
@@ -192,7 +193,7 @@ hunt_problem(Comm_Ex *cx,	/* array of communications structures */
   toler_org[0] = custom_tol1;
   toler_org[1] = custom_tol2;
   toler_org[2] = custom_tol3;
-  damp_org = damp_factor1;
+  /* damp_org = damp_factor1; */
 
   is_steady_state = TRUE;
 

--- a/src/ac_particles.c
+++ b/src/ac_particles.c
@@ -5639,12 +5639,16 @@ load_restart_file(void)
   zero_a_particle(&p);
   while(!feof(fp))
     {
+      char *fgetserr;
       for(i = 0; i < pdim; i++)
 	if(fscanf(fp, "%lf ", &p.x[i]) != 1)
 	  continue;		/* probable EOF */
       if(fscanf(fp, "%lf %d", &p.time, &p.owning_elem_id) != 2)
 	continue;		/* probable EOF */
-      fgets(garbage, 254, fp);
+      fgetserr = fgets(garbage, 254, fp);
+      if (fgetserr == NULL) {
+	EH(-1, "Error reading line in particle restart file");
+      }
       if(get_element_xi_newton(p.owning_elem_id, p.x, p.xi) == -1)
 	EH(-1, "Could not place particle from restart.");
       load_field_variables_at_xi(p.owning_elem_id, p.xi);

--- a/src/bc_colloc.c
+++ b/src/bc_colloc.c
@@ -839,12 +839,18 @@ f_roll_fluid (int ielem_dim,
   double omega,v_dir[3], v_roll[3];
   double velo_avg = 0.0,  pgrad=0.;
   double v_solid=0., res, jac, delta, flow, eps=1.0e-8, viscinv;
-  double jacinv, thick, dthick_dV, dthick_dP;
+  double jacinv, thick;
+#if 0
+  double dthick_dV, dthick_dP;
+#endif
   int Pflag = TRUE;
-  double cur_pt[3]={0,0,0};
   double pg_factor=1.0, tang_sgn=1.0, v_mag=0.;;
 
-  int j,var,jvar,k;
+  int j,var;
+
+#if 0
+  int jvar, k;
+#endif
 
   if(af->Assemble_LSA_Mass_Matrix)
     return;
@@ -973,8 +979,10 @@ if(dist < 10)fprintf(stderr,"roll_fl %g %g %g\n",fv->x0[0],xsurf[0],dist);
          thick += delta;
          j++;
         } while(fabs(delta) > eps && j<20);
-      dthick_dV = -0.5*jacinv;     /*  1/h*derivative  */
-      dthick_dP = CUBE(thick)*viscinv/12.*jacinv;
+#if 0
+     dthick_dV = -0.5*jacinv;     /*  1/h*derivative  */
+     dthick_dP = CUBE(thick)*viscinv/12.*jacinv;
+#endif
 #if 0
 fprintf(stderr,"slip %d %g %g %g %g\n",Pflag,fv->x[0],thick,flow/v_solid,velo_avg);
 fprintf(stderr,"more %g %g %g %g\n",res,jac, dthick_dV,dthick_dP);

--- a/src/brkfix/brk_exo_file.c
+++ b/src/brkfix/brk_exo_file.c
@@ -4222,24 +4222,24 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
 				   &mono->io_wordsize, 
 				   &mono->version);
 
-	status = ex_put_var_names(E->exoid, "g", mono->num_glob_vars,
-				  mono->glob_var_names);
-	EH(status, "ex_put_var_names(g)");
+	status = ex_put_variable_names(E->exoid, EX_GLOBAL, mono->num_glob_vars,
+				       mono->glob_var_names);
+	EH(status, "ex_put_variable_names global");
 
 	alloc_exo_gv(mono, 1);
 
 
 	for (i = 0; i < mono->num_gv_time_indeces; i++) {
-	  status = ex_get_glob_vars(mono->exoid, i+1,
-				    mono->num_glob_vars,
-				    mono->gv[0]);
-	  EH(status, "ex_put_glob_vars");
+	  status = ex_get_var(mono->exoid, i+1, EX_GLOBAL,
+			      1, 1, mono->num_glob_vars,
+			      mono->gv[0]);
+	  EH(status, "ex_get_var global");
 
 	  
-	  status = ex_put_glob_vars(E->exoid, i+1,
-				    mono->num_glob_vars,
+	  status = ex_put_var(E->exoid, i+1, EX_GLOBAL,
+			      1, 0, mono->num_glob_vars,
 				    mono->gv[0]);
-	  EH(status, "ex_put_glob_vars");
+	  EH(status, "ex_put_var glob_vars");
 	}
 
 	

--- a/src/brkfix/fix_exo_file.c
+++ b/src/brkfix/fix_exo_file.c
@@ -501,17 +501,17 @@ fix_exo_file(int num_procs, char* exo_mono_name)
 	/*status = ex_put_var_param(mono->exoid, "g", mono->num_glob_vars);
 	EH(status, "ex_put_var_param(g)");
 	*/
-	status = ex_put_var_names(mono->exoid, "g", mono->num_glob_vars,
-				  mono->glob_var_names);
-	EH(status, "ex_put_var_names(g)");
+	status = ex_put_variable_names(mono->exoid, EX_GLOBAL, mono->num_glob_vars,
+				       mono->glob_var_names);
+	EH(status, "ex_put_variable_names global");
 
 
 
 	for (i = 0; i < mono->num_gv_time_indeces; i++) {
-	  status = ex_put_glob_vars(mono->exoid, mono->gv_time_indeces[i],
-			   mono->num_glob_vars,
-			   mono->gv[i]);
-	  EH(status, "ex_put_glob_vars");
+	  status = ex_put_var(mono->exoid, mono->gv_time_indeces[i], EX_GLOBAL,
+			      1, 0, mono->num_glob_vars,
+			      mono->gv[i]);
+	  EH(status, "ex_put_var global vars");
 	}
 
 	status = ex_close(mono->exoid);

--- a/src/brkfix/ppi.c
+++ b/src/brkfix/ppi.c
@@ -62,11 +62,12 @@ brk_pre_process(char *fn)
   int err2=0;
 
   char * tmp;
+  char * fgetserr;
 
   if ( ( infile = fopen( fn, "r" ) ) == NULL )
     {
       sprintf( buffer, "Error opening input file: %s\n", fn );
-      fprintf(stdout, buffer );
+      fputs(buffer, stdout);
       fflush( stdout );
       exit(1);
     }
@@ -85,7 +86,7 @@ brk_pre_process(char *fn)
     {
       sprintf( buffer,
                "Error opening temporary input file: %s\n", nfn );
-      fprintf(stdout,buffer);
+      fputs(buffer, stdout);
       fflush( stdout );
       exit(1);
     }
@@ -97,8 +98,8 @@ brk_pre_process(char *fn)
 
   for( k=0; k< 80; ++k ) buffer[k] = '\0';
 
-  fgets( in_buffer, 80, infile );
-  while( feof( infile ) == 0 )
+  fgetserr = fgets( in_buffer, 80, infile );
+  while( feof( infile ) == 0 && fgetserr != NULL)
     {
       str1[0] = in_buffer[0];
       while( strcmp( str1, blank_string ) == 0 ||
@@ -142,11 +143,11 @@ brk_pre_process(char *fn)
         }
         str1[0] = buffer[0];
         if( strcmp( str1,"\n" ) != 0 ) {     /* save the line to temp file */
-          fprintf( temp_file, buffer );
+	  fputs(buffer, temp_file);
           for( k=0; k< 80; ++k ) buffer[k] = '\0';
         }
       }   /* end blank line check  and  comment line check */
-      fgets( in_buffer, 80, infile );
+      fgetserr = fgets( in_buffer, 80, infile );
     }   /* end of eof while */
 
   err1 = fclose( infile );

--- a/src/brkfix/utils.c
+++ b/src/brkfix/utils.c
@@ -505,6 +505,7 @@ get_filename_num_procs(const char *basename)
   char fixXXXXXX[] = "/tmp/fileXXXXXX";
   FILE *s;
   int val=-1;
+  int err;
   strcpy(fixXXXXXX,"./fileXXXXXX");
 
   if( mkstemp( fixXXXXXX ) == -1 ) {
@@ -535,7 +536,8 @@ get_filename_num_procs(const char *basename)
    *  Ok, delete the temporary file
    */
   sprintf(string_system_command, "/bin/rm -f %s", fixXXXXXX );
-  system(string_system_command);
+  err = system(string_system_command);
+  EH(err, "Error running /bin/rm -f ");
 
 
   return val;

--- a/src/dp_utils.c
+++ b/src/dp_utils.c
@@ -291,7 +291,7 @@ ddd_add_member(DDD p,
   /*
    *  This is just the identity operator on most systems
    */
-  MPI_Address(address, &p->address[i]);
+  MPI_Get_address(address, &p->address[i]);
 #ifdef DEBUG
    /* the check below does not work on dec or tflop */
   if ((int) address != p->address[i]) {
@@ -320,10 +320,10 @@ void
 ddd_set_commit(DDD p)
 {
 #ifdef PARALLEL
-  MPI_Type_struct(p->num_members, p->block_count, p->address,
+  MPI_Type_create_struct(p->num_members, p->block_count, p->address,
 		  p->data_type, &p->new_type);
   MPI_Type_commit(&p->new_type);
-  MPI_Type_extent(p->new_type, &p->extent);
+  MPI_Type_get_extent(p->new_type, &p->lb, &p->extent);
   MPI_Type_size(p->new_type, &p->size);
   /*  rtn = MPI_Type_count(p->new_type, &p->count); */
 #endif

--- a/src/mm_augc_util.c
+++ b/src/mm_augc_util.c
@@ -812,6 +812,7 @@ update_parameterAC(int iAC,      /* ID NUMBER OF The AC */
  
     if(ibc == APREPRO_AC_BCID)	{
 #ifndef tflop
+      int err;
       FILE *jfp=NULL;
       char cmd_str[80];
       double temp,lambda_user;
@@ -823,7 +824,8 @@ update_parameterAC(int iAC,      /* ID NUMBER OF The AC */
       sprintf(cmd_str,"%s %s %s %s %s %s %.20g","bcdiff.pl"
 	      ,"-p",augc[iAC].Params_File,"-i",Input_File,
 	      augc[iAC].AP_param,lambda);
-      system(cmd_str);
+      err = system(cmd_str);
+      EH(err, "Error could not create process for bcdiff.pl");
  
       augc[iAC].DataFlt[0] = lambda;
 

--- a/src/mm_eh.c
+++ b/src/mm_eh.c
@@ -309,12 +309,12 @@ smooth_stop_with_msg( const char *msg )
 	if( Num_Proc == 1 )
 	{
 		fprintf(stderr, "\n\t -- Goma stops smoothly--\n");
-		fprintf(stderr, msg );
+		fputs(msg, stderr);
 	}
 	else
 	{
 		fprintf(stderr,"\n\n Proc %d -- Goma stops smoothly --\n", ProcID);
-		DPRINTF(stderr, msg);
+		DFPUTS(msg, stderr);
 	}	
 	MPI_Finalize();
 	exit(-1);

--- a/src/mm_fill.c
+++ b/src/mm_fill.c
@@ -3220,7 +3220,7 @@ matrix_fill_stress(
   extern int MMH_ip;
   extern int PRS_mat_ielem;
 
-  double delta_t, theta, time_value, h_elem_avg;  /*see arg list */
+  double delta_t, theta, time_value;  /*see arg list */
   int ielem, num_total_nodes;
   
 #if 0
@@ -3260,7 +3260,7 @@ matrix_fill_stress(
      condition routines */
   int call_rotate;
   int rotate_mesh, rotate_momentum;
-  int assemble_rs, make_trivial = 0; /* Flags for Eulerian solid mechanics
+  int make_trivial = 0; /* Flags for Eulerian solid mechanics
 				    and level-set */
   int bct, mode;
 
@@ -3272,12 +3272,9 @@ matrix_fill_stress(
   double wt = 0.0;              /* Quadrature weights
 				 units - ergs/(sec*cm*K) = g*cm/(sec^3*K)     */
 
-  double ls_F[MDE];		/* local copy for adaptive weights  */
-  double ad_wtpos[10],ad_wtneg[10];	/*adaptive integration weights  */
 
   struct Petrov_Galerkin_Data pg_data;
 
-  struct Porous_Media_Terms pm_terms;  /*Needed up here for Hysteresis switching criterion*/
 
   struct elem_side_bc_struct *elem_side_bc ;
   /* Pointer to an element side boundary condition
@@ -3305,7 +3302,6 @@ matrix_fill_stress(
 
   int pspg_local = 0;
   
-  bool owner = TRUE;
 
   NODE_INFO_STRUCT *node;
   SGRID *element_search_grid=NULL;
@@ -3332,7 +3328,6 @@ matrix_fill_stress(
   time_value	  = *ptr_time_value;
   ielem		  = *ptr_ielem;
   num_total_nodes = *ptr_num_total_nodes;
-  h_elem_avg = pg_data.h_elem_avg	  = *ptr_h_elem_avg;
   pg_data.U_norm	  = *ptr_U_norm;
 
   if (Debug_Flag > 1) {
@@ -3646,7 +3641,6 @@ matrix_fill_stress(
    * the natural stress condition on the intefacial elements.
    */
   /* assemble fake equation for elements off interface */
-  assemble_rs = TRUE;
 
   if (pde[R_SOLID1])
     {
@@ -3672,15 +3666,13 @@ matrix_fill_stress(
 		      if (elem_overlaps_interface( e, x, exo, ls->Length_Scale ))
 			{ 
 			  make_trivial = FALSE;
-			  assemble_rs = FALSE;
-			 
+
 			}
 		    }
 		}
 	    }
 	  if (make_trivial)
 	    {
-	      assemble_rs = FALSE;
 	      for (b=0; b < pd->Num_Dim; b++)
 		{
 		  for (i = 0; i < ei->dof[R_SOLID1 + b]; i++) {

--- a/src/mm_fill_ls.c
+++ b/src/mm_fill_ls.c
@@ -10033,19 +10033,19 @@ subelement_mesh_output (double x[],
   ex_put_elem_num_map( exoid, emap );
   */
 
-  ex_put_elem_block ( exoid, 1, "TRI", nvelems, nodes_per_elem, 0 );
-  ex_put_elem_conn ( exoid, 1, vconn );
+  ex_put_block ( exoid, EX_ELEM_BLOCK, 1, "TRI", nvelems, nodes_per_elem, 0, 0, 0 );
+  ex_put_conn ( exoid, EX_ELEM_BLOCK, 1, vconn, 0, 0 );
   
-  ex_put_elem_block ( exoid, 2, "SHEL", nselems, nodes_per_side, 0 );
-  ex_put_elem_conn ( exoid, 2, sconn );
+  ex_put_block ( exoid, EX_ELEM_BLOCK, 2, "SHEL", nselems, nodes_per_side, 0, 0, 0 );
+  ex_put_conn ( exoid, EX_ELEM_BLOCK, 2, sconn, 0, 0 );
   
   /* dummy nodeset on volume */
-  ex_put_node_set_param( exoid, 1, ivconn, 0 );
-  ex_put_node_set( exoid, 1, vconn );
+  ex_put_set_param( exoid, EX_NODE_SET, 1, ivconn, 0 );
+  ex_put_set( exoid, EX_NODE_SET, 1, vconn, NULL );
 
   /* dummy nodeset on surface */
-  ex_put_node_set_param( exoid, 2, isconn, 0 );
-  ex_put_node_set( exoid, 2, sconn );
+  ex_put_set_param( exoid, EX_NODE_SET, 2, isconn, 0 );
+  ex_put_set( exoid, EX_NODE_SET, 2, sconn, NULL );
   
   /* no data for now */
 

--- a/src/mm_fill_terms.c
+++ b/src/mm_fill_terms.c
@@ -28007,9 +28007,6 @@ fluid_stress_conf( double Pi[DIM][DIM],
     * Vicosity and derivatives, we use this for collecting polymer
     * viscosity terms when considering Non-Newontian fluids
     */
-  dbl mu = 0.0;
-  VISCOSITY_DEPENDENCE_STRUCT d_mu_struct;
-  VISCOSITY_DEPENDENCE_STRUCT *d_mu = &d_mu_struct;
 
   // Polymer viscosity and derivatives, polymer time constant
   dbl mup = 0.0, lambda = 0.0;
@@ -28020,25 +28017,6 @@ fluid_stress_conf( double Pi[DIM][DIM],
   dbl mus = 0.0;
   VISCOSITY_DEPENDENCE_STRUCT d_mus_struct;
   VISCOSITY_DEPENDENCE_STRUCT *d_mus = &d_mus_struct;
-
-  // Numerical "adaptive" viscosity and derivatives
-  dbl mu_num;
-  dbl d_mun_dS[MAX_MODES][DIM][DIM][MDE];
-  dbl d_mun_dG[DIM][DIM][MDE];
-  dbl term1=0.0;
-
-  // Dilational viscosity
-  dbl kappa = 0.0;
-  DILVISCOSITY_DEPENDENCE_STRUCT d_dilMu_struct;
-  DILVISCOSITY_DEPENDENCE_STRUCT *d_dilMu = &d_dilMu_struct;
-  int kappaWipesMu = 1;
-
-  // Shift factor and T dependence
-  dbl at = 0.0;
-  dbl d_at_dT[MDE];
-  //Some convenient viscosity variables
-  dbl wlf_denom;
-  dbl mu_over_mu_num = 0.0;
 
   // conformation tensor
   dbl exp_s[MAX_MODES][DIM][DIM];
@@ -28055,7 +28033,6 @@ fluid_stress_conf( double Pi[DIM][DIM],
 
   dbl *grad_v[DIM];		        // Gradient of v.
   dbl gamma[DIM][DIM];                  // Shear rate tensor based on velocity
-  dbl s[DIM][DIM];                      // Polymer stress tensor
   dbl gamma_cont[DIM][DIM];             // Shear rate tensor based on continuous gradient of velocity
   dbl P;
 
@@ -28064,19 +28041,16 @@ fluid_stress_conf( double Pi[DIM][DIM],
 
   // Flag to use a Fortin DEVSS-G stress formulation
   int evss_f;
-  int use_mup;                          // Flag for mup or mus on DEVSS-G term
+
   int v_s[MAX_MODES][DIM][DIM];
   int v_g[DIM][DIM];
   int mode;                             // Index for modal viscoelastic counter
   int conf;                             // Flag for Conformation tensor
 
   // Flag for doing dilational viscosity contributions
-  int do_dilational_visc = 0;
+
   int dim, wim;
   int a, b, p, q, j, w, c, var;
-  dbl (* grad_phi_e ) [DIM][DIM][DIM] = NULL;
-  int eqn = R_MOMENTUM1;
-
 
   dim   = pd->Num_Dim;
   wim   = dim;
@@ -28107,7 +28081,6 @@ fluid_stress_conf( double Pi[DIM][DIM],
   // If d_Pi == NULL, we won't need the viscosity dependencies
   if(d_Pi == NULL)
     {
-      d_mu  = NULL;
       d_mus = NULL;
       d_mup = NULL;
     }

--- a/src/mm_input.c
+++ b/src/mm_input.c
@@ -2325,10 +2325,14 @@ rd_levelset_specs(FILE *ifp,
 
       if( strcmp(input, "GRID_SEARCH") == 0 )
         {
+	  int err;
 	  EH(-1,"The Level Set Search Option : GRID_SEARCH is not functioning at this time.\n");
 
           ls->Search_Option = GRID_SEARCH;
-          fscanf(ifp,"%d", &(ls->Grid_Search_Depth));
+          err = fscanf(ifp,"%d", &(ls->Grid_Search_Depth));
+	  if (err != 1) {
+	    EH(-1, "Expected to read one int for GRID_SEARCH");
+	  }
 
 	  SPF(endofstring(echo_string)," %d",ls->Grid_Search_Depth);
         }
@@ -6621,6 +6625,7 @@ rd_solver_specs(FILE *ifp,
   
   /* look for optional flags specifying dependencies to ignore */
   {
+    int err;
     int eq, var;
     
     for (eq=0; eq<MAX_VARIABLE_TYPES; eq++)
@@ -6664,7 +6669,12 @@ rd_solver_specs(FILE *ifp,
 	  EH(-1, "Error reading variable type for Ignore Dependency");
 	}
       /* look for optional flag to apply this card in a symmetric manner */
-      fscanf(ifp, "%d",&symmetric_flag);
+      err = fscanf(ifp, "%d",&symmetric_flag);
+
+      errno = 0;
+      if ((err != 0 || err != 1) && (err == EOF && errno != 0)) {
+	EH(-1, "Error reading symmetric flag for Ignore Dependency");
+      }
       
       if ( !strcmp(input, "all") || !strcmp(input, "ALL") )
         {
@@ -11685,7 +11695,7 @@ translate_command_line( int argc,
 		    }
 		  strcat(command_line_ap," ");
 		}
-	      sprintf(aprepro_command, command_line_ap);
+	      sprintf(aprepro_command, "%s", command_line_ap);
 	      strcpy_rtn = strcpy(clc[*nclc]->string, command_line_ap);
 	    } /*end of else if list */
 

--- a/src/mm_input_mp.c
+++ b/src/mm_input_mp.c
@@ -2269,8 +2269,12 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 	} 
       else if ( !strcmp(model_name, "SUPG") )
 	{
+	  int err;
 	  mat_ptr->Mwt_funcModel = SUPG;
-	  fscanf(imp, "%lg",&(mat_ptr->Mwt_func));
+	  err = fscanf(imp, "%lg",&(mat_ptr->Mwt_func));
+	  if (err != 1) {
+	    EH(-1, "Expected to read one double for Momentum Weight Function SUPG");
+	  }
 	  SPF(endofstring(es)," %.4g", mat_ptr->Mwt_func );
 	} 
       else  
@@ -3232,8 +3236,12 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 	} 
       else if ( !strcmp(model_name, "SUPG") )
 	{
+	  int err;
 	  mat_ptr->Ewt_funcModel = SUPG;
-	  fscanf(imp, "%lg",&(mat_ptr->Ewt_func));
+	  err = fscanf(imp, "%lg",&(mat_ptr->Ewt_func));
+	  if (err != 1) {
+	    EH(-1, "Expected to read one double for Energy Weight Function SUPG");
+	  }
 	  SPF(endofstring(es)," %.4g", mat_ptr->Ewt_func );
 	} 
       else  
@@ -5011,8 +5019,12 @@ ECHO("\n----Acoustic Properties\n", echo_file);
 	} 
       else if (!strcmp(model_name, "SUPG")) 
 	{
+	  int err;
 	  mat_ptr->Porous_wt_funcModel = SUPG;
-	  fscanf(imp, "%lg",&(mat_ptr->Porous_wt_func));
+	  err = fscanf(imp, "%lg",&(mat_ptr->Porous_wt_func));
+	  if (err != 1) {
+	    EH(-1, "Expected to read one double for Porous Weight Function SUPG");
+	  }
 	  SPF(endofstring(es)," %.4g", mat_ptr->Porous_wt_func);
 	} 
       else 
@@ -5658,8 +5670,12 @@ ECHO("\n----Acoustic Properties\n", echo_file);
     } 
   else if ( !strcmp(model_name, "SUPG") )
     {
+      int err;
       mat_ptr->Spwt_funcModel = SUPG;
-      fscanf(imp, "%lg",&(mat_ptr->Spwt_func));
+      err = fscanf(imp, "%lg",&(mat_ptr->Spwt_func));
+      if (err != 1) {
+	EH(-1, "Expected to read one double for Species Weight Function SUPG");
+      }
     } 
   else 
     {

--- a/src/mm_numjac.c
+++ b/src/mm_numjac.c
@@ -119,9 +119,8 @@ numerical_jacobian_compute_stress(struct Aztec_Linear_Solver_System *ams,
   of the log-conformation tensor. 
 ******************************************************************************/
 {
-  int i, j, k, l, m, ii, nn, kount, nnonzero, index;
+  int i, j, k, l, m, ii, nnonzero, index;
   int zeroCA;
-  int *ija = ams->bindx;
   double *resid_vector_1, *x_1;
   double dx;
   int *irow, *jcolumn, *nelem;
@@ -147,7 +146,6 @@ numerical_jacobian_compute_stress(struct Aztec_Linear_Solver_System *ams,
 
 /* calculates the total number of non-zero entries in the analytical jacobian, a[] */ 
   nnonzero = NZeros+1;
-  nn = ija[numProcUnknowns]-ija[0]; /* total number of diagonal entries a[] */
 
   /* allocate arrays to hold jacobian and vector values */
   irow = (int *) array_alloc(1, nnonzero, sizeof(int));

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -7314,10 +7314,15 @@ rd_post_process_specs(FILE *ifp,
      */
 
     for (i = 0; i < nn_post_data; i++) {
+      char *fgetsretval;
       look_for(ifp, "DATA", input, '=');
 
       save_position = ftell(ifp);
-      fgets(data_line_buffer, MAX_CHAR_IN_INPUT, ifp);
+      fgetsretval = fgets(data_line_buffer, MAX_CHAR_IN_INPUT, ifp);
+      if (fgetsretval == NULL) {
+	EH(-1, "Error reading post processing line");
+      }
+
       fseek(ifp, save_position, SEEK_SET);
 
       /*

--- a/src/mm_std_models.c
+++ b/src/mm_std_models.c
@@ -5924,9 +5924,18 @@ electrolyte_temperature (double t,         /* present value of time */
           t0 = tran->init_time;
         }
 #ifndef tflop
-            if(t <= t0) system("rm T_vs_t.out");  /* zero the file before writing to it */ 
+      if(t <= t0)
+	{
+	  fp = fopen("T_vs_t.out", "w");
+	}
+      else
+	{
+	  fp = fopen("T_vs_t.out", "a");
+	}
+#else
+      fp = fopen("T_vs_t.out", "a");
 #endif
-            if( (fp = fopen("T_vs_t.out", "a")) != NULL)  
+            if(fp != NULL)
               {
                 fprintf(fp, "%15e %15e\n", t, T);
               }

--- a/src/rd_pixel_image.c
+++ b/src/rd_pixel_image.c
@@ -377,8 +377,8 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
 
   // Number of variables and names
   nod_var_names[0] = efv->name[N_ext];
-  err = ex_put_var_param(exoin, "n", num_nod_vars);
-  err = ex_put_var_names(exoin, "n", num_nod_vars, nod_var_names);
+  err = ex_put_variable_param(exoin, EX_NODAL, num_nod_vars);
+  err = ex_put_variable_names(exoin, EX_NODAL, num_nod_vars, nod_var_names);
 
   // Set time
   err = ex_put_time(exoin, time_step, &time_value);
@@ -402,7 +402,7 @@ rd_image_to_mesh(int N_ext, Exo_DB *exo)
 	} // End of loop over all of the nodes (i)
     }
  
-   err = ex_put_nodal_var(exoin, time_step, 1, exo->num_nodes, nodal_var_vals);
+  err = ex_put_var(exoin, time_step, EX_NODAL, 1, 1, exo->num_nodes, nodal_var_vals);
 
    /* Now allocate memory for external field variable array for use and populate */
    /* You need to do this even though you have writtenit to a file */

--- a/src/rd_pixel_image2.c
+++ b/src/rd_pixel_image2.c
@@ -219,8 +219,8 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
       nod_var_names[i] = nod_var_names_temp[i];
     }
     
-    err = ex_put_var_param(exoout, "n", num_nod_vars);
-    err = ex_put_var_names(exoout, "n", num_nod_vars, nod_var_names);
+    err = ex_put_variable_param(exoout, EX_NODAL, num_nod_vars);
+    err = ex_put_variable_names(exoout, EX_NODAL, num_nod_vars, nod_var_names);
     err = ex_put_time(exoout, time_step, &time_value);
     safe_free(nod_var_names);
     first_time_fopen2 = FALSE;
@@ -254,14 +254,32 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
   resz = 1;
   z0 = 0;
   if (pixdim == 2) { 
-    fscanf(pixfid,"%d %d",&(pixsize[0]),&(pixsize[1])); 
-    fscanf(pixfid,"%lf %lf",&resx, &resy);
-    fscanf(pixfid,"%lf %lf",&x0, &y0);
+    err = fscanf(pixfid,"%d %d",&(pixsize[0]),&(pixsize[1]));
+    if (err != 2) {
+      EH(-1, "Error reading pixel file expected two ints");
+    }
+    err = fscanf(pixfid,"%lf %lf",&resx, &resy);
+    if (err != 2) {
+      EH(-1, "Error reading pixel file expected two floats");
+    }
+    err = fscanf(pixfid,"%lf %lf",&x0, &y0);
+    if (err != 2) {
+      EH(-1, "Error reading pixel file expected two floats");
+    }
   }
   else if (pixdim == 3){ 
-    fscanf(pixfid,"%d %d %d",&(pixsize[0]),&(pixsize[1]),&(pixsize[2])); 
-    fscanf(pixfid,"%lf %lf %lf",&resx, &resy, &resz);
-    fscanf(pixfid,"%lf %lf %lf",&x0, &y0, &z0);
+    err = fscanf(pixfid,"%d %d %d",&(pixsize[0]),&(pixsize[1]),&(pixsize[2]));
+    if (err != 3) {
+      EH(-1, "Error reading pixel file expected three ints");
+    }
+    err = fscanf(pixfid,"%lf %lf %lf",&resx, &resy, &resz);
+    if (err != 3) {
+      EH(-1, "Error reading pixel file expected three floats");
+    }
+    err = fscanf(pixfid,"%lf %lf %lf",&x0, &y0, &z0);
+    if (err != 3) {
+      EH(-1, "Error reading pixel file expected three floats");
+    }
   }
   else EH(-1,"Problem reading pixel/voxel input file; first entry should be dimensionality (2 or 3)");
 
@@ -474,7 +492,7 @@ rd_image_to_mesh2(int N_ext, Exo_DB *exo)
     }
   }
 
-  err = ex_put_nodal_var(exoout, time_step, k, exo->num_nodes, nodal_var_vals);
+  err = ex_put_var(exoout, time_step, EX_NODAL, k, 1, exo->num_nodes, nodal_var_vals);
   //err = ex_close(exoout);
 
 

--- a/src/rf_element_storage.c
+++ b/src/rf_element_storage.c
@@ -260,14 +260,14 @@ set_init_Element_Storage(ELEM_BLK_STRUCT *eb_ptr, int mn)
 	   * Get the number of nodal variables in the file, and allocate
 	   * space for storage of their names.
 	   */
-	  error = ex_get_var_param(exoid, "e", &num_vars);
-	  EH(error, "ex_get_var_param");
+	  error = ex_get_variable_param(exoid, EX_ELEM_BLOCK, &num_vars);
+	  EH(error, "ex_get_variable_param");
   
 	  /* First extract all nodal variable names in exoII database */
 	  if (num_vars > 0) {
 	    var_names = alloc_VecFixedStrings(num_vars, (MAX_STR_LENGTH+1));
-	    error = ex_get_var_names(exoid, "e", num_vars, var_names);
-	    EH(error, "ex_get_var_names");
+	    error = ex_get_variable_names(exoid, EX_ELEM_BLOCK, num_vars, var_names);
+	    EH(error, "ex_get_variable_names");
 	    for (i = 0; i < num_vars; i++) strip(var_names[i]);
 	  } else {
 	    fprintf(stderr,
@@ -288,10 +288,10 @@ set_init_Element_Storage(ELEM_BLK_STRUCT *eb_ptr, int mn)
 		  if(!strcasecmp(appended_name,var_names[j]))
 		    {
 		      /*Found variable so load it into element storage */
-		      error  = ex_get_elem_var(exoid, time_step, j+1, 
-					       eb_ptr->Elem_Blk_Id,
-					       eb_ptr->Num_Elems_In_Block,
-					       ev_tmp);
+		      error  = ex_get_var(exoid, time_step, EX_ELEM_BLOCK, j+1,
+					  eb_ptr->Elem_Blk_Id,
+					  eb_ptr->Num_Elems_In_Block,
+					  ev_tmp);
 		      ifound = 1;
 		    }
 		}
@@ -315,10 +315,10 @@ set_init_Element_Storage(ELEM_BLK_STRUCT *eb_ptr, int mn)
 		  if(!strcasecmp(appended_name,var_names[j]))
 		    {
 		      /*Found variable so load it into element storage */
-		      error  = ex_get_elem_var(exoid, time_step, j+1, 
-					       eb_ptr->Elem_Blk_Id,
-					       eb_ptr->Num_Elems_In_Block,
-					       ev_tmp);
+		      error  = ex_get_var(exoid, time_step, EX_ELEM_BLOCK, j+1,
+					  eb_ptr->Elem_Blk_Id,
+					  eb_ptr->Num_Elems_In_Block,
+					  ev_tmp);
 		      ifound = 1;
 		    }
 		}
@@ -341,10 +341,10 @@ set_init_Element_Storage(ELEM_BLK_STRUCT *eb_ptr, int mn)
 		  if(!strcasecmp(appended_name,var_names[j]))
 		    {
 		      /*Found variable so load it into element storage */
-		      error  = ex_get_elem_var(exoid, time_step, j+1, 
-					       eb_ptr->Elem_Blk_Id,
-					       eb_ptr->Num_Elems_In_Block,
-					       ev_tmp);
+		      error  = ex_get_var(exoid, time_step, EX_ELEM_BLOCK, j+1,
+					  eb_ptr->Elem_Blk_Id,
+					  eb_ptr->Num_Elems_In_Block,
+					  ev_tmp);
 		      ifound = 1;
 		    }
 		}

--- a/src/rf_util.c
+++ b/src/rf_util.c
@@ -2268,16 +2268,16 @@ rd_vectors_from_exoII(double u[], const char *file_nm, const int action_flag,
    * Get the number of nodal variables in the file, and allocate
    * space for storage of their names.
    */
-  error = ex_get_var_param(exoid, "n", &num_vars);
-  EH(error, "ex_get_var_param");
-  error = ex_get_var_param(exoid, "e", &num_elem_vars);
-  EH(error, "ex_get_var_param for e");
+  error = ex_get_variable_param(exoid, EX_NODAL, &num_vars);
+  EH(error, "ex_get_variable_param nodal");
+  error = ex_get_variable_param(exoid, EX_ELEM_BLOCK, &num_elem_vars);
+  EH(error, "ex_get_var_param elem");
   
   /* First extract all nodal variable names in exoII database */
   if (num_vars > 0) {
     var_names = alloc_VecFixedStrings(num_vars, (MAX_STR_LENGTH+1));
-    error = ex_get_var_names(exoid, "n", num_vars, var_names);
-    EH(error, "ex_get_var_names");
+    error = ex_get_variable_names(exoid, EX_NODAL, num_vars, var_names);
+    EH(error, "ex_get_variable_names nodal");
     for (i = 0; i < num_vars; i++) strip(var_names[i]);
   } else {
     fprintf(stderr,
@@ -2355,9 +2355,9 @@ rd_vectors_from_exoII(double u[], const char *file_nm, const int action_flag,
 	DPRINTF(stdout,
 		"\n Cannot find external fields in exoII database, setting to null");
       } else {
-	error = ex_get_nodal_var(exoid, time_step, vdex, num_nodes,
-			         efv->ext_fld_ndl_val[variable_no]);
-	EH(error, "ex_get_nodal_var"); 
+	error = ex_get_var(exoid, time_step, EX_NODAL, vdex, 1, num_nodes,
+			   efv->ext_fld_ndl_val[variable_no]);
+	EH(error, "ex_get_var nodal");
       }        
     }
   }
@@ -2486,16 +2486,16 @@ rd_trans_vectors_from_exoII(double u[], const char *file_nm,
    * Get the number of nodal variables in the file, and allocate
    * space for storage of their names.
    */
-  error = ex_get_var_param(exoid, "n", &num_vars);
-  EH(error, "ex_get_var_param");
-  error = ex_get_var_param(exoid, "e", &num_elem_vars);
-  EH(error, "ex_get_var_param for e");
+  error = ex_get_variable_param(exoid, EX_NODAL, &num_vars);
+  EH(error, "ex_get_variable_param nodal");
+  error = ex_get_variable_param(exoid, EX_ELEM_BLOCK, &num_elem_vars);
+  EH(error, "ex_get_variable_param elem");
   
   /* First extract all nodal variable names in exoII database */
   if (num_vars > 0) {
     var_names = alloc_VecFixedStrings(num_vars, (MAX_STR_LENGTH+1));
-    error = ex_get_var_names(exoid, "n", num_vars, var_names);
-    EH(error, "ex_get_var_names");
+    error = ex_get_variable_names(exoid, EX_NODAL, num_vars, var_names);
+    EH(error, "ex_get_variable_names nodal");
     for (i = 0; i < num_vars; i++) strip(var_names[i]);
   } else {
     fprintf(stderr,
@@ -2527,9 +2527,9 @@ rd_trans_vectors_from_exoII(double u[], const char *file_nm,
 	DPRINTF(stdout,
 		"\n Cannot find external fields in exoII database, setting to null");
       } else {
-	error = ex_get_nodal_var(exoid, time_step_lower, vdex, num_nodes, val_low);
-        error = ex_get_nodal_var(exoid, time_step_higher, vdex, num_nodes, val_high);
-	EH(error, "ex_get_nodal_var");
+	error = ex_get_var(exoid, time_step_lower, EX_NODAL, vdex, 1, num_nodes, val_low);
+        error = ex_get_var(exoid, time_step_higher, EX_NODAL, vdex, 1, num_nodes, val_high);
+	EH(error, "ex_get_var nodal");
 
         for (k=0; k<num_nodes; k++){
 		slope = (val_high[k] - val_low[k])/(time_higher - time_lower);
@@ -2596,8 +2596,8 @@ rd_exoII_nv(double *u, int varType, int mn, MATRL_PROP_STRUCT *matrl,
     status = vdex;
     DPRINTF(stdout,"Nodal variable %s found in exoII database - reading.\n", 
 	    exo_var_name);
-    error = ex_get_nodal_var(exoII_id, time_step, vdex, num_nodes, variable);
-    EH(error, "ex_get_nodal_var");
+    error = ex_get_var(exoII_id, time_step, EX_NODAL, vdex, 1, num_nodes, variable);
+    EH(error, "ex_get_var nodal");
     inject_nodal_vec(u, varType, spec, 0, mn, variable);
     safer_free((void **) &variable);
   }
@@ -2640,8 +2640,8 @@ rd_exoII_ev(double *u, int varType, int mn, MATRL_PROP_STRUCT *matrl,
     status = vdex;
     DPRINTF(stdout,"Nodal variable %s found in exoII database - reading.\n", 
 	    exo_var_name);
-    error = ex_get_nodal_var(exoII_id, time_step, vdex, num_nodes, variable);
-    EH(error, "ex_get_nodal_var");
+    error = ex_get_var(exoII_id, time_step, EX_NODAL, vdex, 1, num_nodes, variable);
+    EH(error, "ex_get_var nodal");
     inject_nodal_vec(u, varType, spec, 0, mn, variable);
     safer_free((void **) &variable);
   }
@@ -2732,7 +2732,7 @@ rd_globals_from_exoII(double u[], const char *file_nm, const int start, const in
 		      &num_elem_blk, &num_node_sets, &num_side_sets);
   EH(error, "ex_get_init for efv or init guess");
 
-  error = ex_get_var_param( exoid, "g", &num_global_vars );
+  error = ex_get_variable_param( exoid, EX_GLOBAL, &num_global_vars );
 
   if( num_global_vars > start ) /* This catches both no global vars and no augmenting values to be read */
     {
@@ -2746,8 +2746,8 @@ rd_globals_from_exoII(double u[], const char *file_nm, const int start, const in
       error = ex_inquire(exoid, EX_INQ_TIME, &time_step, &ret_float, ret_char);
       EH(error, "ex_inquire");
 
-      error = ex_get_glob_vars( exoid, time_step, num_global_vars, global_vars );
-      EH(error, "ex_get_glob_vars");
+      error = ex_get_var( exoid, time_step, EX_GLOBAL, 1, 1, num_global_vars, global_vars );
+      EH(error, "ex_get_var global");
 
       /* 
        *  Read only the global vars that are there.  No more, no less

--- a/src/wr_exo.c
+++ b/src/wr_exo.c
@@ -222,8 +222,8 @@ wr_mesh_exo(Exo_DB *x,		/* def'd in exo_struct.h */
 	}
       if ( x->node_map_exists )
 	{
-	  status = ex_put_node_num_map(x->exoid, x->node_map);
-	  EH(status, "ex_put_node_num_map");
+	  status = ex_put_id_map(x->exoid, EX_NODE_MAP, x->node_map);
+	  EH(status, "ex_put_id_map node");
 	}
     }
 
@@ -232,8 +232,8 @@ wr_mesh_exo(Exo_DB *x,		/* def'd in exo_struct.h */
       
       if ( x->elem_map_exists )
 	{
-	  status = ex_put_elem_num_map(x->exoid, x->elem_map);	
-	  EH(status, "ex_put_elem_num_map");
+	  status = ex_put_id_map(x->exoid, EX_ELEM_MAP, x->elem_map);
+	  EH(status, "ex_put_id_map elem");
 	}
 
       if ( x->elem_order_map_exists )
@@ -255,26 +255,26 @@ wr_mesh_exo(Exo_DB *x,		/* def'd in exo_struct.h */
 	    {
 	      fprintf(stderr, "ex_put_elem_block()...\n");
 	    }
-	  status = ex_put_elem_block(x->exoid, 
-				     x->eb_id[i], 
-				     x->eb_elem_type[i],
-				     x->eb_num_elems[i],
-				     x->eb_num_nodes_per_elem[i],
-				     x->eb_num_attr[i]);
-	  EH(status, "ex_put_elem_blocks");
+	  status = ex_put_block(x->exoid, EX_ELEM_BLOCK,
+				x->eb_id[i],
+				x->eb_elem_type[i],
+				x->eb_num_elems[i],
+				x->eb_num_nodes_per_elem[i], 0, 0,
+				x->eb_num_attr[i]);
+	  EH(status, "ex_put_blocks elem");
 
 	  if ( (x->eb_num_elems[i] * x->eb_num_nodes_per_elem[i]) > 0 )
 	    {
-	      status = ex_put_elem_conn(x->exoid, 
-					x->eb_id[i], 
-					x->eb_conn[i]);
-	      EH(status, "ex_put_elem_conn");
+	      status = ex_put_conn(x->exoid, EX_ELEM_BLOCK,
+				   x->eb_id[i],
+				   x->eb_conn[i], 0, 0);
+	      EH(status, "ex_put_conn elem");
 	    }
 
 	  if ( (x->eb_num_elems[i]*x->eb_num_attr[i]) > 0 )
 	    {
-	      status = ex_put_elem_attr(x->exoid, x->eb_id[i], x->eb_attr[i]);
-	      EH(status, "ex_put_elem_attr");
+	      status = ex_put_attr(x->exoid, EX_ELEM_BLOCK, x->eb_id[i], x->eb_attr[i]);
+	      EH(status, "ex_put_attr elem");
 	    }
 	}
     }
@@ -287,16 +287,22 @@ wr_mesh_exo(Exo_DB *x,		/* def'd in exo_struct.h */
     {
       if ( verbosity > 0 )
 	{
-	  fprintf(stderr, "ex_put_concat_node_sets()...\n");
+	  fprintf(stderr, "ex_put_concat_sets() node sets...\n");
 	}
-      status = ex_put_concat_node_sets(x->exoid, x->ns_id, 
-				       x->ns_num_nodes,
-				       x->ns_num_distfacts,
-				       x->ns_node_index,
-				       x->ns_distfact_index,
-				       x->ns_node_list,
-				       x->ns_distfact_list);
-      EH(status, "ex_put_concat_node_sets");
+
+      ex_set_specs ns_specs;
+
+      ns_specs.sets_ids            = x->ns_id;
+      ns_specs.num_entries_per_set = x->ns_num_nodes;
+      ns_specs.num_dist_per_set    = x->ns_num_distfacts;
+      ns_specs.sets_entry_index    = x->ns_node_index;
+      ns_specs.sets_dist_index     = x->ns_distfact_index;
+      ns_specs.sets_entry_list     = x->ns_node_list;
+      ns_specs.sets_extra_list     = NULL;
+      ns_specs.sets_dist_fact      = x->ns_distfact_list;
+
+      status = ex_put_concat_sets(x->exoid, EX_NODE_SET, &ns_specs);
+      EH(status, "ex_put_concat_sets node_sets");
     }
 
 
@@ -308,17 +314,22 @@ wr_mesh_exo(Exo_DB *x,		/* def'd in exo_struct.h */
     {
       if ( verbosity > 0 )
 	{
-	  fprintf(stderr, "ex_put_concat_side_sets()...\n");
+	  fprintf(stderr, "ex_put_concat_sets() side sets...\n");
 	}
-      status = ex_put_concat_side_sets(x->exoid, x->ss_id, 
-				       x->ss_num_sides,
-				       x->ss_num_distfacts,
-				       x->ss_elem_index,
-				       x->ss_distfact_index,
-				       x->ss_elem_list,
-				       x->ss_side_list,
-				       x->ss_distfact_list);
-      EH(status, "ex_put_concat_side_sets");
+
+      ex_set_specs ss_specs;
+      ss_specs.sets_ids            = x->ss_id;
+      ss_specs.num_entries_per_set = x->ss_num_sides;
+      ss_specs.num_dist_per_set    = x->ss_num_distfacts;
+      ss_specs.sets_entry_index    = x->ss_elem_index;
+      ss_specs.sets_dist_index     = x->ss_distfact_index;
+      ss_specs.sets_entry_list     = x->ss_elem_list;
+      ss_specs.sets_extra_list     = x->ss_side_list;
+      ss_specs.sets_dist_fact      = x->ss_distfact_list;
+
+      status = ex_put_concat_sets(x->exoid, EX_SIDE_SET, &ss_specs);
+
+      EH(status, "ex_put_concat_sets side_sets");
     }
 
 
@@ -615,22 +626,22 @@ wr_result_prelim_exo(struct Results_Description *rd,
   if ( rd->ngv > 0 )
     {
       num_vars = rd->ngv;
-      error = ex_put_var_param(exo->exoid, "g", num_vars);
-      EH(error, "ex_put_var_param(g)");
+      error = ex_put_variable_param(exo->exoid, EX_GLOBAL, num_vars);
+      EH(error, "ex_put_variable_param global");
       for ( i=0; i<rd->ngv; i++)
 	{
 	 gvar_names[i] = rd->gvname[i];
 	}
-      error = ex_put_var_names(exo->exoid, "g", num_vars, gvar_names);
-      EH(error, "ex_put_var_names(g)");
+      error = ex_put_variable_names(exo->exoid, EX_GLOBAL, num_vars, gvar_names);
+      EH(error, "ex_put_variable_names global");
     }
       
   /* -------------------- Element Variables -------------------------- */
   if ( rd->nev > 0 )
     {
       num_vars = rd->nev;
-      error = ex_put_var_param(exo->exoid, "e", num_vars);
-      EH(error, "ex_put_var_param(e)");
+      error = ex_put_variable_param(exo->exoid, EX_ELEM_BLOCK, num_vars);
+      EH(error, "ex_put_variable_param elem block");
       for ( i=0; i<rd->nev; i++)
 	{
 	  var_names[i] = rd->evname[i];
@@ -641,8 +652,8 @@ wr_result_prelim_exo(struct Results_Description *rd,
 #ifdef DEBUG
       printf("%s: varnames loaded\n", yo);
 #endif
-      error = ex_put_var_names(exo->exoid, "e", num_vars, var_names);
-      EH(error, "ex_put_var_names(e)");
+      error = ex_put_variable_names(exo->exoid, EX_ELEM_BLOCK, num_vars, var_names);
+      EH(error, "ex_put_variable_names elem block");
 
       /* Create truth table at this time - saves mucho cycles later
          Also malloc the gvec_elem final dim. Easier to do right
@@ -655,8 +666,8 @@ wr_result_prelim_exo(struct Results_Description *rd,
   if ( rd->nnv > 0 )
     {
       num_vars = rd->nnv;
-      error = ex_put_var_param(exo->exoid, "n", num_vars);
-      EH(error, "ex_put_var_param(n)");
+      error = ex_put_variable_param(exo->exoid, EX_NODAL, num_vars);
+      EH(error, "ex_put_variable_param EX_NODAL");
       for ( i=0; i<rd->nnv; i++)
 	{
 	  var_names[i] = rd->nvname[i];
@@ -667,8 +678,8 @@ wr_result_prelim_exo(struct Results_Description *rd,
 #ifdef DEBUG
       printf("%s: varnames loaded\n", yo);
 #endif
-      error = ex_put_var_names(exo->exoid, "n", num_vars, var_names);
-      EH(error, "ex_put_var_names(n)");
+      error = ex_put_variable_names(exo->exoid, EX_NODAL, num_vars, var_names);
+      EH(error, "ex_put_variable_names nodal");
     }
 
   error = ex_close(exo->exoid);
@@ -711,9 +722,9 @@ wr_nodal_result_exo(Exo_DB *exo, char *filename, double vector[],
     }
   error      = ex_put_time(exo->exoid, time_step, &time_value);
   EH(error, "ex_put_time");
-  error      = ex_put_nodal_var(exo->exoid, time_step, variable_index, 
+  error      = ex_put_var(exo->exoid, time_step, EX_NODAL, variable_index, 1,
 				exo->num_nodes, vector);
-  EH(error, "ex_put_nodal_var");
+  EH(error, "ex_put_var nodal");
   error      = ex_close(exo->exoid);
   return;
 }
@@ -757,22 +768,22 @@ wr_elem_result_exo(Exo_DB *exo, const char *filename, double ***vector,
     if (exo->elem_var_tab_exists == TRUE) {
       /* Only write out vals if this variable exists for the block */
       if (exo->elem_var_tab[i*rd->nev + variable_index] == 1) {
-	error = ex_put_elem_var(exo->exoid, time_step, variable_index+1,
+	error = ex_put_var(exo->exoid, time_step, EX_ELEM_BLOCK, variable_index+1,
 				exo->eb_id[i], exo->eb_num_elems[i],
 				vector[i][variable_index]);
-	EH(error, "ex_put_elem_var");
+	EH(error, "ex_put_var elem");
       }
     }
     else {
       /* write it anyway (not really recommended from a performance viewpoint) */
-      error      = ex_put_elem_var ( exo->exoid,
-				     time_step, 
-				     variable_index+1, /* Convert to 1 based for 
-							  exodus */
-				     exo->eb_id[i],
-				     exo->eb_num_elems[i],
-				     vector[i][variable_index] );
-      EH(error, "ex_put_elem_var");
+      error      = ex_put_var ( exo->exoid,
+				time_step, EX_ELEM_BLOCK,
+				variable_index+1, /* Convert to 1 based for
+						     exodus */
+				exo->eb_id[i],
+				exo->eb_num_elems[i],
+				vector[i][variable_index] );
+      EH(error, "ex_put_var elem");
     }
   }
 
@@ -817,9 +828,9 @@ wr_global_result_exo( Exo_DB *exo,
     EH(-1,"wr_nodal_result_exo: could not open the output file");
   }
 
-  error = ex_put_glob_vars ( exo->exoid, time_step, ngv, u );
+  error = ex_put_var( exo->exoid, time_step, EX_GLOBAL, 1, 0, ngv, u );
 
-  EH(error, "ex_put_glob_vars");
+  EH(error, "ex_put_var glob_vars");
 
   error = ex_close( exo->exoid);
 
@@ -1144,11 +1155,11 @@ create_truth_table(struct Results_Description *rd, Exo_DB *exo,
   }
 
   /* write out table */
-  error      = ex_put_elem_var_tab ( exo->exoid,
-				     exo->num_elem_blocks,
-				     rd->nev,
-				     exo->elem_var_tab );
-  EH(error, "ex_put_elem_var_tab");
+  error      = ex_put_truth_table ( exo->exoid, EX_ELEM_BLOCK,
+				    exo->num_elem_blocks,
+				    rd->nev,
+				    exo->elem_var_tab );
+  EH(error, "ex_put_truth_table EX_ELEM_BLOCK");
 
   /* Now set truth table exists flag */
   exo->elem_var_tab_exists = TRUE;
@@ -1398,7 +1409,11 @@ add_info_stamp(Exo_DB *exo)
 
   if ( ProcID < 8 )		/* too much I/O overhead for many procs */
     {
-      getcwd(buf, MAX_LINE_LENGTH+1);
+      char *cwderr;
+      cwderr = getcwd(buf, MAX_LINE_LENGTH+1);
+      if (cwderr == NULL) {
+	strcpy(buf, ".");
+      }
     }
   else
     {
@@ -1492,36 +1507,36 @@ wr_resetup_exo(Exo_DB *exo,
 
   if ( exo->num_glob_vars > 0 )
     {
-      status = ex_put_var_param(exo->exoid, "g", exo->num_glob_vars);
-      EH(status, "ex_put_var_param(g)");
-      status = ex_put_var_names(exo->exoid, "g", exo->num_glob_vars,
+      status = ex_put_variable_param(exo->exoid, EX_GLOBAL, exo->num_glob_vars);
+      EH(status, "ex_put_variable_param global");
+      status = ex_put_variable_names(exo->exoid, EX_GLOBAL, exo->num_glob_vars,
 				exo->glob_var_names);
-      EH(status, "ex_put_var_names(g)");
+      EH(status, "ex_put_variable_names global");
     }
 
   if ( exo->num_elem_vars > 0 )
     {
-      status = ex_put_var_param(exo->exoid, "e", exo->num_elem_vars);
-      EH(status, "ex_put_var_param(e)");
-      status = ex_put_var_names(exo->exoid, "e", 
-				exo->num_elem_vars,
-				exo->elem_var_names);
-      EH(status, "ex_put_var_names(e)");
-      status = ex_put_elem_var_tab(exo->exoid, 
+      status = ex_put_variable_param(exo->exoid, EX_ELEM_BLOCK, exo->num_elem_vars);
+      EH(status, "ex_put_variable_param elem block");
+      status = ex_put_variable_names(exo->exoid, EX_ELEM_BLOCK,
+				     exo->num_elem_vars,
+				     exo->elem_var_names);
+      EH(status, "ex_put_variable_names elem block");
+      status = ex_put_truth_table(exo->exoid, EX_ELEM_BLOCK,
 				   exo->num_elem_blocks,
 				   exo->num_elem_vars, 
 				   exo->elem_var_tab);
-      EH(status, "ex_put_elem_var_tab");
+      EH(status, "ex_put_truth_table elem block");
     }
 
   if ( exo->num_node_vars > 0 )
     {
-      status = ex_put_var_param(exo->exoid, "n", exo->num_node_vars);
-      EH(status, "ex_put_var_param(n)");
-      status = ex_put_var_names(exo->exoid, "n", 
+      status = ex_put_variable_param(exo->exoid, EX_NODAL, exo->num_node_vars);
+      EH(status, "ex_put_variable_param nodal");
+      status = ex_put_variable_names(exo->exoid, EX_NODAL,
 				exo->num_node_vars,
 				exo->node_var_names);
-      EH(status, "ex_put_var_names(n)");
+      EH(status, "ex_put_variable_names nodal");
     }
 
   if ( exo->num_times > 0 )
@@ -1619,14 +1634,14 @@ wr_result_exo(Exo_DB *exo,
 		  
 		  if ( exo->elem_var_tab[index] != 0 )
 		    {
-		      status = ex_put_elem_var(exo->exoid, time_index, k+1,
-					       exo->eb_id[j], 
-					       exo->eb_num_elems[j],
-					       &(exo->ev[i][index][0]));
+		      status = ex_put_var(exo->exoid, time_index, EX_ELEM_BLOCK, k+1,
+					  exo->eb_id[j],
+					  exo->eb_num_elems[j],
+					  &(exo->ev[i][index][0]));
 		      if ( status < 0 )
 			{
 			  sprintf(err_msg, 
-                                  "ex_put_elem_var() bad rtn: time %d, elemvar %d, EB ID %d",
+                                  "ex_put_var() elem bad rtn: time %d, elemvar %d, EB ID %d",
                                   time_index, k+1, exo->eb_id[j]);
 			  EH(-1, err_msg);
 			}
@@ -1648,11 +1663,11 @@ wr_result_exo(Exo_DB *exo,
 
 	  for ( j = 0; j < exo->num_nv_indeces; j++)
 	    {
-	      status = ex_put_nodal_var(exo->exoid, time_index, 
-					exo->nv_indeces[j],
-					exo->num_nodes, 
-					&(exo->nv[i][j][0]));
-	      EH(status, "ex_put_nodal_var");
+	      status = ex_put_var(exo->exoid, time_index, EX_NODAL,
+				  exo->nv_indeces[j], 1,
+				  exo->num_nodes,
+				  &(exo->nv[i][j][0]));
+	      EH(status, "ex_put_var nodal");
 	    }
 	}
     }


### PR DESCRIPTION
Make compiling new things less annoying, we should add warnings to the jenkins bot so warnings don't build up again

There were also quite a few SEACAS functions that are now deprecated that I updated

**Requires GUTS branch fix-deprecated-and-warnings** as [MP] Weight Function's were being read in improperly and a required field was allowed to be left blank when SUPG was specified