### PR TITLE
Add FP_EXCEPT compile flag to enable floating point exception checking

### DIFF
--- a/settings.mk-example
+++ b/settings.mk-example
@@ -89,6 +89,9 @@ PREFIX = /home/goma/build
 # If you want stratimikos support, use the above DEFINES and add the following
 #	     -DHAVE_STRATIMIKOS
 
+# Enable trapping on floating point exception (useful for debugging NaN's)
+#	     -DFP_EXCEPT
+
 # TOOLING used for install, cleaning, and library creation
 # install
 # INSTALL	= cp

--- a/src/main.c
+++ b/src/main.c
@@ -74,6 +74,10 @@ extern void handle_ieee(void );
 
 #include "brk_utils.h"
 
+#ifdef FP_EXCEPT
+#include <fenv.h>
+#endif
+
 #define _MAIN_C
 #include "goma.h"
 
@@ -210,7 +214,11 @@ main(int argc, char **argv)
   int           nclc = 0;		/* number of command line commands */
 
 /********************** BEGIN EXECUTION ***************************************/
-  
+
+#ifdef FP_EXCEPT
+  feenableexcept ((FE_OVERFLOW | FE_DIVBYZERO | FE_INVALID));
+#endif
+
 /* assume number of commands is less than or equal to the number of 
  * arguments in the command line minus 1 (1st is program name) */
 


### PR DESCRIPTION
When compiled with FP_EXCEPT defined and a supported compiler gdb/ddd will break on floating point exception allowing you to backtrace easily.