### PR TITLE
Use petsc-pkg METIS and ParMETIS in legacy build script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,7 +60,7 @@ The build-goma-dependencies.sh script relies on several packages readily availab
 
 For Ubuntu this will install the necessary packages to run the script:
 
-`sudo apt-get install git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config`
+`sudo apt-get install git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config autoconf`
 
 For CentOS / Fedora
 


### PR DESCRIPTION
Change to PETSc packaged versions of METIS and ParMETIS as the website is often down and ParMETIS licensing prevents us from rehosting without permission.