### PR TITLE
Annotate warnings in pull request review, remove GCC 11 warnings

### DIFF
--- a/.github/workflows/build-unit.yml
+++ b/.github/workflows/build-unit.yml
@@ -23,6 +23,8 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Release -Bbuild -DENABLE_TESTING=ON .
     - name: Build Goma
       run: |
+        cp scripts/gcc-warnings.json "$HOME/"
+        echo "::add-matcher::$HOME/gcc-warnings.json"
         cd build
         make -j 2
         ./goma -v

--- a/scripts/gcc-warnings.json
+++ b/scripts/gcc-warnings.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc-warnings",
+            "pattern": [
+                {
+                    "regexp": "^(.*?):(\\d+):(\\d*):?\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -1722,7 +1722,7 @@ static int calc_standard_fields(double **post_proc_vect,
     /* parameters are sent through USER_POST input line for 3D printing orientation ...  */
     if (pd->e[pg->imtrx][R_ENERGY] && USER_POST != -1 && len_u_post_proc > 2) {
       double q_mag = 0., sign = 0.;
-      double radius = u_post_proc[1], overlap = u_post_proc[2];
+      double radius = u_post_proc[1]; //overlap = u_post_proc[2];
       int dir = 0;
       if (cr->HeatFluxModel == CR_HF_FOURIER_0) {
         if (mp->ConductivityModel == USER) {
@@ -1740,7 +1740,7 @@ static int calc_standard_fields(double **post_proc_vect,
       if (fv->x0[2] <= radius) {
         dir = 0;
       } else {
-        double tmp = modf((fv->x0[2] - radius) / (2 * radius - overlap), &sign);
+        // double tmp = modf((fv->x0[2] - radius) / (2 * radius - overlap), &sign);
         sign += 1.;
         dir = (int)sign % 2;
       }

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -1722,7 +1722,7 @@ static int calc_standard_fields(double **post_proc_vect,
     /* parameters are sent through USER_POST input line for 3D printing orientation ...  */
     if (pd->e[pg->imtrx][R_ENERGY] && USER_POST != -1 && len_u_post_proc > 2) {
       double q_mag = 0., sign = 0.;
-      double radius = u_post_proc[1]; //overlap = u_post_proc[2];
+      double radius = u_post_proc[1]; // overlap = u_post_proc[2];
       int dir = 0;
       if (cr->HeatFluxModel == CR_HF_FOURIER_0) {
         if (mp->ConductivityModel == USER) {


### PR DESCRIPTION
This comments out some warnings in orientation vector from @rbsecor 's in progress post processing

Also adds warnings to the pull request review files pane.

All warnings should be fixed for GCC 11.