### PR TITLE
Fix rare parallel bug where msr was corrupted

### DIFF
--- a/src/mm_sol_nonlinear.c
+++ b/src/mm_sol_nonlinear.c
@@ -2806,6 +2806,7 @@ if( *converged )
   if (Linear_Solver == AZTEC) ams->status[AZ_its] = total_ls_its;
   LOCA_UMF_ID = UMF_system_id;
 
+free_and_clear:  
 /*
  * If using LOCA, there may be another resolve after exiting the
  * nonlinear solver, so defer restoring external matrix rows
@@ -2822,8 +2823,6 @@ if( *converged )
           dofs_hidden = FALSE;
         }
     }
-
-free_and_clear:
 
   safe_free( (void *) delta_x);
   safe_free( (void *) res_p);


### PR DESCRIPTION
Fix rare bug where if a failure occurred in solve nonlinear the msr matrix could become corrupted.

This was due to show_external not being called with the msr format in this special case.