### PR TITLE
Added EVSS_GRADV and LOG_CONF_GRADV as Polymer Stress Formulations

### DIFF
--- a/include/rf_fem_const.h
+++ b/include/rf_fem_const.h
@@ -68,7 +68,10 @@
 #define EVSS_F          2  /* Fortin's formulation */
 #define EVSS_L          3  /* Level set solid-fluid formulation */
 #define LOG_CONF        4  /* Log-conformation tensor formulation */
-
+#define EVSS_GRADV      5  /* Fortin's formulation using GradV instead of G */
+                           /* for stress constitutive equations */
+#define LOG_CONF_GRADV  6  /* Log-conformation tensor formulation using */
+                           /* GradV instead of G for stress constitutive equations */
 /* Discontinuous Galerkin viscoelastic jacobian options */
 #define EXPLICIT_DG     1
 #define FULL_DG         2

--- a/src/bc_integ.c
+++ b/src/bc_integ.c
@@ -1085,7 +1085,7 @@ apply_integrated_bc(double x[],           /* Solution vector for the current pro
 	  break;
 
         case STRESS_DEVELOPED_BC:
-          if (vn->evssModel == LOG_CONF)
+          if (vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
             {
               stress_no_v_dot_gradS_logc(func_stress, d_func_stress, delta_t, theta);
             }

--- a/src/mm_fill.c
+++ b/src/mm_fill.c
@@ -1480,7 +1480,7 @@ matrix_fill(
        */
       do_LSA_mods(LSA_VOLUME);
 
-      if(vn->evssModel == EVSS_F)
+      if(vn->evssModel == EVSS_F || vn->evssModel == EVSS_GRADV)
 	{
 	  err = assemble_stress_fortin(theta, delta_t, pg_data.hsquared,
 				       pg_data.hhv, pg_data.dhv_dxnode, pg_data.v_avg, pg_data.dv_dnode);
@@ -1511,7 +1511,7 @@ matrix_fill(
 	  if (err) return -1;
 #endif
 	}
-      else if(vn->evssModel==LOG_CONF)
+      else if(vn->evssModel==LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
         {
           err = assemble_stress_log_conf(theta, delta_t, pg_data.hsquared,
                                      pg_data.hhv, pg_data.dhv_dxnode, pg_data.v_avg, pg_data.dv_dnode);
@@ -3813,7 +3813,7 @@ matrix_fill_stress(
        */
       do_LSA_mods(LSA_VOLUME);
 
-      if(vn->evssModel==LOG_CONF)
+      if(vn->evssModel==LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
         {
           err = assemble_stress_log_conf(theta, delta_t, pg_data.hsquared,
                                      pg_data.hhv, pg_data.dhv_dxnode, pg_data.v_avg, pg_data.dv_dnode);

--- a/src/mm_fill_stress.c
+++ b/src/mm_fill_stress.c
@@ -1990,37 +1990,43 @@ assemble_stress_fortin(dbl tt,	/* parameter to vary time integration from
 						  if(pd->CoordinateSystem != CYLINDRICAL)
 						    {
 						      if( ucwt != 0)
-                                                       {
-                                                         for( k=0; k<VIM; k++)
-                                                           {
-                                                             advection_c -= ucwt*((double)delta(a,p)*bf[VELOCITY1+a]->grad_phi[j][k]*s[k][b] +
-                                                                                 (double)delta(b,p)*s[a][k]*bf[VELOCITY1+b]->grad_phi[j][k]);
-                                                           }
-                                                       }
-                                                     if( lcwt != 0.)
-                                                       {
-                                                         advection_c += lcwt*(s[a][p]*bf[VELOCITY1+b]->grad_phi[j][b] +
-                                                                              s[b][p]*bf[VELOCITY1+a]->grad_phi[j][a]);
-                                                       }
-                                                   }
-                                                 else
-                                                   {
-                                                     if( ucwt != 0)
-                                                       {
-                                                         for( k=0; k<VIM; k++)
-                                                           {
-                                                             advection_c -= ucwt*((double)delta(a,p)*bf[var]->grad_phi[j][k]*s[k][b] +
-                                                                                 (double)delta(b,p)*s[a][k]*bf[var]->grad_phi[j][k]);
-                                                           }
-                                                       }
-                                                     if( lcwt != 0.)
-                                                       {
-                                                         advection_c += lcwt*(s[a][p]*bf[var]->grad_phi[j][b] +
-                                                                              s[b][p]*bf[var]->grad_phi[j][a]);
-                                                       }
-                                                   }
-                                                 advection_c *= wt_func;
-                                               }
+							{
+							  for( k=0; k<VIM; k++)
+							    {
+							      advection_c -= ucwt*(bf[VELOCITY1+a]->grad_phi_e[j][p][k][a]*s[k][b] +
+										   bf[VELOCITY1+b]->grad_phi_e[j][p][k][b]*s[a][k]);
+							    }
+							}
+						      if( lcwt != 0.)
+							{
+							  for( k=0; k<VIM; k++)
+							    {
+							      advection_c += lcwt*(bf[VELOCITY1+b]->grad_phi_e[j][p][b][k]*s[a][k] +
+										   bf[VELOCITY1+a]->grad_phi_e[j][p][a][k]*s[k][b]);
+							    }
+							}
+						    }
+						  else
+						    {
+						      if( ucwt != 0)
+							{
+							  for( k=0; k<VIM; k++)
+							    {
+							      advection_c -= ucwt*(bf[VELOCITY1]->grad_phi_e[j][p][k][a]*s[k][b] +
+										   bf[VELOCITY1]->grad_phi_e[j][p][k][b]*s[a][k]);
+							    }
+							}
+						      if( lcwt != 0.)
+							{
+							  for( k=0; k<VIM; k++)
+							    {
+							      advection_c += lcwt*(bf[VELOCITY1]->grad_phi_e[j][p][b][k]*s[a][k] +
+										   bf[VELOCITY1]->grad_phi_e[j][p][a][k]*s[k][b]);
+							    }
+							}
+						    }
+						  advection_c *= wt_func;
+						}
 						     
 					      advection = advection_a +  advection_b + advection_c;
 					      advection *= at * lambda * det_J * wt *h3;
@@ -2044,16 +2050,16 @@ assemble_stress_fortin(dbl tt,	/* parameter to vary time integration from
 					  source_c =  -at * d_mup_dv_pj * ( g[a][b] +  gt[a][b]);
                                           if(evss_gradv)
                                             {
-                                             if(pd->CoordinateSystem != CYLINDRICAL)
-                                               {
-                                                 source_c -= at * mup * (bf[VELOCITY1+a]->grad_phi_e[j][p][a][b] +
-                                                                         bf[VELOCITY1+b]->grad_phi_e[j][p][b][a]);
-                                               }
-                                             else
-                                               {
-                                                 source_c -= at * mup * (bf[var]->grad_phi_e[j][p][a][b] +
-                                                                         bf[var]->grad_phi_e[j][p][b][a]);
-                                               }
+					      if(pd->CoordinateSystem != CYLINDRICAL)
+						{
+						  source_c -= at * mup * (bf[VELOCITY1+a]->grad_phi_e[j][p][a][b] +
+									  bf[VELOCITY1+b]->grad_phi_e[j][p][b][a]);
+						}
+					      else
+						{
+						  source_c -= at * mup * (bf[VELOCITY1]->grad_phi_e[j][p][a][b] +
+									  bf[VELOCITY1]->grad_phi_e[j][p][b][a]);
+						}
                                             }
 					  source_c *= wt_func;
 					  

--- a/src/mm_fill_terms.c
+++ b/src/mm_fill_terms.c
@@ -2767,7 +2767,7 @@ assemble_momentum(dbl time,       /* current time */
   /*
    * Calculate the momentum stress tensor at the current gauss point
    */
-  if(vn->evssModel==LOG_CONF)
+  if(vn->evssModel==LOG_CONF || vn->evssModel==LOG_CONF_GRADV)
     {
       fluid_stress_conf(Pi, d_Pi);
     }
@@ -4052,7 +4052,8 @@ assemble_momentum(dbl time,       /* current time */
 	       * J_m_G
 	       */
 		  
-	      if ( pdv[POLYMER_STRESS11] && (vn->evssModel == EVSS_F || vn->evssModel == LOG_CONF) )
+	      if ( pdv[POLYMER_STRESS11] && (vn->evssModel == EVSS_F || vn->evssModel == LOG_CONF
+					     || vn->evssModel == EVSS_GRADV || vn->evssModel == LOG_CONF_GRADV) )
 		{
 		  for ( b=0; b<VIM; b++)
 		    {
@@ -23791,7 +23792,7 @@ assemble_p_source ( double pressure, const int bcflag )
 	{
 	 if (!af->Assemble_Jacobian) d_Pi = NULL; 
   		/* compute stress tensor and its derivatives */
-           if(vn->evssModel==LOG_CONF)
+           if(vn->evssModel==LOG_CONF || vn->evssModel==LOG_CONF_GRADV)
              {
                fluid_stress_conf(Pi, d_Pi);
              }
@@ -25156,7 +25157,7 @@ assemble_uvw_source ( int eqn, double val )
   else
     {
       /* compute stress tensor and its derivatives */
-      if(vn->evssModel==LOG_CONF)
+      if(vn->evssModel==LOG_CONF || vn->evssModel==LOG_CONF_GRADV)
         {
           fluid_stress_conf(Pi, d_Pi);
         }
@@ -26193,7 +26194,7 @@ assemble_momentum_path_dependence(dbl time,       /* currentt time step */
   /*
    * Stress tensor, but don't need dependencies
    */
-  if(vn->evssModel==LOG_CONF)
+  if(vn->evssModel==LOG_CONF || vn->evssModel==LOG_CONF_GRADV)
     {
       fluid_stress_conf(Pi, NULL);
     }
@@ -27243,7 +27244,7 @@ fluid_stress( double Pi[DIM][DIM],
       particle_stress(tau_p, d_tau_p_dv, d_tau_p_dvd,d_tau_p_dy,d_tau_p_dmesh,d_tau_p_dp, w0);
     }
 
-  if ( pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F) )
+  if ( pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F || vn->evssModel == EVSS_GRADV) )
     {
       evss_f = 1.;
     }
@@ -28045,7 +28046,6 @@ fluid_stress_conf( double Pi[DIM][DIM],
   int v_s[MAX_MODES][DIM][DIM];
   int v_g[DIM][DIM];
   int mode;                             // Index for modal viscoelastic counter
-  int conf;                             // Flag for Conformation tensor
 
   // Flag for doing dilational viscosity contributions
 
@@ -28117,7 +28117,7 @@ fluid_stress_conf( double Pi[DIM][DIM],
     }
 
   // Load up DEVSS-G flag and Gs
-  if(pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F || vn->evssModel==LOG_CONF))
+  if(pd->v[POLYMER_STRESS11] && (vn->evssModel==LOG_CONF || vn->evssModel==LOG_CONF_GRADV))
     {
       evss_f = 1;
     }
@@ -28140,22 +28140,10 @@ fluid_stress_conf( double Pi[DIM][DIM],
       memset(gamma_cont, 0, sizeof(double)*DIM*DIM);
     }
 
-  // Turn on conformation tensor flag if desired
-  if (vn->evssModel == LOG_CONF)
-    {
-      conf = LOG_CONF;
-    }
-  else
-    {
-      conf = 0;
-    }
-
-
-  if (conf == LOG_CONF) {
-    for (mode = 0; mode < vn->modes; mode++) {
-      compute_exp_s(fv->S[mode], exp_s[mode], eig_values, R1);
-    }
+  for (mode = 0; mode < vn->modes; mode++) {
+    compute_exp_s(fv->S[mode], exp_s[mode], eig_values, R1);
   }
+
 
   // Load shear rate tensor
   for(a=0; a<VIM; a++)
@@ -28170,35 +28158,25 @@ fluid_stress_conf( double Pi[DIM][DIM],
   mus = viscosity(gn, gamma, d_mus);
 
   // Check if the conformation tensor mapping is valid
-  if(conf)
+  for(mode=0; mode<vn->modes; mode++)
     {
-      for(mode=0; mode<vn->modes; mode++)
-  	{
-  	  // Polymer viscosity
-  	  mup = viscosity(ve[mode]->gn, gamma, d_mup);
-  	  // Polymer time constant
-  	  lambda = 0.0;
-  	  if(ve[mode]->time_constModel == CONSTANT)
-  	    {
-  	      lambda = ve[mode]->time_const;
-  	    }  	  
-	  /* Looks like these models are not working right now
-	   *else if(ve[mode]->time_constModel == CARREAU || ve[mode]->time_constModel == POWER_LAW)
-	   * {
-	   *   lambda = mup/ve[mode]->time_const;
-	   * }
-	   */
-  	  if(lambda==0.0)
-  	    {
-  	      EH( -1, "The conformation tensor needs a non-zero polymer time constant.");
-  	    }
-  	  if(mup==0.0)
-  	    {
-  	      EH( -1, "The conformation tensor needs a non-zero polymer viscosity.");
-  	    }
-  	}
+      // Polymer viscosity
+      mup = viscosity(ve[mode]->gn, gamma, d_mup);
+      // Polymer time constant
+      lambda = 0.0;
+      if(ve[mode]->time_constModel == CONSTANT)
+	{
+	  lambda = ve[mode]->time_const;
+	}  	  
+      if(lambda==0.0)
+	{
+	  EH( -1, "The conformation tensor needs a non-zero polymer time constant.");
+	}
+      if(mup==0.0)
+	{
+	  EH( -1, "The conformation tensor needs a non-zero polymer viscosity.");
+	}
     }
-
 
   // Load up fluid stress terms in Pi
   for(a=0; a<VIM; a++)
@@ -28223,14 +28201,7 @@ fluid_stress_conf( double Pi[DIM][DIM],
 		  Pi[a][b] += mup*(gamma[a][b]-gamma_cont[a][b]);
 
 		  // PolymerStress contribution
-		  if(conf)
-		    {
-		      Pi[a][b] += mup/lambda*(exp_s[mode][a][b]-(double)delta(a,b));
-		    }
-		  else
-		    {
-		      Pi[a][b] += fv->S[mode][a][b];
-		    }
+		  Pi[a][b] += mup/lambda*(exp_s[mode][a][b]-(double)delta(a,b));
 		}
             }
         }
@@ -28264,10 +28235,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 			    {
 			      d_Pi->T[p][q][j] += d_mup->T[j]*(gamma[p][q]-gamma_cont[p][q]);
 			    }
-			  if(conf)
-			    {
-			      d_Pi->T[p][q][j] += d_mup->T[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-			    }			  
+			  // Log-conformation tensor stress
+			  d_Pi->T[p][q][j] += d_mup->T[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			}		      
 		    }
 		}
@@ -28303,10 +28272,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 			    {
 			      d_Pi->nn[p][q][j] += d_mup->nn[j]*(gamma[p][q]-gamma_cont[p][q]);
 			    }
-			  if(conf)
-			    {
-			      d_Pi->nn[p][q][j] += d_mup->nn[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-			    }			  
+			  // Log-conformation tensor stress
+			  d_Pi->nn[p][q][j] += d_mup->nn[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			}		      
 		    }
 		}
@@ -28342,10 +28309,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 			    {
 			      d_Pi->F[p][q][j] += d_mup->F[j]*(gamma[p][q]-gamma_cont[p][q]);
 			    }
-			  if(conf)
-			    {
-			      d_Pi->F[p][q][j] += d_mup->F[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-			    }			  
+			  // Log-conformation tensor stress
+			  d_Pi->F[p][q][j] += d_mup->F[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			}		      
 		    }
 		}
@@ -28384,10 +28349,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 				{
 				  d_Pi->pf[p][q][a][j] += d_mup->pf[a][j]*(gamma[p][q]-gamma_cont[p][q]);
 				}
-			      if(conf)
-				{
-				  d_Pi->pf[p][q][a][j] += d_mup->pf[a][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-				}			  
+			      // Log-conformation tensor stress
+			      d_Pi->pf[p][q][a][j] += d_mup->pf[a][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			    }		      
 			}
 		    }
@@ -28431,10 +28394,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 				  d_Pi->v[p][q][b][j] += mup*bf[var+p]->grad_phi_e[j][b][q][p];
 				  d_Pi->v[p][q][b][j] += d_mup->v[b][j]*(gamma[p][q]-gamma_cont[p][q]);
 				}
-			      if(conf)
-				{
-				  d_Pi->v[p][q][b][j] += d_mup->v[b][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-				}			  
+			      // Log-conformation tensor stress
+			      d_Pi->v[p][q][b][j] += d_mup->v[b][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			    }		      
 			}
 		    }
@@ -28496,10 +28457,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 				  d_Pi->X[p][q][b][j] += mup*fv->d_grad_v_dmesh[q][p][b][j];
 				  d_Pi->X[p][q][b][j] += d_mup->X[b][j]*(gamma[p][q]-gamma_cont[p][q]);
 				}
-			      if(conf)
-				{
-				  d_Pi->X[p][q][b][j] += d_mup->X[b][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-				}			  
+			      // Log-conformation tensor stress
+			      d_Pi->X[p][q][b][j] += d_mup->X[b][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			    }		      
 			}
 		    }
@@ -28539,7 +28498,7 @@ fluid_stress_conf( double Pi[DIM][DIM],
                               d_Pi->S[p][q][mode][b][c][j] = 0.;
                               /* Note: We use b <= c below to be consistent with the symmetry of the stress
                                  tensor and to avoid double contributions to the Jacobian in assemble_momentum */
-                              if ( b <= c && conf == LOG_CONF )
+                              if ( b <= c )
                                 {
                                   d_Pi->S[p][q][mode][b][c][j] =
                                     mup/lambda*d_exp_s_ds[mode][p][q][b][c] * bf[var]->phi[j];
@@ -28618,10 +28577,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 				{
 				  d_Pi->C[p][q][w][j] += d_mup->C[w][j]*(gamma[p][q]-gamma_cont[p][q]);
 				}
-			      if(conf)
-				{
-				  d_Pi->C[p][q][w][j] += d_mup->C[w][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-				}			  
+			      // Log-conformation tensor stress
+			      d_Pi->C[p][q][w][j] += d_mup->C[w][j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			    }		      
 			}
 		    }
@@ -28657,10 +28614,8 @@ fluid_stress_conf( double Pi[DIM][DIM],
 			    {
 			      d_Pi->P[p][q][j] += d_mup->P[j]*(gamma[p][q]-gamma_cont[p][q]);
 			    }
-			  if(conf)
-			    {
-			      d_Pi->P[p][q][j] += d_mup->P[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
-			    }			  
+			  // Log-conformation tensor stress
+			  d_Pi->P[p][q][j] += d_mup->P[j]/lambda*(exp_s[mode][p][q]-(double)delta(p,q));
 			}		      
 		    }
 		}

--- a/src/mm_flux.c
+++ b/src/mm_flux.c
@@ -699,7 +699,7 @@ evaluate_flux(
                             dbl eig_values[DIM];
 		            dbl mup = 0.;
  			    dbl lambda = 0.;
-                            if(vn->evssModel==LOG_CONF)
+                            if(vn->evssModel==LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
                               {
                                 for ( ve_mode=0; ve_mode < vn->modes; ve_mode++)
                                   {

--- a/src/mm_input_mp.c
+++ b/src/mm_input_mp.c
@@ -2364,6 +2364,10 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 	{
 	  vn_glob[mn]->evssModel = EVSS_F;
 	}
+      else if ( !strcmp(model_name, "EVSS_GRADV") )
+	{
+	  vn_glob[mn]->evssModel = EVSS_GRADV;
+	}
       else if ( !strcmp(model_name, "EVSS_L") )
 	{
 	  vn_glob[mn]->evssModel = EVSS_L;
@@ -2371,6 +2375,10 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
       else if ( !strcmp(model_name, "LOG_CONF") )
 	{
 	  vn_glob[mn]->evssModel = LOG_CONF;
+	}
+      else if ( !strcmp(model_name, "LOG_CONF_GRADV") )
+	{
+	  vn_glob[mn]->evssModel = LOG_CONF_GRADV;
 	}
       else
 	{
@@ -2684,7 +2692,7 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 	      exit(-1);
 	    }
 
-	  if( vn_glob[mn]->evssModel == LOG_CONF )
+	  if( vn_glob[mn]->evssModel == LOG_CONF || vn_glob[mn]->evssModel == LOG_CONF_GRADV)
 	    {
 	      if ( modal_data[mn] != 0.0 )
 		{

--- a/src/mm_ns_bc.c
+++ b/src/mm_ns_bc.c
@@ -4188,7 +4188,7 @@ fvelo_slip_level(double func[MAX_PDIM],
   /* compute stress tensor and its derivatives */
   if( type == VELO_SLIP_LEVEL_SIC_BC) 
     {
-      if(vn->evssModel == LOG_CONF)
+      if(vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
         {
           fluid_stress_conf( Pi, d_Pi);
         }
@@ -4904,7 +4904,7 @@ sheet_tension ( double cfunc[MDE][DIM],
         }
     }
 
-    if(vn->evssModel == LOG_CONF)
+    if(vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
       {
         fluid_stress_conf( Pi, &d_Pi);
       }
@@ -6553,7 +6553,7 @@ flow_n_dot_T_nobc(double func[DIM],
   if(iflag == -1) fv->P = pdatum;
 
   /* compute stress tensor and its derivatives */
-  if(vn->evssModel == LOG_CONF)
+  if(vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
     {
       fluid_stress_conf( Pi, d_Pi);
     }
@@ -6731,7 +6731,8 @@ flow_n_dot_T_nobc(double func[DIM],
 	    }
 	}
 
-      if ( pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F || vn->evssModel == LOG_CONF) )
+      if ( pd->v[POLYMER_STRESS11] && (vn->evssModel == EVSS_F || vn->evssModel == LOG_CONF
+				       || vn->evssModel == EVSS_GRADV || vn->evssModel == LOG_CONF_GRADV) )
 	{
 	  for (p=0; p<pd->Num_Dim; p++)
 	    {
@@ -7484,6 +7485,7 @@ stress_no_v_dot_gradS_logc(double func[MAX_MODES][6],
   int v_s[MAX_MODES][DIM][DIM];
   int inv_v_s [DIM][DIM];
   int dim = pd->Num_Dim;
+  int logc_gradv = 0;
 
   dbl grad_v[DIM][DIM];    /* Velocity gradient based on velocity - discontinuous across element */
   dbl gamma[DIM][DIM];     /* Shear-rate tensor based on velocity */
@@ -7546,6 +7548,11 @@ stress_no_v_dot_gradS_logc(double func[MAX_MODES][6],
   memset( R1, 0, sizeof(double)*DIM*DIM);
   memset( eig_values, 0, sizeof(double)*DIM);
 
+  if(vn->evssModel == LOG_CONF_GRADV)
+    {
+      logc_gradv = 1;
+    }
+  
   /*
    * Load up Field variables...
    */
@@ -7670,7 +7677,14 @@ stress_no_v_dot_gradS_logc(double func[MAX_MODES][6],
               Rt_dot_gradv[i][j] = 0.;  
               for(w=0; w<VIM; w++) 
                 {
-                  Rt_dot_gradv[i][j] += R1_T[i][w] * gt[w][j];
+		  if(logc_gradv)
+		    {
+		      Rt_dot_gradv[i][j] += R1_T[i][w] * grad_v[j][w];
+		    }
+		  else
+		    {
+		      Rt_dot_gradv[i][j] += R1_T[i][w] * gt[w][j];
+		    }
                 }
             }
         }     
@@ -11256,7 +11270,7 @@ apply_sharp_wetting_velocity(double func[MAX_PDIM],
   /* compute stress tensor and its derivatives */
   if( include_stress)  
     {
-      if(vn->evssModel == LOG_CONF)
+      if(vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
         {
           fluid_stress_conf( Pi, d_Pi);
         }
@@ -14892,7 +14906,7 @@ shear_to_shell ( double cfunc[MDE][DIM],
   
   detJ = 1.0;
 
-  if(vn->evssModel == LOG_CONF)
+  if(vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
     {
       fluid_stress_conf( Pi, &d_Pi);
     }

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -2515,7 +2515,8 @@ calc_standard_fields(double **post_proc_vect, /* rhs vector now called
     local_lumped[VON_MISES_STRESS] = 1.;
   }
 
-  if (LOG_CONF_MAP != -1 && pd->v[POLYMER_STRESS11] && vn->evssModel == LOG_CONF) {
+  if (LOG_CONF_MAP != -1 && pd->v[POLYMER_STRESS11] &&
+      (vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)) {
     index = 0;
     VISCOSITY_DEPENDENCE_STRUCT d_mup_struct;
     VISCOSITY_DEPENDENCE_STRUCT *d_mup = &d_mup_struct;

--- a/src/mm_sol_nonlinear.c
+++ b/src/mm_sol_nonlinear.c
@@ -944,7 +944,8 @@ EH(-1,"version not compiled with frontal solver");
 				     &num_total_nodes,
 				     &h_elem_avg, &U_norm, NULL);
 	     
-              if( vn->evssModel == LOG_CONF && pd->v[POLYMER_STRESS11] && af->Assemble_Jacobian == TRUE)
+              if( (vn->evssModel == LOG_CONF || vn->evssModel == LOG_CONF_GRADV)
+		  && pd->v[POLYMER_STRESS11] && af->Assemble_Jacobian == TRUE)
                 {
                   numerical_jacobian_compute_stress(ams, x, resid_vector, delta_t, theta, 
                                      x_old, x_older, xdot, xdot_old,x_update,


### PR DESCRIPTION
Added two more options for Polymer Stress Formulation: EVSS_GRADV and LOG_CONF_GRADV. These Polymer Stress Formulations are versions of EVSS_F and LOG_CONF that use the velocity gradient in the assemble_stress functions instead of the velocity gradient projection G.