### PR TITLE
Add DPI information for rotated BCs

### DIFF
--- a/include/brkfix/exo_utils.h
+++ b/include/brkfix/exo_utils.h
@@ -39,10 +39,6 @@ EXTERN Element_shape type2shape
 PROTO((const Element_type ));
 #endif
 
-EXTERN int find_element_block
-PROTO(( Exo_DB *,   // Exodus database
-	int ));     // Element number
-
 EXTERN int find_element_friends  // Outputs number of friends found
 PROTO(( Exo_DB *,   // Exodus database
 	int,        // Element of which I want to find friends

--- a/include/dpi.h
+++ b/include/dpi.h
@@ -89,6 +89,8 @@
 #define DIM_NUM_SIDE_SETS			"num_side_sets_proc"
 #define DIM_NUM_SIDE_SETS_GLOBAL		"num_side_sets_global"
 #define DIM_NUM_UNIVERSE_NODES			"num_universe_nodes"
+#define DIM_LEN_SS_BLOCK_INDEX_GLOBAL           "len_ss_block_index_global"
+#define DIM_LEN_SS_BLOCK_LIST_GLOBAL            "len_ss_block_list_global"
 
 /*
  * netCDF Variables.
@@ -146,6 +148,10 @@
 #define VAR_SS_NUM_SIDES_GLOBAL			"ss_num_sides_global"
 #define VAR_SS_PROP_GLOBAL			"ss_prop_global"
 #define VAR_UNDEFINED_BASIC_EQNVAR_ID		"undefined_basic_eqnvar_id"
+
+#define VAR_SS_BLOCK_INDEX_GLOBAL               "ss_block_index_global"
+#define VAR_SS_BLOCK_LIST_GLOBAL                "ss_block_list_global"
+#define VAR_SS_INTERNAL_GLOBAL                  "ss_internal_global"
 
 /*
  * Some defaults describing the maximum problem sizes that were considered
@@ -251,6 +257,7 @@ struct Distributed_Processing_Information
 
   int *ns_node_index_global;	/* New! [num_node_sets_global] */
   int *ns_distfact_index_global;/* New! [num_node_sets_global] */
+  int *ss_internal_global;
 
   int *ns_distfact_list_index_global; /* New! - where to put distfacts from
 				       * this processor in the global list
@@ -328,6 +335,9 @@ struct Distributed_Processing_Information
   int undefined_basic_eqnvar_id; /* scalar - pad ends of the rectangular shaped
 				  * 2d arrays of node descriptions with these*/
 
+  int *ss_block_index_global;
+  int *ss_block_list_global;
+
 };
 
 typedef struct Distributed_Processing_Information Dpi;
@@ -380,6 +390,8 @@ struct Shadow_Identifiers
   int num_side_sets;
   int num_side_sets_global;
   int num_universe_nodes;
+  int len_ss_block_index_global;
+  int len_ss_block_list_global;
 
   /*
    * variables (arrays).
@@ -443,6 +455,11 @@ struct Shadow_Identifiers
   int ss_elem_index_global;
   int ss_elem_len_global;
   int ss_elem_list_index_global;
+
+  int ss_block_index_global;
+  int ss_block_list_global;
+  int ss_internal_global;
+
 
   int ss_id_global;		/* List of global side set identifiers. */
   int ss_index_global;		/* Global sideset INDEX for each local

--- a/include/rd_mesh.h
+++ b/include/rd_mesh.h
@@ -26,6 +26,8 @@
 #define EXTERN extern
 #endif
 
+EXTERN int * find_ss_internal_boundary(Exo_DB *e);
+
 EXTERN int find_mat_number	/* rd_mesh.c */
 PROTO((const int ,		/* ielem - element number (0 based) */
        const Exo_DB *));	/* exo - the whole mesh */
@@ -44,7 +46,9 @@ PROTO((Exo_DB *,		/* ptr to EXOII mesh datastructure */
        Dpi    *));		/* ptr to distributed processing info d.s. */
 
 EXTERN void setup_old_exo	/* rd_mesh.c */
-PROTO((Exo_DB *));		/* ptr to EXODUS II mesh database */
+PROTO((Exo_DB *,		/* ptr to EXODUS II mesh database */
+       Dpi *,
+       int));
 
 EXTERN void check_sidesets	/* rd_mesh.c */
 PROTO((Exo_DB *,		/* EXODUS II FE db has all mesh info    (in) */

--- a/src/brkfix/brk_exo_file.c
+++ b/src/brkfix/brk_exo_file.c
@@ -727,7 +727,7 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
 
   zero_base(mono);
 
-  setup_old_exo(mono);
+  setup_old_exo(mono, NULL, 1);
 
 
   /*
@@ -1573,6 +1573,8 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
   ebi              = (int *) smalloc(neb*SZ_INT);
 
   new_proc_eb_ptr  = (int *) smalloc((neb+1)*SZ_INT);
+
+  int * ss_internal = find_ss_internal_boundary(mono);
 
   for ( s=0; s<num_pieces; s++)
     {
@@ -4061,6 +4063,57 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
 	    }
 	}
 
+      D->ss_block_index_global = NULL;
+      D->ss_block_list_global = NULL;
+      if (mono->num_side_sets > 0)
+        {
+          D->ss_block_index_global =
+              calloc(mono->num_side_sets + 1, sizeof(int));
+          D->ss_block_list_global =
+              calloc(MAX_MAT_PER_SS * mono->num_side_sets, sizeof(int));
+
+          // populate list of blocks associated to side sets
+
+          int ss_block_index = 0;
+          for (int ss_id = 0; ss_id < mono->num_side_sets; ss_id++)
+            {
+              int ss_start = ss_block_index;
+              for (int elem_index = mono->ss_elem_index[ss_id];
+                   elem_index <
+                   (mono->ss_elem_index[ss_id] + mono->ss_num_sides[ss_id]);
+                   elem_index++)
+                {
+                  int elem = mono->ss_elem_list[elem_index];
+                  int block = find_elemblock_index(elem, mono);
+                  if (block == -1)
+                    {
+                      EH(-1, "Element block not found");
+                    }
+
+                  // check if block is in array for ss already
+                  int known = 0;
+                  for (int i = ss_start; i < ss_block_index; i++)
+                    {
+                      if (D->ss_block_list_global[i] == block)
+                        {
+                          known = 1;
+                        }
+                    }
+
+                  if (!known)
+                    {
+                      D->ss_block_list_global[ss_block_index] = block;
+                      ss_block_index++;
+                    }
+                }
+
+              D->ss_block_index_global[ss_id] = ss_start;
+              D->ss_block_index_global[ss_id + 1] = ss_block_index;
+            }
+        }
+
+      D->ss_internal_global = ss_internal;
+
 #ifdef DEBUG
       for ( i=0; i<mono->eb_num_props; i++)
 	{
@@ -4516,14 +4569,18 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
 
       free(D->global_node_description[0]);
       free(D->eb_elem_type_global[0]);
+
+      D->ss_internal_global = NULL; // skip freeing ss_internal
       free_dpi(D);
 
     } /* set loop */
+
 
   free(proc_eb_id);
   free(proc_eb_ptr);
   free(ebi);
   free(new_proc_eb_ptr);
+  free(ss_internal);
 
   if ( mono->num_dim > 0 )
     {
@@ -4858,17 +4915,12 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
 
   free(Proc_SS_Node_Count);
   free(Proc_SS_Node_Pointers);
-  free(SS_Internal_Boundary);
   free(mono->eb_elem_itype);
 
   free(Coor);
   Coor = NULL;
   free(Matilda);
   Matilda = NULL;
-
-  for ( i=0; i<MAX_MAT_PER_SS+1; i++) {
-    free(ss_to_blks[i]);
-  }
 
   free_element_blocks(mono);
 

--- a/src/rd_mesh.c
+++ b/src/rd_mesh.c
@@ -205,9 +205,17 @@ read_mesh_exoII(Exo_DB *exo,
     }
 	
 
+  // SS_Internal_Boundary uses the dpi values
+  SS_Internal_Boundary = alloc_int_1(exo->num_side_sets, INT_NOINIT);
+  for (int ss_index = 0; ss_index < exo->num_side_sets; ss_index++)
+    {
+      int global_ss_index = dpi->ss_index_global[ss_index];
+      SS_Internal_Boundary[ss_index] = dpi->ss_internal_global[global_ss_index];
+    }
+
   setup_old_dpi(exo, dpi);
 
-  setup_old_exo(exo);
+  setup_old_exo(exo, dpi, Num_Proc);
 
   /*
    * Duane mentions that blindly compiling with MDE too low (like 12)
@@ -266,6 +274,112 @@ read_mesh_exoII(Exo_DB *exo,
   return 0;
 }
 
+
+/*
+ * Finally, determine whether a particular side set is internal or
+ * external.
+ *
+ * Ground Rules:
+ *	[1] A side set is external if it is not internal.
+ *	[2] A side set is internal if any two element/side pairs share nodes.
+ *   [3] It suffices to look for duplicate nodes only among the
+ *	    element/side pairs in the same side set. I.e., an "internal" sideset
+ *       is not supposed to have two side sets associated with it.
+ *   [4] Note that side sets that are partially internal and partially
+ *	    external are not accounted for in this scheme. Unless you rewrite
+ *	    the code, you'll need to break those hybrids into pieces.
+ */
+
+int *find_ss_internal_boundary(Exo_DB *e)
+{
+  char err_msg[MAX_CHAR_ERR_MSG];
+  int *ss_is_internal = alloc_int_1(e->num_side_sets, -1);
+  int *first_side_node_list = alloc_int_1(MAX_NODES_PER_SIDE, -1);
+  int *other_side_node_list = alloc_int_1(MAX_NODES_PER_SIDE, -1);
+
+  for (int ss_index = 0; ss_index < e->num_side_sets; ss_index++)
+    {
+      /*
+       * It suffices to check the first element/side pair. The nodes here
+       * are cross-checked with the nodes in subsequent element/side pairs
+       * in this same sideset.
+       */
+      int side = 0;
+      int start = e->ss_node_side_index[ss_index][side];
+      int end = e->ss_node_side_index[ss_index][side + 1];
+      for (int i = 0; i < (end - start); i++)
+        {
+          first_side_node_list[i] = e->ss_node_list[ss_index][start + i];
+        }
+
+      /*
+       * Sort the node numbers into ascending order.
+       */
+      if ((end - start) < 1)
+        {
+          EH(-1, "Bad side node index listing!");
+        }
+      integer_sort((end - start), first_side_node_list);
+
+      /*
+       * Now look at the 2nd through last elem/sides nodegroups for any match,
+       * but only if there are at least 2 sides in this sideset.
+       *
+       *	"Just one side?"
+       *
+       *	"You're external, buddy!
+       */
+
+      int num_sides = e->ss_num_sides[ss_index];
+      if (num_sides > 1)
+        {
+          side = 1;
+          int match_found = FALSE;
+          do
+            {
+              int start = e->ss_node_side_index[ss_index][side];
+              int end = e->ss_node_side_index[ss_index][side + 1];
+              for (int i = 0; i < (end - start); i++)
+                {
+                  other_side_node_list[i] =
+                      e->ss_node_list[ss_index][start + i];
+                }
+              if ((end - start) < 1)
+                {
+                  sprintf(err_msg,
+                          "SS ID %d (%d sides), side_index[%d]=%d, "
+                          "side_index[%d]=%d",
+                          e->ss_id[ss_index], e->ss_num_sides[ss_index], side,
+                          start, side + 1, end);
+                  EH(-1, err_msg);
+                }
+              integer_sort((end - start), other_side_node_list);
+              int equal_vectors = TRUE;
+              for (int i = 0; i < (end - start); i++)
+                {
+                  equal_vectors &=
+                      (other_side_node_list[i] == first_side_node_list[i]);
+                }
+              match_found = equal_vectors;
+              side++;
+            }
+          while (side < num_sides && !match_found);
+
+          if (match_found)
+            {
+              /*
+               * Set this indicator to the SS ID, but any quantity not
+               * equal to "0" would do just as well.
+               */
+              ss_is_internal[ss_index] = e->ss_id[ss_index];
+            }
+        }
+    }
+  free(other_side_node_list);
+  free(first_side_node_list);
+  return ss_is_internal;
+}
+
 /*
  * The new fangled read routines for EXODUS II data have filled a data
  * structure. This data structure is mined and the values of the traditional
@@ -274,23 +388,19 @@ read_mesh_exoII(Exo_DB *exo,
  * arrays are allocated.
  */
 
-void 
-setup_old_exo(Exo_DB *e)
+void
+setup_old_exo(Exo_DB *e, Dpi *dpi, int num_proc)
 {
   /* int blk_start; */
   int cur;			/* tmp counter for how many ebs touch a SS */
   /* int eb;			 element block index */
   int ebi;
   int elem;
-  int equal_vectors;		/* boolean */
-  int hi;
   int i;
   int j;
   int k;
-  int l;
   int length;
   int lo;
-  int match_found;		/* boolean */
   int mmps;			/* max EBs (~mats) per side set found */
   /*   int nb;			 number of blocks */
   int node;
@@ -298,7 +408,6 @@ setup_old_exo(Exo_DB *e)
   int nodes_this_side;
   int npe;
   int num_sides;
-  int side;
   int ss_index;			
   int ss_index_max;		/* index for SS touching the most EBs */
   /* int start; */
@@ -309,8 +418,6 @@ setup_old_exo(Exo_DB *e)
   int *ssl;			/* lists of sidesets that EBs touch */
   int *ssp;			/* side set pointers */
 
-  int *snl_std;			/* tmp arrays of unique nodes on SSs used */
-  int *snl_cmp;			/* to determine external/internal status */
   char Title[MAX_LINE_LENGTH+1];/* EXODUS II title                              */
   char err_msg[MAX_CHAR_ERR_MSG];
   strcpy(Title,          e->title);
@@ -630,18 +737,33 @@ setup_old_exo(Exo_DB *e)
 	 }
      }
 
-   for ( ss_index=0; ss_index<e->num_side_sets; ss_index++)
+   if (num_proc > 1) {
+    for ( ss_index=0; ss_index<e->num_side_sets; ss_index++) 
      {
+        ss_to_blks[0][ss_index] = e->ss_id[ss_index];
 
-       ss_to_blks[0][ss_index] = e->ss_id[ss_index];
-
-       lo = ssp[ss_index];
-
-       for ( j=ssp[ss_index]; j<ssp[ss_index+1]; j++)
-	 {
-	   ss_to_blks[j-lo+1][ss_index] = e->eb_id[ebl[j]];
-	 }
+        int global_ss_index = dpi->ss_index_global[ss_index];
+        int start = dpi->ss_block_index_global[global_ss_index];
+        int end = dpi->ss_block_index_global[global_ss_index +1];
+        for (int bidx = start; bidx < end; bidx++) {
+          // expects 1-indexed blocks
+          ss_to_blks[bidx - start + 1][ss_index] = dpi->ss_block_list_global[bidx] + 1;
+        }
      }
+   } else {
+       
+    for ( ss_index=0; ss_index<e->num_side_sets; ss_index++)
+        {
+        ss_to_blks[0][ss_index] = e->ss_id[ss_index];
+
+        lo = ssp[ss_index];
+
+        for ( j=ssp[ss_index]; j<ssp[ss_index+1]; j++)
+            {
+            ss_to_blks[j-lo+1][ss_index] = e->eb_id[ebl[j]];
+            }
+        }
+   }
 
    /*
     * Tell us about this connectivity...
@@ -678,90 +800,6 @@ setup_old_exo(Exo_DB *e)
 #endif
 
    /*
-    * Finally, determine whether a particular side set is internal or
-    * external. 
-    *
-    * Ground Rules:
-    *	[1] A side set is external if it is not internal.
-    *	[2] A side set is internal if any two element/side pairs share nodes. 
-    *   [3] It suffices to look for duplicate nodes only among the 
-    *	    element/side pairs in the same side set. I.e., an "internal" sideset
-    *       is not supposed to have two side sets associated with it.
-    *   [4] Note that side sets that are partially internal and partially
-    *	    external are not accounted for in this scheme. Unless you rewrite
-    *	    the code, you'll need to break those hybrids into pieces.
-    */
-
-   SS_Internal_Boundary = alloc_int_1(e->num_side_sets, -1);
-   snl_std = alloc_int_1(MAX_NODES_PER_SIDE, -1);
-   snl_cmp = alloc_int_1(MAX_NODES_PER_SIDE, -1);
-
-   for (ss_index = 0; ss_index < e->num_side_sets; ss_index++) {
-     /*
-      * It suffices to check the first element/side pair. The nodes here
-      * are cross-checked with the nodes in subsequent element/side pairs
-      * in this same sideset.
-      */
-     side  = 0;
-     lo    = e->ss_node_side_index[ss_index][side];
-     hi    = e->ss_node_side_index[ss_index][side+1];
-     for (l = 0; l < (hi-lo); l++) {
-       snl_std[l] = e->ss_node_list[ss_index][lo+l];
-     }
-
-     /*
-      * Sort the node numbers into ascending order.
-      */
-     if ((hi-lo) < 1) {
-       EH(-1, "Bad side node index listing!");
-     }
-     integer_sort((hi-lo), snl_std);
-
-     /*
-      * Now look at the 2nd through last elem/sides nodegroups for any match,
-      * but only if there are at least 2 sides in this sideset.
-      *
-      *	"Just one side?" 
-      *
-      *	"You're external, buddy!
-      */
-
-     num_sides   = e->ss_num_sides[ss_index];
-     if (num_sides > 1) { 
-       side        = 1;
-       match_found = FALSE;
-       do {
-	 lo    = e->ss_node_side_index[ss_index][side];
-	 hi    = e->ss_node_side_index[ss_index][side+1];
-	 for (l = 0; l < (hi-lo); l++) {
-	   snl_cmp[l] = e->ss_node_list[ss_index][lo+l];
-	 }
-	 if ((hi-lo) < 1) {
-	   sprintf(err_msg, 
-                   "SS ID %d (%d sides), side_index[%d]=%d, side_index[%d]=%d",
-		   e->ss_id[ss_index], e->ss_num_sides[ss_index],
-		   side, lo, side+1, hi);
-	   EH(-1, err_msg);
-	 }
-	 integer_sort((hi-lo), snl_cmp);
-	 equal_vectors = TRUE;
-	 for (l = 0; l < (hi-lo); l++) {
-	   equal_vectors &= (snl_cmp[l] == snl_std[l]);
-	 }
-	 match_found = equal_vectors;
-	 side++;
-       } while (side<num_sides && !match_found);
-       if (match_found) {
-	 /*
-	  * Set this indicator to the SS ID, but any quantity not
-	  * equal to "0" would do just as well.
-	  */
-	 SS_Internal_Boundary[ss_index] = e->ss_id[ss_index];
-       }
-     }
-   }
-
-   /*
     * The node_map and elem_map from EXODUS are no longer appropriated by
     * our parallel processing needs. They are being returned to whatever
     * other uses you may have for them.
@@ -786,8 +824,6 @@ setup_old_exo(Exo_DB *e)
   /*
    * Free malloced memory from this routine
    */
-  safer_free((void **) &snl_std);
-  safer_free((void **) &snl_cmp);
   safer_free((void **) &ssp);
   safer_free((void **) &ebl);
 
@@ -1113,7 +1149,7 @@ check_elemblocks(Exo_DB *e,	   /* EXODUS II FE db has all mesh info (in) */
 
 void
 setup_old_dpi(Exo_DB *e,
-	      Dpi    *d)
+          Dpi    *d)
 {
 
   Num_Internal_Nodes = d->num_internal_nodes;

--- a/src/rd_mesh.c
+++ b/src/rd_mesh.c
@@ -202,6 +202,7 @@ read_mesh_exoII(Exo_DB *exo,
 				   like the element number map, but some
 				   information has its own netcdf name.
 				   */
+      check_parallel_error("Error in reading Distributed Processing Information");
     }
 	
 

--- a/src/wr_dpi.c
+++ b/src/wr_dpi.c
@@ -299,6 +299,24 @@ wr_dpi(Dpi *d,
 		   d->num_universe_nodes,
 		   &si.num_universe_nodes);
 
+  
+  if (d->num_side_sets_global > 0) {
+    define_dimension(u, DIM_LEN_SS_BLOCK_INDEX_GLOBAL,
+                     d->num_side_sets_global + 1,
+                     &si.len_ss_block_index_global);
+    
+    define_dimension(u, DIM_LEN_SS_BLOCK_LIST_GLOBAL,
+                     d->ss_block_index_global[d->num_side_sets_global],
+                     &si.len_ss_block_list_global);
+  } else {
+      define_dimension(u, DIM_LEN_SS_BLOCK_INDEX_GLOBAL,
+                       0,
+                       &si.len_ss_block_index_global);
+      define_dimension(u, DIM_LEN_SS_BLOCK_LIST_GLOBAL,
+                       0,
+                       &si.len_ss_block_list_global);
+  }
+
   /*
    * Define variables. Arrays only get defined if their respective dimensions
    * are greater than zero.
@@ -575,6 +593,24 @@ wr_dpi(Dpi *d,
 		      &si.ss_prop_global);
     }
 
+  if ( d->num_side_sets_global > 0 )
+    {
+      define_variable(u, VAR_SS_INTERNAL_GLOBAL, NC_INT, 1,
+                      si.num_side_sets_global, -1,
+                      d->num_side_sets_global, -1,
+                      &si.ss_internal_global);
+
+      define_variable(u, VAR_SS_BLOCK_INDEX_GLOBAL, NC_INT, 1,
+                      si.len_ss_block_index_global, -1,
+                      d->num_side_sets_global + 1, -1,
+                      &si.ss_block_index_global);
+
+      define_variable(u, VAR_SS_BLOCK_LIST_GLOBAL, NC_INT, 1,
+                      si.len_ss_block_list_global, -1,
+                      d->ss_block_index_global[d->num_side_sets_global], -1,
+                      &si.ss_block_list_global);
+    }
+
   define_variable(u, VAR_UNDEFINED_BASIC_EQNVAR_ID, NC_INT, 0, 
 		  -1, -1,
 		  -1, -1,
@@ -829,6 +865,21 @@ wr_dpi(Dpi *d,
   put_variable(u, NC_INT, 0, 
 	       -1,	-1, 
 	       si.undefined_basic_eqnvar_id, &(d->undefined_basic_eqnvar_id));
+
+  if (d->num_side_sets_global > 0) {
+
+      put_variable(u, NC_INT, 1,
+                   d->num_side_sets_global, -1,
+                   si.ss_internal_global, d->ss_internal_global);
+
+      put_variable(u, NC_INT, 1,
+                   d->num_side_sets_global+1, -1,
+                   si.ss_block_index_global, d->ss_block_index_global);
+
+      put_variable(u, NC_INT, 1,
+                   d->ss_block_index_global[d->num_side_sets_global], -1,
+                   si.ss_block_list_global, d->ss_block_list_global);
+  }
 
   /*
    * Close the file (flush buffers).


### PR DESCRIPTION
Adds new dpi variables to create ss_to_blks and SS_Internal_Boundary so that they are consistent with serial goma.

Allows the use of rotated BCs on double sided side sets in parallel.

Closes #132 

Linked to goma/brkfix#5