### PR TITLE
Fix garbage writeout on fix when proc doesn't contain nodal var

### DIFF
--- a/src/rd_exo.c
+++ b/src/rd_exo.c
@@ -2034,7 +2034,7 @@ void alloc_exo_nv(Exo_DB *x, const int num_timeplanes, const int num_nodal_vars)
   for (i = 0; i < x->num_nv_time_indeces; i++) {
     x->nv[i] = (dbl **)smalloc(x->num_nv_indeces * sizeof(dbl *));
     for (j = 0; j < x->num_nv_indeces; j++) {
-      x->nv[i][j] = (dbl *)smalloc(x->num_nodes * sizeof(dbl));
+      x->nv[i][j] = (dbl *)calloc(x->num_nodes, sizeof(dbl));
     }
   }
 


### PR DESCRIPTION
If a processor doesn't have a nodal variable if malloc returns garbage the exodus output will have garbage in that processor values

This assures that it is 0 instead.