### PR TITLE
fix gvec_elem initialization as we expect NULL values to be filled

### DIFF
--- a/src/ac_conti.c
+++ b/src/ac_conti.c
@@ -300,9 +300,10 @@ continue_problem (Comm_Ex *cx,	/* array of communications structures */
   fprintf(stderr, "wr_result_prelim() starts...\n", tnv);
 #endif
 
-  gvec_elem = (double ***) smalloc ( (exo->num_elem_blocks)*sizeof(double **));
-  for (i = 0; i < exo->num_elem_blocks; i++)
-    gvec_elem[i] = (double **) smalloc ( (tev + tev_post)*sizeof(double *));
+  gvec_elem = (double ***) calloc (exo->num_elem_blocks, sizeof(double **));
+  for (i = 0; i < exo->num_elem_blocks; i++) {
+    gvec_elem[i] = (double **) calloc (tev + tev_post, sizeof(double *));
+  }
 
   wr_result_prelim_exo(rd,
                        exo,

--- a/src/ac_hunt.c
+++ b/src/ac_hunt.c
@@ -319,9 +319,9 @@ hunt_problem(Comm_Ex *cx,	/* array of communications structures */
   fprintf(stderr, "wr_result_prelim() starts...\n", tnv);
 #endif
 
-  gvec_elem = (double ***) smalloc ( (exo->num_elem_blocks)*sizeof(double **));
+  gvec_elem = (double ***) calloc (exo->num_elem_blocks, sizeof(double **));
   for (i = 0; i < exo->num_elem_blocks; i++) {
-    gvec_elem[i] = (double **) smalloc ( (tev + tev_post)*sizeof(double *));
+    gvec_elem[i] = (double **) calloc(tev + tev_post, sizeof(double *));
   }
 
   wr_result_prelim_exo( rd,

--- a/src/ac_loca_interface.c
+++ b/src/ac_loca_interface.c
@@ -387,9 +387,10 @@ int do_loca (Comm_Ex *cx,  /* array of communications structures */
   DPRINTF(stderr, "wr_result_prelim() starts...\n", tnv);
 #endif
 
-  gvec_elem = (double ***) smalloc ( (exo->num_elem_blocks)*sizeof(double **));
-  for (i = 0; i < exo->num_elem_blocks; i++)
-    gvec_elem[i] = (double **) smalloc ( (tev + tev_post)*sizeof(double *));
+  gvec_elem = (double ***) calloc (exo->num_elem_blocks, sizeof(double **));
+  for (i = 0; i < exo->num_elem_blocks; i++) {
+    gvec_elem[i] = (double **) calloc (tev + tev_post, sizeof(double *));
+  }
 
   wr_result_prelim_exo(rd, exo, ExoFileOut, gvec_elem);
 


### PR DESCRIPTION
Another bug from @tjiptowi , we expect NULL initialization of gvec_elem array and can run into a memory read error due to garbage values if not done correctly.