### PR TITLE
Replace ftp-link to netcdf package to https-link

### DIFF
--- a/scripts/build-goma-dependencies.sh
+++ b/scripts/build-goma-dependencies.sh
@@ -268,7 +268,7 @@ $MUMPS_MD5 \
 ARCHIVE_URLS=("http://www.caam.rice.edu/software/ARPACK/SRC/arpack96.tar.gz" \
 "http://www.caam.rice.edu/software/ARPACK/SRC/patch.tar.gz" \
 "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-${HDF5_VERSION}/src/hdf5-${HDF5_VERSION}.tar.bz2" \
-"ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-${NETCDF_VERSION}.tar.gz" \
+"https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-${NETCDF_VERSION}.tar.gz" \
 "http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/parmetis-4.0.3.tar.gz" \
 "http://downloads.sourceforge.net/project/sparse/sparse/sparse1.4b/sparse1.4b.tar.gz" \
 "http://codeload.github.com/xiaoyeli/superlu_dist/tar.gz/v5.1.3" \


### PR DESCRIPTION
In corporate environment it is frequently impossible to download anything (in our case - netcdf package) from ftp. Working alternative https-link has been found on the page [NetCDF Downloads](https://www.unidata.ucar.edu/downloads/netcdf/) and is suggested now as a replacement. 