### PR TITLE
Fix a bug in level set supg

### DIFF
--- a/src/mm_fill_fill.c
+++ b/src/mm_fill_fill.c
@@ -454,9 +454,11 @@ assemble_fill(double tt,
          for ( a=0; a < VIM; a++ )
 	    {
 	     v_dot_Dphi[i] += v_rel[a] * grad_phi_i[a];
+	     if ( Fill_Weight_Fcn == FILL_WEIGHT_SUPG )
+	       {
+		 vc_dot_Dphi[i] += vcent[a] * grad_phi_i[a];
+	       }
             }
-	 if ( Fill_Weight_Fcn == FILL_WEIGHT_SUPG )
-	     vc_dot_Dphi[i] += vcent[a] * grad_phi_i[a];
         }
     }
 


### PR DESCRIPTION
Move term vc_dot_Dphi inside the loop

Was incorrectly outside the loop so was being filled with incorrect values, SUPG converges now.