### PR TITLE
fix memory error in bulk_side_id_and_stu  from slider_shell problem

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -238,7 +238,7 @@ INCLUDES = $(GOMA_INC) $(SPARSE_INC) $(TRILINOS_INC) \
 DEBUG_FLAGS ?= -g -gdwarf-2
 
 # All compiler options
-CCFLAGS ?= -O
+CCFLAGS ?= -O2
 
 # C/C++ warning flags
 C_WARN_FLAGS ?= -Wall

--- a/src/mm_shell_util.c
+++ b/src/mm_shell_util.c
@@ -920,7 +920,7 @@ bulk_side_id_and_stu(const int bulk_elem, const int shell_elem,
   double sign, Hsign = 0.0, Lsign = 0.0, r;
   int bulk_dim, shell_dim, nbulk = 0, nshell = 0, nmatch;
   int iH = -1, iL = -1, s_first = 0, bulk_n1, bulk_n2;
-  int bulk_nodes[8], shell_nodes[4], matches[4];
+  int bulk_nodes[8], shell_nodes[4], matches[8];
   int bulk_node_order[4];
   int bulk_type = Elem_Type(exo, bulk_elem);
   int bulk_eptr = Proc_Connect_Ptr[bulk_elem];


### PR DESCRIPTION
Closes #61, found when debugging rotation fixes as I had optimization turned on.
