### PR TITLE
fix mistaken use of mat id for block index

### DIFF
--- a/src/rf_util.c
+++ b/src/rf_util.c
@@ -2351,13 +2351,19 @@ int rd_vectors_from_exoII(double u[],
 	      matrl = mp_glob[mn];
 	    }
             if (mn != -1 && (pd_glob[mn]->i[var] == I_P0)) {
-              error = rd_exoII_ev(u, var, mn, matrl, elem_var_names, exo->eb_num_elems[mn],
-                                  num_elem_vars, exoid, time_step, 0, exo);
+              int eb_index = in_list(mn, 0, exo->num_elem_blocks, Matilda);
+              if (eb_index != -1) {
+                error = rd_exoII_ev(u, var, mn, matrl, elem_var_names, exo->eb_num_elems[eb_index],
+                                    num_elem_vars, exoid, time_step, 0, exo);
+              }
             } else if (mn != -1 && (pd_glob[mn]->i[var] == I_P1)) {
-              int dof = getdofs(type2shape(exo->eb_elem_itype[mn]), I_P1);
-              for (int i = 0; i < dof; i++) {
-                error = rd_exoII_ev(u, var, mn, matrl, elem_var_names, exo->eb_num_elems[mn],
-                                    num_elem_vars, exoid, time_step, i, exo);
+              int eb_index = in_list(mn, 0, exo->num_elem_blocks, Matilda);
+              if (eb_index != -1) {
+                int dof = getdofs(type2shape(exo->eb_elem_itype[eb_index]), I_P1);
+                for (int i = 0; i < dof; i++) {
+                  error = rd_exoII_ev(u, var, mn, matrl, elem_var_names, exo->eb_num_elems[eb_index],
+                                      num_elem_vars, exoid, time_step, i, exo);
+                }
               }
             } else {
               error = rd_exoII_nv(u, var, mn, matrl, var_names, num_nodes, num_vars, exoid,
@@ -2973,8 +2979,10 @@ static void inject_elem_vec(double sol_vec[],
   int e_start, e_end, ielem, ielem_type, num_local_nodes;
   int iconnect_ptr, i, I, index;
   int found_quantity;
-  e_start = exo->eb_ptr[matID];
-  e_end = exo->eb_ptr[matID + 1];
+  int eb_index = in_list(matID, 0, exo->num_elem_blocks, Matilda);
+  EH(eb_index, "Trying to read unknown material element block index inject_elem_vec");
+  e_start = exo->eb_ptr[eb_index];
+  e_end = exo->eb_ptr[eb_index + 1];
   for (ielem = e_start; ielem < e_end; ielem++) {
 
     ielem_type = Elem_Type(exo, ielem); /* func defd in el_geom.h */

--- a/src/sl_eggrollwrap.c
+++ b/src/sl_eggrollwrap.c
@@ -337,9 +337,10 @@ void eggrollwrap(int *istuff, /* info for eigenvalue extraction */
           for (int iev = 0; iev < tev; iev++) {
             bool is_P1 = FALSE;
             int dof = 0;
-            for (int mn = 0; mn < upd->Num_Mat; mn++) {
+            for (int eb_index = 0; eb_index < exo->num_elem_blocks; eb_index++) {
+              int mn = Matilda[eb_index];
               if (pd_glob[mn]->i[rd->evtype[iev]] == I_P1) {
-                dof = MAX(getdofs(type2shape(exo->eb_elem_itype[mn]), I_P1), dof);
+                dof = MAX(getdofs(type2shape(exo->eb_elem_itype[eb_index]), I_P1), dof);
                 is_P1 = TRUE;
               }
             }

--- a/src/wr_exo.c
+++ b/src/wr_exo.c
@@ -891,7 +891,7 @@ void create_truth_table(struct Results_Description *rd, Exo_DB *exo, double ***g
         if (pd_glob[mat_num]->i[j] == I_P1) {
           if (exo->truth_table_existance_key[j - V_FIRST] == 0) {
             /* We just found a candidate for an element variable */
-            tev += getdofs(type2shape(exo->eb_elem_itype[mat_num]), I_P1);
+            tev += getdofs(type2shape(exo->eb_elem_itype[eb_indx]), I_P1);
             ;
             exo->truth_table_existance_key[j - V_FIRST] = 1;
           }
@@ -901,7 +901,7 @@ void create_truth_table(struct Results_Description *rd, Exo_DB *exo, double ***g
            if ( exo->truth_table_existance_key[j - V_FIRST] == 0 )
              {
               /* We just found a candidate for an element variable */
-              tev += getdofs(type2shape(exo->eb_elem_itype[mat_num]),I_P1);;
+              tev += getdofs(type2shape(exo->eb_elem_itype[eb_indx]),I_P1);;
               exo->truth_table_existance_key[j - V_FIRST] = 1;
              }
           }
@@ -1003,7 +1003,7 @@ void create_truth_table(struct Results_Description *rd, Exo_DB *exo, double ***g
           }
         }
         if (pd_glob[mat_num]->i[j] == I_P1) {
-          int dof = getdofs(type2shape(exo->eb_elem_itype[mat_num]), I_P1);
+          int dof = getdofs(type2shape(exo->eb_elem_itype[eb_indx]), I_P1);
           /* We just found a candidate for an element variable */
           for (int k = 0; k < dof; k++) {
             exo->elem_var_tab[i++] = 1;

--- a/src/wr_soln.c
+++ b/src/wr_soln.c
@@ -115,9 +115,10 @@ void write_solution(char output_file[],             /* name EXODUS II file */
   for (i = 0; i < tev; i++) {
     bool is_P1 = FALSE;
     int dof = 0;
-    for (int mn = 0; mn < upd->Num_Mat; mn++) {
+    for (int eb_index = 0; eb_index < exo->num_elem_blocks; eb_index++) {
+      int mn = Matilda[eb_index];
       if (pd_glob[mn]->i[rd->evtype[i]] == I_P1) {
-        dof = MAX(getdofs(type2shape(exo->eb_elem_itype[mn]), I_P1), dof);
+        dof = MAX(getdofs(type2shape(exo->eb_elem_itype[eb_index]), I_P1), dof);
         is_P1 = TRUE;
       }
     }


### PR DESCRIPTION
Hopefully addresses #324 more fully.

Mat ID was being used in place of block index which works out in a lot of cases but not when materials are *not* shared across all processors.