### PR TITLE
Fixed convective flux term for SPECIES_FLUX. Previously, was always b…

### DIFF
--- a/src/mm_flux.c
+++ b/src/mm_flux.c
@@ -1146,7 +1146,6 @@ evaluate_flux(
                           local_qconv += (fv->snormal[a]*(fv->v[a]-x_dot[a])
                                          *fv->c[species_id] );
                         }
-                          local_qconv = 0;
                           local_flux +=  weight*det*local_q;
                           local_flux_conv += weight*det*local_qconv;
 		      break;


### PR DESCRIPTION
In the post processing fluxes, under SPECIES_FLUX, the convective flux is always set to zero after it's evaluated for some reason. I fixed this by taking out the line of code that sets local_qconv equal to zero. As it is now, the post-processing output file only shows the diffusive flux, and always shows the convective flux equal to zero. As far as I can tell, this was probably just put in as a test and never reset.