### PR TITLE
Fix bug on element variable fixing, and running overloaded

### DIFF
--- a/src/brkfix/fix_exo_file.c
+++ b/src/brkfix/fix_exo_file.c
@@ -288,8 +288,12 @@ int fix_exo_file(int num_procs, const char *exo_mono_name) {
     build_global_conn(poly, dpin, mono, fix_data);
 
     // element truth table checking
-    for (int i = 0; i < (mono->num_elem_blocks * mono->num_elem_vars); i++) {
-      mono->elem_var_tab[i] |= poly->elem_var_tab[i];
+    if (mono->elem_var_tab != NULL) {
+      for (int i = 0; i < (mono->num_elem_blocks * mono->num_elem_vars); i++) {
+        if (poly->elem_var_tab != NULL) { // guard against pieces without element variables
+          mono->elem_var_tab[i] |= poly->elem_var_tab[i];
+        }
+      }
     }
 
     /*

--- a/src/rd_exo.c
+++ b/src/rd_exo.c
@@ -1803,6 +1803,7 @@ void init_exo_struct(Exo_DB *x) {
   x->ss_side_list = NULL;
 
   x->base_mesh = NULL;
+  x->elem_var_tab = NULL;
   /*
    * Let this value indicate that the structure in memory is not currently
    * attached to any open netCDF file. Once open, this will become >-1.

--- a/src/rd_mesh.c
+++ b/src/rd_mesh.c
@@ -693,13 +693,28 @@ void setup_old_exo(Exo_DB *e, Dpi *dpi, int num_proc) {
    * Reality checks...
    */
 
-  if (Num_Node / Num_Proc < 1) {
-    sprintf(err_msg, "Whoa! Problem with %d nodes on %d processors.", Num_Node, Num_Proc);
+  unsigned long long num_global_node = 0;
+  unsigned long long num_local_node = Num_Node;
+  unsigned long long num_global_elem = 0;
+  unsigned long long num_local_elem = Num_Elem;
+
+  if (num_proc > 1) {
+    MPI_Allreduce(&num_local_node, &num_global_node, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM,
+                  MPI_COMM_WORLD);
+    MPI_Allreduce(&num_local_elem, &num_global_elem, 1, MPI_UNSIGNED_LONG_LONG, MPI_SUM,
+                  MPI_COMM_WORLD);
+  } else {
+    num_global_elem = Num_Elem;
+    num_global_node = Num_Node;
+  }
+
+  if (num_global_node / Num_Proc < 1) {
+    sprintf(err_msg, "Whoa! Problem with %lld nodes on %d processors.", num_global_node, Num_Proc);
     GOMA_EH(GOMA_ERROR, err_msg);
   }
 
-  if (Num_Elem / Num_Proc < 1) {
-    sprintf(err_msg, "Whoa! Problem with %d elems on %d processors.", Num_Elem, Num_Proc);
+  if (num_global_elem / Num_Proc < 1) {
+    sprintf(err_msg, "Whoa! Problem with %lld elems on %d processors.", num_global_elem, Num_Proc);
     GOMA_EH(GOMA_ERROR, err_msg);
   }
 


### PR DESCRIPTION
Fixes a bug with `fix` when a mesh is broken enough that the element variables don't exist on all processors.