### PR TITLE
use old style loop variable definitions until CMakeLists.txt/Makefile is updated to use gnu99 by default

### DIFF
--- a/src/brkfix/brk_exo_file.c
+++ b/src/brkfix/brk_exo_file.c
@@ -4075,10 +4075,12 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
           // populate list of blocks associated to side sets
 
           int ss_block_index = 0;
-          for (int ss_id = 0; ss_id < mono->num_side_sets; ss_id++)
+          int ss_id;
+          for (ss_id = 0; ss_id < mono->num_side_sets; ss_id++)
             {
               int ss_start = ss_block_index;
-              for (int elem_index = mono->ss_elem_index[ss_id];
+              int elem_index;
+              for (elem_index = mono->ss_elem_index[ss_id];
                    elem_index <
                    (mono->ss_elem_index[ss_id] + mono->ss_num_sides[ss_id]);
                    elem_index++)
@@ -4092,7 +4094,8 @@ brk_exo_file(int num_pieces, char *Brk_File, char *Exo_File)
 
                   // check if block is in array for ss already
                   int known = 0;
-                  for (int i = ss_start; i < ss_block_index; i++)
+                  int i;
+                  for (i = ss_start; i < ss_block_index; i++)
                     {
                       if (D->ss_block_list_global[i] == block)
                         {

--- a/src/rd_mesh.c
+++ b/src/rd_mesh.c
@@ -1,3 +1,4 @@
+
 /************************************************************************ *
 * Goma - Multiphysics finite element software                             *
 * Sandia National Laboratories                                            *
@@ -208,7 +209,8 @@ read_mesh_exoII(Exo_DB *exo,
 
   // SS_Internal_Boundary uses the dpi values
   SS_Internal_Boundary = alloc_int_1(exo->num_side_sets, INT_NOINIT);
-  for (int ss_index = 0; ss_index < exo->num_side_sets; ss_index++)
+  int ss_index;
+  for (ss_index = 0; ss_index < exo->num_side_sets; ss_index++)
     {
       int global_ss_index = dpi->ss_index_global[ss_index];
       SS_Internal_Boundary[ss_index] = dpi->ss_internal_global[global_ss_index];
@@ -298,7 +300,8 @@ int *find_ss_internal_boundary(Exo_DB *e)
   int *first_side_node_list = alloc_int_1(MAX_NODES_PER_SIDE, -1);
   int *other_side_node_list = alloc_int_1(MAX_NODES_PER_SIDE, -1);
 
-  for (int ss_index = 0; ss_index < e->num_side_sets; ss_index++)
+  int ss_index;
+  for (ss_index = 0; ss_index < e->num_side_sets; ss_index++)
     {
       /*
        * It suffices to check the first element/side pair. The nodes here
@@ -308,7 +311,8 @@ int *find_ss_internal_boundary(Exo_DB *e)
       int side = 0;
       int start = e->ss_node_side_index[ss_index][side];
       int end = e->ss_node_side_index[ss_index][side + 1];
-      for (int i = 0; i < (end - start); i++)
+      int i;
+      for (i = 0; i < (end - start); i++)
         {
           first_side_node_list[i] = e->ss_node_list[ss_index][start + i];
         }
@@ -340,7 +344,8 @@ int *find_ss_internal_boundary(Exo_DB *e)
             {
               int start = e->ss_node_side_index[ss_index][side];
               int end = e->ss_node_side_index[ss_index][side + 1];
-              for (int i = 0; i < (end - start); i++)
+	      int i;
+              for (i = 0; i < (end - start); i++)
                 {
                   other_side_node_list[i] =
                       e->ss_node_list[ss_index][start + i];
@@ -356,7 +361,7 @@ int *find_ss_internal_boundary(Exo_DB *e)
                 }
               integer_sort((end - start), other_side_node_list);
               int equal_vectors = TRUE;
-              for (int i = 0; i < (end - start); i++)
+              for (i = 0; i < (end - start); i++)
                 {
                   equal_vectors &=
                       (other_side_node_list[i] == first_side_node_list[i]);
@@ -746,7 +751,8 @@ setup_old_exo(Exo_DB *e, Dpi *dpi, int num_proc)
         int global_ss_index = dpi->ss_index_global[ss_index];
         int start = dpi->ss_block_index_global[global_ss_index];
         int end = dpi->ss_block_index_global[global_ss_index +1];
-        for (int bidx = start; bidx < end; bidx++) {
+        int bidx;
+        for (bidx = start; bidx < end; bidx++) {
           // expects 1-indexed blocks
           ss_to_blks[bidx - start + 1][ss_index] = dpi->ss_block_list_global[bidx] + 1;
         }


### PR DESCRIPTION
Mainly for those using older compilers that don't default to gnu99