### PR TITLE
Extend list of continuation parameters in Goma

### DIFF
--- a/include/mm_mp_const.h
+++ b/include/mm_mp_const.h
@@ -645,6 +645,8 @@ extern int Num_Var_Init_Mat[MAX_NUMBER_MATLS];	/* number of variables to overwri
 #define TAGC_PTT_EPS                       5400
 #define TAGC_SHIFT_FUNC                    5500
 #define TAGC_SHIFT_FUNC1                   5501
+#define TAGC_POLYMER_YIELD_STRESS          5600
+#define TAGC_POLYMER_YIELD_EXPONENT        5700
 
  /* 
   * Constants used in the Elasticity Constitutive Equations

--- a/src/ac_update_parameter.c
+++ b/src/ac_update_parameter.c
@@ -733,6 +733,19 @@ update_MT_parameter(double lambda, /* Parameter value */
     case TAGC_SHIFT_FUNC:
     case TAGC_SHIFT_FUNC1:
       vn_glob[mn]->shift[mpr-TAGC_SHIFT_FUNC] = lambda;
+
+    case TAGC_POLYMER_YIELD_STRESS:
+        for(int mm=0;mm<vn_glob[mn]->modes;mm++)
+        {
+                ve_glob[mn][mm]->gn->tau_y = lambda;
+        }
+      break;
+
+    case TAGC_POLYMER_YIELD_EXPONENT:
+        for(int mm=0;mm<vn_glob[mn]->modes;mm++)
+        {
+                ve_glob[mn][mm]->gn->fexp = lambda;
+        }
       break;
 
       /* 
@@ -1636,6 +1649,12 @@ retrieve_MT_parameter(double *lambda, /* Parameter value */
     case TAGC_SHIFT_FUNC1:
       *lambda = vn_glob[mn]->shift[mpr-TAGC_SHIFT_FUNC];
       break;
+      
+    case TAGC_POLYMER_YIELD_STRESS:
+      *lambda = ve_glob[mn][cont->upMPID-TAGC_POLYMER_YIELD_STRESS]->gn->tau_y;
+
+    case TAGC_POLYMER_YIELD_EXPONENT:
+      *lambda = ve_glob[mn][cont->upMPID-TAGC_POLYMER_YIELD_EXPONENT]->gn->fexp;
 
       /* 
        * Constants used in the Elasticity Constitutive Equations

--- a/src/mm_augc_util.c
+++ b/src/mm_augc_util.c
@@ -445,6 +445,13 @@ load_extra_unknownsAC(int iAC,    /* ID NUMBER OF AC'S */
 	xa[iAC] = vn_glob[mn]->shift[augc[iAC].MPID-TAGC_SHIFT_FUNC];
 	break;
 
+      case TAGC_POLYMER_YIELD_STRESS:
+        xa[iAC] = ve_glob[mn][augc[iAC].MPID-TAGC_POLYMER_YIELD_STRESS]->gn->tau_y;
+        break;
+
+      case TAGC_POLYMER_YIELD_EXPONENT:
+        xa[iAC] = ve_glob[mn][augc[iAC].MPID-TAGC_POLYMER_YIELD_EXPONENT]->gn->fexp;
+        break;
 	/* 
 	 * Constants used in the Elasticity Constitutive Equations
 	 */
@@ -1210,6 +1217,14 @@ update_parameterAC(int iAC,      /* ID NUMBER OF The AC */
       case TAGC_SHIFT_FUNC:
       case TAGC_SHIFT_FUNC1:
 	vn_glob[mn]->shift[augc[iAC].MPID-TAGC_SHIFT_FUNC] = lambda;
+	break;
+
+      case TAGC_POLYMER_YIELD_STRESS:
+        ve_glob[mn][augc[iAC].MPID-TAGC_POLYMER_YIELD_STRESS]->gn->tau_y = lambda;
+	break;
+
+      case TAGC_POLYMER_YIELD_EXPONENT:
+	ve_glob[mn][augc[iAC].MPID-TAGC_POLYMER_YIELD_EXPONENT]->gn->fexp = lambda;
 	break;
 
 	/* 


### PR DESCRIPTION
This merge request will add polymer yield stress and yield exponent to the list of parameters over which continuation problems may be run.