### PR TITLE
numjac uses h_elem_size so make it work with bar elements

### DIFF
--- a/src/mm_fill_aux.c
+++ b/src/mm_fill_aux.c
@@ -1013,6 +1013,15 @@ h_elem_siz(dbl hsquared[DIM], dbl hh[DIM][DIM],
     }
   }
   
+  // bar2 in 2d space (at least)
+  if (pd->Num_Dim == 2 && ei->ielem_dim == 1) {
+    memset(hsquared, 0.0, sizeof(double)*DIM*MDE);
+    p1[0] = xnode[0][0] - xnode[0][ei->num_local_nodes - 1];
+    p1[1] = xnode[1][0] - xnode[1][ei->num_local_nodes - 1];
+    hsquared[0] = p1[0]*p1[0] + p1[1]*p1[1];
+    return;
+  }
+
   if (dim == 2) {
     /*
      * Calculate the midpoint positions on each of the faces
@@ -1258,7 +1267,7 @@ global_h_elem_siz(dbl x[], dbl x_old[], dbl xdot[], dbl resid_vector[],
   for (e = 0; e < exo->num_elems; e++) {
     (void) load_elem_dofptr(e, exo , x, x_old, xdot, xdot, 
 			    resid_vector, 1);
-    if(ei->ielem_dim != 1) h_elem_siz(hsquared, hhv, dhv_dxnode, 0);
+    h_elem_siz(hsquared, hhv, dhv_dxnode, 0);
     h_elem = 0.;
     for (p = 0; p < ei->ielem_dim; p++) {
       h_elem += hsquared[p];


### PR DESCRIPTION
numjac should always get acceptable values for estimating length scale of elements with one dimension.