### PR TITLE
Make NS and SS order match input file, for Cubit remeshing

### DIFF
--- a/include/dpi.h
+++ b/include/dpi.h
@@ -15,6 +15,8 @@
 #ifndef GOMA_DPI_H
 #define GOMA_DPI_H
 
+#include <stdbool.h>
+
 struct Distributed_Processing_Information {
   int num_elem_blocks_global;
   int num_elems; /* New! */
@@ -145,8 +147,24 @@ struct Distributed_Processing_Information {
 
   int base_internal_elems;
   int base_border_elems;
+
+  // ns and ss consistency for Cubit
+  bool goma_dpi_data;
+  int global_ns_node_len;
+  int *global_ns_nodes;
+  int global_ss_elem_len;
+  int *global_ss_elems;
+  int *global_ss_sides;
 };
 typedef struct Distributed_Processing_Information Dpi;
 
 extern Dpi *DPI_ptr;
 #endif
+
+// NETCDF definitions
+
+#define GOMA_NC_DIM_LEN_NS_NODE_LIST "goma_len_ns_node_list"
+#define GOMA_NC_DIM_LEN_SS_ELEM_LIST "goma_len_ss_elem_list"
+#define GOMA_NC_VAR_NS_NODE_LIST     "goma_ns_node_list"
+#define GOMA_NC_VAR_SS_ELEM_LIST     "goma_ss_elem_list"
+#define GOMA_NC_VAR_SS_SIDE_LIST     "goma_ss_side_list"

--- a/src/brkfix/bbb.c
+++ b/src/brkfix/bbb.c
@@ -793,8 +793,14 @@ void build_global_ns(Dpi *d, /* distributed processing info from polylith */
     return;
   }
 
-  for (i = 0; i < m->ns_node_len; i++) {
-    m->ns_node_list[i] = fd->ns_node_list[i];
+  if (d->goma_dpi_data) {
+    for (i = 0; i < m->ns_node_len; i++) {
+      m->ns_node_list[i] = d->global_ns_nodes[i];
+    }
+  } else {
+    for (i = 0; i < m->ns_node_len; i++) {
+      m->ns_node_list[i] = fd->ns_node_list[i];
+    }
   }
 
   for (i = 0; i < m->ns_distfact_len; i++) {
@@ -836,9 +842,16 @@ void build_global_ss(Dpi *d, /* distributed processing info from polylith */
     return;
   }
 
-  for (i = 0; i < m->ss_elem_len; i++) {
-    m->ss_elem_list[i] = fd->ss_elem_list[i];
-    m->ss_side_list[i] = fd->ss_side_list[i];
+  if (d->goma_dpi_data) {
+    for (i = 0; i < m->ss_elem_len; i++) {
+      m->ss_elem_list[i] = d->global_ss_elems[i];
+      m->ss_side_list[i] = d->global_ss_sides[i];
+    }
+  } else {
+    for (i = 0; i < m->ss_elem_len; i++) {
+      m->ss_elem_list[i] = fd->ss_elem_list[i];
+      m->ss_side_list[i] = fd->ss_side_list[i];
+    }
   }
 
   for (i = 0; i < m->ss_distfact_len; i++) {

--- a/src/metis_decomp.c
+++ b/src/metis_decomp.c
@@ -1,6 +1,7 @@
 #ifdef GOMA_ENABLE_METIS
 #include <exodusII.h>
 #include <metis.h>
+#include <netcdf.h>
 #include <stdlib.h>
 
 #include "base_mesh.h"
@@ -541,10 +542,112 @@ goma_error goma_metis_decomposition(char **filenames, int n_files) {
 
       if (monolith->num_node_sets > 0) {
         put_node_sets(exoid, monolith, node_indicator, global_to_local);
+
+        if (monolith->num_dim == 2) {
+          // global ns order preservation
+          ex_close(exoid);
+          int ncid;
+          err = nc_open(proc_name, NC_WRITE | NC_SHARE, &ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          err = nc_redef(ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          int nc_ns_len;
+          err = nc_def_dim(ncid, GOMA_NC_DIM_LEN_NS_NODE_LIST, monolith->ns_node_len, &nc_ns_len);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+          int nc_ns;
+          err = nc_def_var(ncid, GOMA_NC_VAR_NS_NODE_LIST, NC_INT, 1, &nc_ns_len, &nc_ns);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          err = nc_enddef(ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          int *ns_nodes = calloc(monolith->ns_node_len, sizeof(int));
+          for (int i = 0; i < monolith->ns_node_len; i++) {
+            ns_nodes[i] = dpi->node_index_global[monolith->ns_node_list[i]];
+          }
+
+          err = nc_put_var(ncid, nc_ns, ns_nodes);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          err = nc_close(ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          free(ns_nodes);
+
+          int comp_ws = monolith->comp_wordsize;
+          int io_ws = monolith->io_wordsize;
+          float version = monolith->version;
+          exoid = ex_open(proc_name, EX_WRITE, &comp_ws, &io_ws, &version);
+        }
       }
 
       if (monolith->num_side_sets > 0) {
         put_side_sets(exoid, monolith, elem_indicator, global_to_local_elem);
+
+        // global ss order preservation
+        if (monolith->num_dim == 2) {
+          ex_close(exoid);
+          int ncid;
+          err = nc_open(proc_name, NC_WRITE, &ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          err = nc_redef(ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          int nc_ss_len;
+          err = nc_def_dim(ncid, GOMA_NC_DIM_LEN_SS_ELEM_LIST, monolith->ss_elem_len, &nc_ss_len);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+          int nc_ss_elem;
+          err = nc_def_var(ncid, GOMA_NC_VAR_SS_ELEM_LIST, NC_INT, 1, &nc_ss_len, &nc_ss_elem);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+          int nc_ss_side;
+          err = nc_def_var(ncid, GOMA_NC_VAR_SS_SIDE_LIST, NC_INT, 1, &nc_ss_len, &nc_ss_side);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          err = nc_enddef(ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          int *ss_elems = calloc(monolith->ss_elem_len, sizeof(int));
+          int *ss_sides = calloc(monolith->ss_elem_len, sizeof(int));
+          for (int i = 0; i < monolith->ss_elem_len; i++) {
+            ss_elems[i] = dpi->elem_index_global[monolith->ss_elem_list[i]];
+            ss_sides[i] = monolith->ss_side_list[i];
+          }
+
+          err = nc_put_var(ncid, nc_ss_elem, ss_elems);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+          err = nc_put_var(ncid, nc_ss_side, ss_sides);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          err = nc_close(ncid);
+          if (err)
+            GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+          free(ss_elems);
+          free(ss_sides);
+
+          int comp_ws = monolith->comp_wordsize;
+          int io_ws = monolith->io_wordsize;
+          float version = monolith->version;
+          exoid = ex_open(proc_name, EX_WRITE, &comp_ws, &io_ws, &version);
+        }
       }
 
       err = ex_put_init_global(exoid, monolith->num_nodes, monolith->num_elems,

--- a/src/rd_dpi.c
+++ b/src/rd_dpi.c
@@ -539,6 +539,83 @@ int rd_dpi(Exo_DB *exo, Dpi *d, char *fn, bool parallel_call) {
     free(global_recv_nodes);
   }
 
+  d->goma_dpi_data = false;
+  // read ns and ss consistency data
+  int ncid;
+  int err = nc_open(fn, NC_NOWRITE | NC_SHARE, &ncid);
+  if (err)
+    GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+  int nc_ns_id;
+  size_t nc_ns_len;
+  bool goma_ns_found = true;
+  err = nc_inq_dimid(ncid, GOMA_NC_DIM_LEN_NS_NODE_LIST, &nc_ns_id);
+  if (err == NC_EBADID) {
+    goma_ns_found = false;
+  } else if (err != NC_NOERR) {
+    GOMA_EH(GOMA_ERROR, nc_strerror(err));
+  }
+
+  int nc_ss_id;
+  size_t nc_ss_len;
+  bool goma_ss_found = true;
+  err = nc_inq_dimid(ncid, GOMA_NC_DIM_LEN_SS_ELEM_LIST, &nc_ss_id);
+  if (err == NC_EBADID) {
+    goma_ns_found = false;
+  } else if (err != NC_NOERR) {
+    GOMA_EH(GOMA_ERROR, nc_strerror(err));
+  }
+
+  d->global_ns_node_len = 0;
+  if (goma_ns_found) {
+    err = nc_inq_dimlen(ncid, nc_ns_id, &nc_ns_len);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+    int nc_node_list;
+    err = nc_inq_varid(ncid, GOMA_NC_VAR_NS_NODE_LIST, &nc_node_list);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+    d->goma_dpi_data = true;
+    d->global_ns_node_len = nc_ns_len;
+    d->global_ns_nodes = calloc(nc_ns_len, sizeof(int));
+    err = nc_get_var(ncid, nc_node_list, d->global_ns_nodes);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+  }
+
+  d->global_ss_elem_len = 0;
+  if (goma_ss_found) {
+    err = nc_inq_dimlen(ncid, nc_ss_id, &nc_ss_len);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+    int nc_elem_list;
+    int nc_side_list;
+    err = nc_inq_varid(ncid, GOMA_NC_VAR_SS_ELEM_LIST, &nc_elem_list);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+    err = nc_inq_varid(ncid, GOMA_NC_VAR_SS_SIDE_LIST, &nc_side_list);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+    d->goma_dpi_data = true;
+    d->global_ss_elem_len = nc_ss_len;
+    d->global_ss_elems = calloc(nc_ss_len, sizeof(int));
+    d->global_ss_sides = calloc(nc_ss_len, sizeof(int));
+    err = nc_get_var(ncid, nc_elem_list, d->global_ss_elems);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+    err = nc_get_var(ncid, nc_side_list, d->global_ss_sides);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+  }
+
+  err = nc_close(ncid);
+  if (err)
+    GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
   return 0;
 }
 int zero_dpi(Dpi *d) {

--- a/src/wr_dpi.c
+++ b/src/wr_dpi.c
@@ -140,6 +140,73 @@ int wr_dpi(Dpi *d, char *filename) {
   ex_error = ex_close(exoid);
   CHECK_EX_ERROR(ex_error, "ex_close");
 
+  // goma consistency
+
+  if (d->goma_dpi_data) {
+
+    int ncid;
+    int err = nc_open(filename, NC_WRITE | NC_SHARE, &ncid);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+    if (d->global_ns_node_len > 0) {
+      err = nc_redef(ncid);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+      int nc_ns_len;
+      err = nc_def_dim(ncid, GOMA_NC_DIM_LEN_NS_NODE_LIST, d->global_ns_node_len, &nc_ns_len);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+      int nc_ns;
+      err = nc_def_var(ncid, GOMA_NC_VAR_NS_NODE_LIST, NC_INT, 1, &nc_ns_len, &nc_ns);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+      err = nc_enddef(ncid);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+      err = nc_put_var(ncid, nc_ns, d->global_ns_nodes);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+    }
+
+    if (d->global_ss_elem_len > 0) {
+      err = nc_redef(ncid);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+      int nc_ss_len;
+      err = nc_def_dim(ncid, GOMA_NC_DIM_LEN_SS_ELEM_LIST, d->global_ss_elem_len, &nc_ss_len);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+      int nc_ss_elem;
+      err = nc_def_var(ncid, GOMA_NC_VAR_SS_ELEM_LIST, NC_INT, 1, &nc_ss_len, &nc_ss_elem);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+      int nc_ss_side;
+      err = nc_def_var(ncid, GOMA_NC_VAR_SS_SIDE_LIST, NC_INT, 1, &nc_ss_len, &nc_ss_side);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+      err = nc_enddef(ncid);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+
+      err = nc_put_var(ncid, nc_ss_elem, d->global_ss_elems);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+      err = nc_put_var(ncid, nc_ss_side, d->global_ss_sides);
+      if (err)
+        GOMA_EH(GOMA_ERROR, nc_strerror(err));
+    }
+
+    err = nc_close(ncid);
+    if (err)
+      GOMA_EH(GOMA_ERROR, nc_strerror(err));
+  }
+
   GOMA_EH(zero_dpi(d), "zero_dpi");
   return 0;
 }


### PR DESCRIPTION
Have to check some things still but this seems to be the main cause of #383 Cubit expects NS and SS to be ordered in a certain manner.