### PR TITLE
Re-add isystem fix for newer compilers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -174,9 +174,10 @@ TRILINOS_TOP ?= $(GOMA_LIBS)/trilinos-12.10.1-Built
 include $(TRILINOS_TOP)/include/Makefile.export.Trilinos
 
 # Trilinos includes and libraries
-TRILINOS_INC ?= $(subst -I, -isystem, $(Trilinos_INCLUDE_DIRS) $(Trilinos_TPL_INCLUDE_DIRS))
+TRILINOS_INC_REMOVE_USR_INCLUDE = $(subst -I/usr/include, ,  $(Trilinos_INCLUDE_DIRS) $(Trilinos_TPL_INCLUDE_DIRS))
+TRILINOS_INC ?= $(subst -I, -isystem, $(TRILINOS_INC_REMOVE_USR_INCLUDE))
 TRILINOS_LIB ?= $(Trilinos_LIBRARY_DIRS) $(Trilinos_TPL_LIBRARY_DIRS) \
-		$(Trilinos_LIBRARIES) $(Trilinos_TPL_LIBRARIES)
+$(Trilinos_LIBRARIES) $(Trilinos_TPL_LIBRARIES)
 
 # ARPACK
 # ------


### PR DESCRIPTION
This fixed was removed in a previous pull request and missed on review, probably need to run the test suite on newer compilers and build with both cmake and makefile