### PR TITLE
Add MULTI_CONTACT_LINE Lame MU model

### DIFF
--- a/docs/material_file/mechanical_and_constitutive/lame_mu.rst
+++ b/docs/material_file/mechanical_and_constitutive/lame_mu.rst
@@ -65,6 +65,24 @@ The details of each model option are given below:
 |                                                                                   | * <float3> - :math:`G_1`                                                                          |
 |                                                                                   | * <float3> - :math:`r_0`                                                                          |
 +-----------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
+|**MULTI_CONTACT_LINE** <float1> <float2> <float3> <ns1> ... <nsN>                  |The **MULTI_CONTACT_LINE** model is a based on the CONTACT_LINE model and allows multiple nodesets |
+|                                                                                   |                                                                                                   |
+|                                                                                   |.. figure:: /figures/361_goma_physics.png                                                          |
+|                                                                                   |   :align: center                                                                                  |
+|                                                                                   |   :width: 90%                                                                                     |
+|                                                                                   |                                                                                                   |
+|                                                                                   |*r* is the distance from the fixed point, :math:`r_0` is a decay length, :math:`G_0`is the modulus |
+|                                                                                   |far from the contact line, and :math:`G_0 + G_1` is the modulus at the contact line.               |
+|                                                                                   |                                                                                                   |
+|                                                                                   |The {float_list} contains four values for this model, where:                                       |
+|                                                                                   |                                                                                                   |
+|                                                                                   | * <float1> - :math:`G_0` (or :math:`\mu_0`)                                                       |
+|                                                                                   | * <float2> - :math:`G_1`                                                                          |
+|                                                                                   | * <float3> - :math:`r_0`                                                                          |
+|                                                                                   | * <ns1> - Node set number of points to calculate distance                                         |
+|                                                                                   | * <ns2> - Optional second node set number calculate distance                                      |
+|                                                                                   | * <nsN> - Optional N'th node set number calculate distance                                        |
++-----------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------+
 |**SHEAR_HARDEN** <float1> <float2>                                                 |The **SHEAR_HARDEN** model is:                                                                     |
 |                                                                                   |                                                                                                   |
 |                                                                                   |.. figure:: /figures/362_goma_physics.png                                                          |

--- a/include/mm_as_structs.h
+++ b/include/mm_as_structs.h
@@ -1731,6 +1731,7 @@ struct Field_Variables {
 
   dbl eddy_nu;       /* Eddy viscosity for turbulent flow */
   dbl wall_distance; /* Distance to nearest wall */
+  dbl multi_contact_line_distance; /* Distance to multi contact line points */
 
   /*
    * Grads of scalars...

--- a/include/mm_as_structs.h
+++ b/include/mm_as_structs.h
@@ -1729,8 +1729,8 @@ struct Field_Variables {
   dbl sh_sat_2;   /* Porous shell saturation layer 2 */
   dbl sh_sat_3;   /* Porous shell saturation layer 3 */
 
-  dbl eddy_nu;       /* Eddy viscosity for turbulent flow */
-  dbl wall_distance; /* Distance to nearest wall */
+  dbl eddy_nu;                     /* Eddy viscosity for turbulent flow */
+  dbl wall_distance;               /* Distance to nearest wall */
   dbl multi_contact_line_distance; /* Distance to multi contact line points */
 
   /*

--- a/include/mm_mp_const.h
+++ b/include/mm_mp_const.h
@@ -483,6 +483,7 @@ extern int Num_Var_Init_Mat[MAX_NUMBER_MATLS]; /* number of variables to overwri
 #define DENSE_POWER_LAW 8
 #define POISSON_RATIO   9
 #define SHRINKAGE       10
+#define MULTI_CONTACT_LINE    11
 
 /* Diffusion Constitutive equation parameters */
 #define FICKIAN                3

--- a/include/mm_mp_const.h
+++ b/include/mm_mp_const.h
@@ -477,13 +477,13 @@ extern int Num_Var_Init_Mat[MAX_NUMBER_MATLS]; /* number of variables to overwri
 
 /* Modulus parameters */
 /*#define POWER_LAW    4  - defined rf_fem_const.h*/
-#define CONTACT_LINE    5
-#define SHEAR_HARDEN    6
-#define EXPONENTIAL     7
-#define DENSE_POWER_LAW 8
-#define POISSON_RATIO   9
-#define SHRINKAGE       10
-#define MULTI_CONTACT_LINE    11
+#define CONTACT_LINE       5
+#define SHEAR_HARDEN       6
+#define EXPONENTIAL        7
+#define DENSE_POWER_LAW    8
+#define POISSON_RATIO      9
+#define SHRINKAGE          10
+#define MULTI_CONTACT_LINE 11
 
 /* Diffusion Constitutive equation parameters */
 #define FICKIAN                3

--- a/include/mm_mp_structs.h
+++ b/include/mm_mp_structs.h
@@ -1252,7 +1252,10 @@ struct Elastic_Constitutive {
   int len_u_mu;
   dbl *u_mu;
   dbl d_lame_mu[MAX_VARIABLE_TYPES + MAX_CONC];
+  int *u_mu_ns;
+  int len_u_mu_ns;
   int lame_mu_tableid;
+  double *multi_contact_line_distances;
 
   dbl lame_lambda;
   int lame_lambda_model;

--- a/include/mm_post_def.h
+++ b/include/mm_post_def.h
@@ -690,6 +690,7 @@ extern int FIRST_STRAINRATE_INVAR;
 extern int SEC_STRAINRATE_INVAR;
 extern int THIRD_STRAINRATE_INVAR;
 extern int WALL_DISTANCE;
+extern int CONTACT_DISTANCE;
 /*
  *  Post-processing Step 1: add a new variable flag to end of mm_post_proc.h
  *

--- a/src/dp_vif.c
+++ b/src/dp_vif.c
@@ -2381,6 +2381,7 @@ void noahs_ark(void) {
     ddd_add_member(n, &elc_glob[i]->lame_mu_model, 1, MPI_INT);
 
     ddd_add_member(n, &elc_glob[i]->len_u_mu, 1, MPI_INT);
+    ddd_add_member(n, &elc_glob[i]->len_u_mu_ns, 1, MPI_INT);
 
     ddd_add_member(n, elc_glob[i]->d_lame_mu, MAX_VARIABLE_TYPES + MAX_CONC, MPI_DOUBLE);
     ddd_add_member(n, &elc_glob[i]->lame_mu_tableid, 1, MPI_INT);
@@ -2449,6 +2450,7 @@ void noahs_ark(void) {
     ddd_add_member(n, &elc_rs_glob[i]->lame_mu_model, 1, MPI_INT);
 
     ddd_add_member(n, &elc_rs_glob[i]->len_u_mu, 1, MPI_INT);
+    ddd_add_member(n, &elc_rs_glob[i]->len_u_mu_ns, 1, MPI_INT);
 
     ddd_add_member(n, elc_rs_glob[i]->d_lame_mu, MAX_VARIABLE_TYPES + MAX_CONC, MPI_DOUBLE);
     ddd_add_member(n, &elc_rs_glob[i]->lame_mu_tableid, 1, MPI_INT);
@@ -3125,6 +3127,7 @@ void ark_landing(void) {
     e = elc_glob[i];
 
     dalloc(e->len_u_mu, e->u_mu);
+    e->u_mu_ns = malloc(e->len_u_mu_ns*sizeof(int));
 
     dalloc(e->len_u_lambda, e->u_lambda);
 
@@ -3143,6 +3146,7 @@ void ark_landing(void) {
     e = elc_rs_glob[i];
 
     dalloc(e->len_u_mu, e->u_mu);
+    e->u_mu_ns = malloc(e->len_u_mu_ns*sizeof(int));
 
     dalloc(e->len_u_lambda, e->u_lambda);
 
@@ -3435,6 +3439,9 @@ void noahs_dove(void) {
     crdv(m->len_u_DiffCoeff_function_constants, m->u_DiffCoeff_function_constants);
 
     crdv(e->len_u_mu, e->u_mu);
+    if (e->len_u_mu_ns > 0) {
+      ddd_add_member(n, e->u_mu_ns, e->len_u_mu_ns, MPI_INT);
+    }
 
     crdv(e->len_u_lambda, e->u_lambda);
 
@@ -3453,6 +3460,9 @@ void noahs_dove(void) {
     e = elc_rs_glob[i];
 
     crdv(e->len_u_mu, e->u_mu);
+    if (e->len_u_mu_ns > 0) {
+      ddd_add_member(n, e->u_mu_ns, e->len_u_mu_ns, MPI_INT);
+    }
 
     crdv(e->len_u_lambda, e->u_lambda);
 

--- a/src/dp_vif.c
+++ b/src/dp_vif.c
@@ -3127,7 +3127,7 @@ void ark_landing(void) {
     e = elc_glob[i];
 
     dalloc(e->len_u_mu, e->u_mu);
-    e->u_mu_ns = malloc(e->len_u_mu_ns*sizeof(int));
+    e->u_mu_ns = malloc(e->len_u_mu_ns * sizeof(int));
 
     dalloc(e->len_u_lambda, e->u_lambda);
 
@@ -3146,7 +3146,7 @@ void ark_landing(void) {
     e = elc_rs_glob[i];
 
     dalloc(e->len_u_mu, e->u_mu);
-    e->u_mu_ns = malloc(e->len_u_mu_ns*sizeof(int));
+    e->u_mu_ns = malloc(e->len_u_mu_ns * sizeof(int));
 
     dalloc(e->len_u_lambda, e->u_lambda);
 

--- a/src/dp_vif.c
+++ b/src/dp_vif.c
@@ -2645,6 +2645,7 @@ void noahs_ark(void) {
   ddd_add_member(n, &SEC_STRAINRATE_INVAR, 1, MPI_INT);
   ddd_add_member(n, &THIRD_STRAINRATE_INVAR, 1, MPI_INT);
   ddd_add_member(n, &WALL_DISTANCE, 1, MPI_INT);
+  ddd_add_member(n, &CONTACT_DISTANCE, 1, MPI_INT);
   ddd_add_member(n, &USER_POST, 1, MPI_INT);
   if (len_u_post_proc > 0) {
     ddd_add_member(n, u_post_proc, len_u_post_proc, MPI_DOUBLE);

--- a/src/load_field_variables.c
+++ b/src/load_field_variables.c
@@ -1762,6 +1762,18 @@ int load_fv(void)
     }
   }
 
+  fv->multi_contact_line_distance = 0;
+  if (elc_glob[ei[pg->imtrx]->mn]->multi_contact_line_distances != NULL) {
+    if (pdgv[pd->ShapeVar]) {
+      dofs = ei[pg->imtrx]->dof[pd->ShapeVar];
+      for (i = 0; i < dofs; i++) {
+        fv->multi_contact_line_distance +=
+            elc_glob[ei[pg->imtrx]->mn]->multi_contact_line_distances[ei[pg->imtrx]->gnn_list[pd->ShapeVar][i]] *
+            bf[pd->ShapeVar]->phi[i];
+      }
+    }
+  }
+
   /*
    * External...
    */

--- a/src/load_field_variables.c
+++ b/src/load_field_variables.c
@@ -1768,7 +1768,8 @@ int load_fv(void)
       dofs = ei[pg->imtrx]->dof[pd->ShapeVar];
       for (i = 0; i < dofs; i++) {
         fv->multi_contact_line_distance +=
-            elc_glob[ei[pg->imtrx]->mn]->multi_contact_line_distances[ei[pg->imtrx]->gnn_list[pd->ShapeVar][i]] *
+            elc_glob[ei[pg->imtrx]->mn]
+                ->multi_contact_line_distances[ei[pg->imtrx]->gnn_list[pd->ShapeVar][i]] *
             bf[pd->ShapeVar]->phi[i];
       }
     }

--- a/src/mm_as_alloc.c
+++ b/src/mm_as_alloc.c
@@ -1781,6 +1781,9 @@ static void init_Elastic_Constitutive(struct Elastic_Constitutive *e) {
     e->d_lame_mu[i] = (double)0;
   }
   e->lame_mu_tableid = 0;
+  e->u_mu_ns = NULL;
+  e->len_u_mu_ns = 0;
+  e->multi_contact_line_distances = NULL;
 
   e->lame_lambda = (double)0;
   e->lame_lambda_model = 0;

--- a/src/mm_fill_solid.c
+++ b/src/mm_fill_solid.c
@@ -4672,6 +4672,21 @@ int load_elastic_properties(struct Elastic_Constitutive *elcp,
     }
   } else if (elc_ptr->lame_mu_model == CONSTANT) {
     *mu = elc_ptr->lame_mu;
+  } else if (elc_ptr->lame_mu_model == MULTI_CONTACT_LINE) {
+    /* make mu (shear modulus) become very large near a critical points,
+     * and decay to lower value radially from that point
+     * this helps keep elements near critical point from shearing excessively
+     * while elements far away won't dilate much
+     *  u_mu[0]  is minimum value of the shear modulus (comparable to lambda, e.g. 0.5)
+     *  u_mu[1]  is the maximum value of the shear modulus (large, e.g. 1e4)
+     *  u_mu[2]  is the decay length (problem dependent)
+     *  u_mu_ns[0....len_u_mu_ns]  are the node sets for the critical points
+     *  multi_contact_line_distances are the distances from the critical points
+     */
+    dist = fv->multi_contact_line_distance / 
+           elc_ptr->u_mu[2];
+    *mu = elc_ptr->lame_mu = elc_ptr->u_mu[0] + 0.1 / (pow(dist, 3.0) + 0.1 / elc_ptr->u_mu[1]);
+
   } else if (elc_ptr->lame_mu_model == CONTACT_LINE) {
     /* make mu (shear modulus) become very large near a critical point,
      * and decay to lower value radially from that point

--- a/src/mm_fill_solid.c
+++ b/src/mm_fill_solid.c
@@ -4683,8 +4683,7 @@ int load_elastic_properties(struct Elastic_Constitutive *elcp,
      *  u_mu_ns[0....len_u_mu_ns]  are the node sets for the critical points
      *  multi_contact_line_distances are the distances from the critical points
      */
-    dist = fv->multi_contact_line_distance / 
-           elc_ptr->u_mu[2];
+    dist = fv->multi_contact_line_distance / elc_ptr->u_mu[2];
     *mu = elc_ptr->lame_mu = elc_ptr->u_mu[0] + 0.1 / (pow(dist, 3.0) + 0.1 / elc_ptr->u_mu[1]);
 
   } else if (elc_ptr->lame_mu_model == CONTACT_LINE) {

--- a/src/mm_input_mp.c
+++ b/src/mm_input_mp.c
@@ -843,6 +843,21 @@ void rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
         GOMA_EH(GOMA_ERROR, err_msg);
       }
       elc_glob[mn]->len_u_mu = num_const;
+    } else if (!strcmp(model_name, "MULTI_CONTACT_LINE")) {
+      elc_glob[mn]->lame_mu_model = MULTI_CONTACT_LINE;
+      elc_glob[mn]->u_mu = (double *)alloc_void_struct_1(sizeof(double), 3);
+      elc_glob[mn]->len_u_mu = 3;
+      if (fscanf(imp, "%lf %lf %lf", &(elc_glob[mn]->u_mu[0]), &(elc_glob[mn]->u_mu[1]),
+                 &(elc_glob[mn]->u_mu[2])) != 3) {
+        GOMA_EH(GOMA_ERROR, "error reading MULTI_CONTACT_LINE constants");
+      }
+      num_const = read_constants_int(imp, &(elc_glob[mn]->u_mu_ns));
+      if (num_const < 1) {
+        sr = sprintf(err_msg, "Matl %s expected at least 1 constant for %s %s model.\n",
+                     pd_glob[mn]->MaterialName, "Lame MU", "MULTI_CONTACT_LINE");
+        GOMA_EH(GOMA_ERROR, err_msg);
+      }
+      elc_glob[mn]->len_u_mu_ns = num_const;
     } else if (!strcmp(model_name, "SHEAR_HARDEN")) {
       elc_glob[mn]->lame_mu_model = SHEAR_HARDEN;
       num_const = read_constants(imp, &(elc_glob[mn]->u_mu), NO_SPECIES);
@@ -876,7 +891,12 @@ void rd_mp_specs(FILE *imp, char input[], int mn, char *echo_file)
       GOMA_EH(model_read, err_msg);
     }
 
-    SPF_DBL_VEC(endofstring(es), num_const, elc_glob[mn]->u_mu);
+    if (elc_glob[mn]->lame_mu_model == MULTI_CONTACT_LINE) {
+      SPF_DBL_VEC(endofstring(es), 3, elc_glob[mn]->u_mu);
+      SPF_INT_VEC(endofstring(es), num_const, elc_glob[mn]->u_mu_ns);
+    } else {
+      SPF_DBL_VEC(endofstring(es), num_const, elc_glob[mn]->u_mu);
+    }
   }
 
   ECHO(es, echo_file);

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -10080,8 +10080,7 @@ int load_nodal_tkn(struct Results_Description *rd, int *tnv, int *tnv_post) {
     WALL_DISTANCE = index_post;
     index_post++;
   }
-  if (CONTACT_DISTANCE != -1 &&
-      (Num_Var_In_Type[pg->imtrx][R_MESH1])) {
+  if (CONTACT_DISTANCE != -1 && (Num_Var_In_Type[pg->imtrx][R_MESH1])) {
     set_nv_tkud(rd, index, 0, 0, -2, "CONTACT_DISTANCE", "[1]", "Contact distance", FALSE);
     index++;
     if (CONTACT_DISTANCE == 2) {

--- a/src/mm_post_proc.c
+++ b/src/mm_post_proc.c
@@ -336,6 +336,7 @@ int FIRST_STRAINRATE_INVAR = -1;
 int SEC_STRAINRATE_INVAR = -1;
 int THIRD_STRAINRATE_INVAR = -1;
 int WALL_DISTANCE = -1;
+int CONTACT_DISTANCE = -1;
 
 int len_u_post_proc = 0; /* size of dynamically allocated u_post_proc
                           * actually is */
@@ -1589,6 +1590,11 @@ static int calc_standard_fields(double **post_proc_vect,
   if (WALL_DISTANCE != -1 && (pd->e[pg->imtrx][VELOCITY1] || pd->e[pg->imtrx][R_LUBP])) {
     local_post[WALL_DISTANCE] = fv->wall_distance;
     local_lumped[WALL_DISTANCE] = 1.;
+  }
+
+  if (CONTACT_DISTANCE != -1 && (pd->e[pg->imtrx][MESH_DISPLACEMENT1])) {
+    local_post[CONTACT_DISTANCE] = fv->multi_contact_line_distance;
+    local_lumped[CONTACT_DISTANCE] = 1.;
   }
 
   if (DIELECTROPHORETIC_FIELD != -1 && pd->e[pg->imtrx][R_ENORM]) {
@@ -7774,6 +7780,7 @@ void rd_post_process_specs(FILE *ifp, char *input) {
   iread = look_for_post_proc(ifp, "Second StrainRate Invariant", &SEC_STRAINRATE_INVAR);
   iread = look_for_post_proc(ifp, "Third StrainRate Invariant", &THIRD_STRAINRATE_INVAR);
   iread = look_for_post_proc(ifp, "Wall Distance", &WALL_DISTANCE);
+  iread = look_for_post_proc(ifp, "Contact Distance", &CONTACT_DISTANCE);
   iread = look_for_post_proc(ifp, "User-Defined Post Processing", &USER_POST);
 
   /*
@@ -10071,6 +10078,17 @@ int load_nodal_tkn(struct Results_Description *rd, int *tnv, int *tnv_post) {
       index_post_export++;
     }
     WALL_DISTANCE = index_post;
+    index_post++;
+  }
+  if (CONTACT_DISTANCE != -1 &&
+      (Num_Var_In_Type[pg->imtrx][R_MESH1])) {
+    set_nv_tkud(rd, index, 0, 0, -2, "CONTACT_DISTANCE", "[1]", "Contact distance", FALSE);
+    index++;
+    if (CONTACT_DISTANCE == 2) {
+      Export_XP_ID[index_post_export] = index_post;
+      index_post_export++;
+    }
+    CONTACT_DISTANCE = index_post;
     index_post++;
   }
 

--- a/src/mm_sol_nonlinear.c
+++ b/src/mm_sol_nonlinear.c
@@ -17,6 +17,8 @@
  */
 
 #include "bc_contact.h"
+#include "mm_eh.h"
+#include "mm_mp_const.h"
 #include "sl_epetra_interface.h"
 #include "sl_util_structs.h"
 
@@ -174,6 +176,31 @@ int neg_lub_height_global = FALSE;
 
 int zero_detJ = FALSE;
 int zero_detJ_global = FALSE;
+static goma_error
+assemble_prefill(struct GomaLinearSolverData *ams, double x[], Exo_DB *exo, Dpi *dpi) {
+
+  // check for multi contact line
+  for (int mn = 0; mn < upd->Num_Mat; mn++) {
+    if (elc_glob[mn]->lame_mu_model == MULTI_CONTACT_LINE) {
+      if (elc_glob[mn]->multi_contact_line_distances == NULL) {
+        elc_glob[mn]->multi_contact_line_distances =
+            (double *)malloc(sizeof(double) * exo->num_nodes);
+      }
+      bool apply_displacements = false;
+      if (upd->matrix_index[R_MESH1] != -1) {
+        apply_displacements = true;
+      }
+
+      goma_error err = find_current_distances(exo, dpi, x, apply_displacements,
+                                              elc_glob[mn]->len_u_mu_ns, elc_glob[mn]->u_mu_ns, 0,
+                                              NULL, elc_glob[mn]->multi_contact_line_distances);
+      if (err != GOMA_SUCCESS) {
+        return err;
+      }
+    }
+  }
+  return GOMA_SUCCESS;
+}
 
 /*
 
@@ -897,6 +924,10 @@ int solve_nonlinear_problem(struct GomaLinearSolverData *ams,
       /* Exchange dof before matrix fill so parallel information
          is properly communicated */
       exchange_dof(cx, dpi, x, pg->imtrx);
+
+  err = assemble_prefill(ams, x, exo, dpi);
+  if (err == -1)
+    return (err);
 
       err = matrix_fill_full(ams, x, resid_vector, x_old, x_older, xdot, xdot_old, x_update,
                              &delta_t, &theta, First_Elem_Side_BC_Array[pg->imtrx], &time_value,
@@ -3185,6 +3216,10 @@ static int soln_sens(double lambda,  /*  parameter */
     }
   }
 
+  err = assemble_prefill(ams, x, exo, dpi);
+  if (err == -1)
+    return (err);
+
   err = matrix_fill_full(ams, x, res_p, x_old, x_older, xdot, xdot_old, x_update, &delta_t, &theta,
                          First_Elem_Side_BC_Array[pg->imtrx], &time_value, exo, dpi,
                          &num_total_nodes, &h_elem_avg, &U_norm, NULL);
@@ -3224,6 +3259,9 @@ static int soln_sens(double lambda,  /*  parameter */
       augc[iAC].evol = 0.0;
     }
   }
+  err = assemble_prefill(ams, x, exo, dpi);
+  if (err == -1)
+    return (err);
 
   err = matrix_fill_full(ams, x, res_m, x_old, x_older, xdot, xdot_old, x_update, &delta_t, &theta,
                          First_Elem_Side_BC_Array[pg->imtrx], &time_value, exo, dpi,

--- a/src/mm_sol_nonlinear.c
+++ b/src/mm_sol_nonlinear.c
@@ -925,9 +925,9 @@ int solve_nonlinear_problem(struct GomaLinearSolverData *ams,
          is properly communicated */
       exchange_dof(cx, dpi, x, pg->imtrx);
 
-  err = assemble_prefill(ams, x, exo, dpi);
-  if (err == -1)
-    return (err);
+      err = assemble_prefill(ams, x, exo, dpi);
+      if (err == -1)
+        return (err);
 
       err = matrix_fill_full(ams, x, resid_vector, x_old, x_older, xdot, xdot_old, x_update,
                              &delta_t, &theta, First_Elem_Side_BC_Array[pg->imtrx], &time_value,


### PR DESCRIPTION
Adds a new Lame MU model for multiple CONTACT_LINE like nodesets to be used, currently the same parameters are used for each nodeset, nodesets are not limited to single noded