### PR TITLE
Add regularized Saramito model and fix bug in 3D computation of deviatoric stress norm

### DIFF
--- a/include/mm_fill_stress.h
+++ b/include/mm_fill_stress.h
@@ -203,8 +203,9 @@ compute_d_exp_s_ds(dbl [DIM][DIM],                   //s - stress
                    dbl [DIM][DIM][DIM][DIM]);        // d_exp_s_ds
 
 dbl
-compute_saramito_model_terms(dbl stress[DIM][DIM],   // stresss
-                             dbl yield_stress,             // yield stress
-                             SARAMITO_DEPENDENCE_STRUCT* d_sCoeff); // struct for sCoeff sensitvities
+compute_saramito_model_terms(dbl [DIM][DIM],  // stress
+                             dbl,             // yield stress
+                             dbl,             // yield stress exponent
+                             SARAMITO_DEPENDENCE_STRUCT* ); // struct for sCoeff sensitvities
 
 #endif /* _MM_FILL_STRESS_H */

--- a/src/mm_fill_stress.c
+++ b/src/mm_fill_stress.c
@@ -6136,7 +6136,8 @@ compute_saramito_model_terms(dbl stress[DIM][DIM],
                                  dbl yieldStress,
                                  dbl yieldExpon,
                                  SARAMITO_DEPENDENCE_STRUCT *d_sCoeff) {
-  /* start by computing the norm of the deviatoric stress, sqrt(J_2)
+  /* start by computing the norm of sigma_d (the deviatoric stress) which is written as
+   * sqrt( trace(sigma_d*sigma_d)/2 )
    *
    * see the following wikipedia page for the mathematical details:
    * https://en.wikipedia.org/wiki/Cauchy_stress_tensor#Invariants_of_the_stress_deviator_tensor
@@ -6223,7 +6224,6 @@ compute_saramito_model_terms(dbl stress[DIM][DIM],
        *                        * d(normOfStressDSqr)/d(stress)
        */
 
-      // invVIM will be used as d(normOfStressD)/d(stress)
       dbl d_normOfStressD_d_Stress = 0.5 / normOfStressD * d_sCoeff_d_normOfStressD;
 
       for (int i = 0; i < VIM; i++) {

--- a/src/mm_fill_stress.c
+++ b/src/mm_fill_stress.c
@@ -6165,8 +6165,8 @@ compute_saramito_model_terms(dbl stress[DIM][DIM],
   dbl sCoeff;
   dbl expYSC=1;
   if(yieldExpon > 0){
-	  expYSC = exp(yieldExpon*sc);
-	  sCoeff = log( 1. + expYSC )/(yieldExpon);
+	  expYSC = exp(sc/yieldExpon);
+	  sCoeff = log( 1. + expYSC )*yieldExpon;
   }
   else{
 	  sCoeff = fmax(0, sc);

--- a/src/mm_fill_stress.c
+++ b/src/mm_fill_stress.c
@@ -6206,13 +6206,13 @@ compute_saramito_model_terms(dbl stress[DIM][DIM],
 
     if(VIM>2){
       d_sCoeff->s[0][0] += 2.*invDenom*( stress[0][0] - stress[2][2]);
-	    d_sCoeff->s[0][1] += 4.*invDenom*stress[0][1];
-	    d_sCoeff->s[1][0] += 4.*invDenom*stress[1][0];
+	  d_sCoeff->s[0][1] += 4.*invDenom*stress[0][1];
+	  d_sCoeff->s[1][0] += 4.*invDenom*stress[1][0];
       d_sCoeff->s[1][1] += 2.*invDenom*(stress[1][1] - stress[2][2]);
       d_sCoeff->s[0][2] = 2.*stress[0][2];
-	    d_sCoeff->s[2][0] = d_sCoeff->s[0][2];
+	  d_sCoeff->s[2][0] = d_sCoeff->s[0][2];
       d_sCoeff->s[1][2] = 2.*stress[1][2];
-	    d_sCoeff->s[2][1] = d_sCoeff->s[1][2];
+	  d_sCoeff->s[2][1] = d_sCoeff->s[1][2];
       d_sCoeff->s[2][2] = 2.*invDenom*( 2*stress[2][2] - stress[0][0] - stress[1][1]);
     }
 

--- a/src/mm_fill_stress.c
+++ b/src/mm_fill_stress.c
@@ -6142,17 +6142,17 @@ compute_saramito_model_terms(dbl stress[DIM][DIM],
    * https://en.wikipedia.org/wiki/Cauchy_stress_tensor#Invariants_of_the_stress_deviator_tensor
    */
 
-  dbl trace = 0;
+  dbl traceOverVIM = 0;
   for (int i = 0; i < VIM; i++) {
-    trace += stress[i][i];
+    traceOverVIM += stress[i][i];
   }
 
-  trace /= VIM;
+  traceOverVIM /= VIM;
 
   // square of the deviatoric sress norm
   dbl normOfStressDSqr = 0;
   for (int i = 0; i < VIM; i++) {
-    normOfStressDSqr += pow(stress[i][i] - trace, 2) / 2.;
+    normOfStressDSqr += pow(stress[i][i] - traceOverVIM, 2) / 2.;
 
     for (int j = i + 1; j < VIM; j++) {
       normOfStressDSqr += pow(stress[i][j], 2);
@@ -6202,7 +6202,7 @@ compute_saramito_model_terms(dbl stress[DIM][DIM],
       }
 
       for (int i = 0; i < VIM; i++) {
-        d_sCoeff->s[i][i] = -trace;
+        d_sCoeff->s[i][i] = -traceOverVIM;
 
         for (int j = i; j < VIM; j++) {
           if (i == j) {

--- a/src/mm_input_mp.c
+++ b/src/mm_input_mp.c
@@ -2893,12 +2893,28 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 	  vn_glob[mn]->ConstitutiveEquation == SARAMITO_GIESEKUS)
 	{
 	  /* Should yield stress be a modal property? Let's assume not for now */
-	  strcpy(search_string, "Polymer Yield Stress");
-
 	  dbl tau_y_val;
+	  dbl fexp_val;
+
+	  strcpy(search_string, "Polymer Yield Stress");
 	  model_read = look_for_mat_prop(imp, search_string, 
 					 &(ConstitutiveEquation), 
 					 &tau_y_val,
+					 NO_USER, NULL,
+					 model_name, SCALAR_INPUT, &NO_SPECIES,es);
+
+	  if( model_read < 1 )
+	    {
+	      if( model_read == -1) SPF(err_msg,"%s card is missing.",search_string);
+	      if( model_read == -2) SPF(err_msg,"Only CONSTANT %s mode model supported.", search_string);
+	      fprintf(stderr,"%s\n",err_msg);
+	      exit(-1);
+	    }
+
+	  strcpy(search_string, "Yield Exponent");
+	  model_read = look_for_mat_prop(imp, search_string, 
+					 &(ConstitutiveEquation), 
+					 &fexp_val,
 					 NO_USER, NULL,
 					 model_name, SCALAR_INPUT, &NO_SPECIES,es);
 
@@ -2913,6 +2929,7 @@ rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
 	  for(mm=0;mm<vn_glob[mn]->modes;mm++)
 	    {
 	      ve_glob[mn][mm]->gn->tau_y = tau_y_val;
+		  ve_glob[mn][mm]->gn->fexp = fexp_val;
 	    }
 	  ECHO(es,echo_file);
 	}

--- a/src/mm_ns_bc.c
+++ b/src/mm_ns_bc.c
@@ -7542,7 +7542,7 @@ stress_no_v_dot_gradS(double func[MAX_MODES][6],
 
       if(saramitoEnabled == TRUE)
 	{
-	  saramitoCoeff = compute_saramito_model_terms(s, ve[mode]->gn->tau_y, d_saramito);
+	  saramitoCoeff = compute_saramito_model_terms(s, ve[mode]->gn->tau_y, ve[mode]->gn->fexp, d_saramito);
 	}
       else
 	{

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -2197,17 +2197,17 @@ calc_standard_fields(double **post_proc_vect, /* rhs vector now called
   {  
     for (int mode = 0; mode < vn->modes; mode++) {
 
-      dbl trace = 0;
+      dbl traceOverVim = 0;
       for(int i=0; i<VIM; i++){
-        trace += fv->S[mode][i][i];
+        traceOverVim += fv->S[mode][i][i];
       }
 
-      trace /= VIM;
+      traceOverVim /= VIM;
 
       // square of the deviatoric sress norm
       dbl normOfStressDSqr = 0;
       for(int i=0; i<VIM; i++){
-        normOfStressDSqr += pow(fv->S[mode][i][i] - trace, 2)/2.;
+        normOfStressDSqr += pow(fv->S[mode][i][i] - traceOverVim, 2)/2.;
 
         for(int j=i+1; j<VIM; j++){
           normOfStressDSqr += pow(fv->S[mode][i][j], 2);

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -2196,14 +2196,22 @@ calc_standard_fields(double **post_proc_vect, /* rhs vector now called
   if(STRESS_NORM != -1)
   {  
     for (int mode = 0; mode < vn->modes; mode++) {
-      dbl invDenom = 1./(2.*VIM);
-          
+
+      dbl trace = 0;
+      for(int i=0; i<VIM; i++){
+        trace += fv->S[mode][i][i];
+      }
+
+      trace /= VIM;
+
       // square of the deviatoric sress norm
-                                      
-      dbl normOfStressDSqr = pow(fv->S[mode][0][0] - fv->S[mode][1][1], 2)*invDenom + pow(fv->S[mode][0][1], 2);
-      if(VIM>2){
-        normOfStressDSqr += pow(fv->S[mode][0][0] - fv->S[mode][2][2], 2)*invDenom + pow(fv->S[mode][0][2], 2)
-          + pow(fv->S[mode][1][1] - fv->S[mode][2][2], 2)*invDenom + pow(fv->S[mode][1][2], 2);
+      dbl normOfStressDSqr = 0;
+      for(int i=0; i<VIM; i++){
+        normOfStressDSqr += pow(fv->S[mode][i][i] - trace, 2)/2.;
+
+        for(int j=i+1; j<VIM; j++){
+          normOfStressDSqr += pow(fv->S[mode][i][j], 2);
+        }
       }
           
       dbl normOfStressD = sqrt(normOfStressDSqr);
@@ -2215,7 +2223,7 @@ calc_standard_fields(double **post_proc_vect, /* rhs vector now called
   if(SARAMITO_YIELD != -1)
   {  
     for (int mode = 0; mode < vn->modes; mode++) {
-      dbl coeff = compute_saramito_model_terms(fv->S[mode], ve[mode]->gn->tau_y, NULL);
+      dbl coeff = compute_saramito_model_terms(fv->S[mode], ve[mode]->gn->tau_y, ve[mode]->gn->fexp, NULL);
       local_post[SARAMITO_YIELD + mode] = coeff;
       local_lumped[SARAMITO_YIELD + mode] = 1.;
     }


### PR DESCRIPTION
This merge request adds capability to run a regularized Saramito model for EVP flows. A bug present in the computation of the deviatoric stress tensor norm for 3D cases has also been fixed.