### PR TITLE
Implement automatic recognition of stock openmpi in Ubuntu 19.X

### DIFF
--- a/scripts/build-goma-dependencies.sh
+++ b/scripts/build-goma-dependencies.sh
@@ -157,6 +157,8 @@ if [ "$PRINT_MENU" == "false" ]; then
             MPI_BASE_DIR="/usr/lib64/openmpi"
         elif [ -d "/usr/lib/openmpi" ] ; then
             MPI_BASE_DIR="/usr/lib/openmpi"
+        elif [ -d "/usr/lib/x86_64-linux-gnu/openmpi" ] ; then
+            MPI_BASE_DIR="/usr/lib/x86_64-linux-gnu/openmpi"
         else
             MPI_BASE_DIR="BUILD"
         fi

--- a/scripts/user-interaction.sh
+++ b/scripts/user-interaction.sh
@@ -112,6 +112,8 @@ function mpi_test {
                 MPI_BASE_DIR="/usr/lib64/openmpi"
             elif [ -d "/usr/lib/openmpi" ] ; then
                 MPI_BASE_DIR="/usr/lib/openmpi"
+            elif [ -d "/usr/lib/x86_64-linux-gnu/openmpi" ] ; then
+                MPI_BASE_DIR="/usr/lib/x86_64-linux-gnu/openmpi"
             else
                 echo "You have openMPI natively installed but I was unable to find it"
                 echo "Please enter your openMPI path"


### PR DESCRIPTION
In Ubuntu 19.X stock versions of openmpi libraries and include files are installed to the directory 
`/usr/lib/x86_64-linux-gnu/openmpi` and can't be found by the script  `scripts/build-goma-dependencies.sh`. Suggested modification resolves this issue.

P.S. I am not sure that automatic tests can determine possible errors, caused by this commit.
