### PR TITLE
Add a ENABLE_LOGGING ifdef, disable .log by default

### DIFF
--- a/include/mm_eh.h
+++ b/include/mm_eh.h
@@ -118,10 +118,27 @@ extern int current_severity;	/* global error signal (-1=die,0=prnt,1=dbg) */
  *
  * Requires use of a local static const char yo[] ="Routine_name".
  */
+#define log_err(...) \
+do \
+  { \
+    save_place(GOMA_ERR, yo, __FILE__, __LINE__);  \
+    logprintf(__VA_ARGS__); \
+  } while(0)
 
-#define log_err	save_place(GOMA_ERR, yo, __FILE__, __LINE__); logprintf
-#define log_msg save_place(GOMA_MSG, yo, __FILE__, __LINE__); logprintf
-#define log_dbg save_place(GOMA_DBG, yo, __FILE__, __LINE__); logprintf
+
+#define log_msg(...) \
+do \
+  { \
+    save_place(GOMA_MSG, yo, __FILE__, __LINE__);  \
+    logprintf(__VA_ARGS__); \
+  } while(0)
+
+#define log_dbg(...) \
+do \
+  { \
+    save_place(GOMA_DBG, yo, __FILE__, __LINE__);  \
+    logprintf(__VA_ARGS__); \
+  } while(0)
 
 #ifndef DEFAULT_GOMA_LOG_FILENAME
 #define DEFAULT_GOMA_LOG_FILENAME ".log"

--- a/settings.mk-example
+++ b/settings.mk-example
@@ -92,6 +92,9 @@ PREFIX = /home/goma/build
 # Enable trapping on floating point exception (useful for debugging NaN's)
 #	     -DFP_EXCEPT
 
+# To enable .log files with some extra information
+#	     -DENABLE_LOGGING
+
 # TOOLING used for install, cleaning, and library creation
 # install
 # INSTALL	= cp


### PR DESCRIPTION
Disables the .log files, to re-enable ENABLE_LOGGING can be passed as a compiler define.

Most people don't seem to look at these so it would be better to avoid creating them by default.

When running many problems in a single directory these can build up to large filesizes.

Closes #205 