### PR TITLE
Add a new TPL build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.a
 *.o
 *.pyc
+__pycache__
 goma
 .cproject
 .project

--- a/BUILD.md
+++ b/BUILD.md
@@ -45,6 +45,41 @@ PETSc is configured through `pkg-config` so `pkg-config` should be available on 
 
 ### Building third party libraries
 
+#### TPL build script
+
+A third party library builder is available in the `tpls` folder named `tpls/install-tpls.py`. 
+This tool should work with any semi-recent python3 (RedHat 8 or later)
+
+Some basic build dependencies should already be present on your system:
+
+For Ubuntu this will install the necessary packages to run the script:
+
+    sudo apt-get install git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config autoconf
+
+For CentOS / Fedora
+
+ .  sudo dnf install git patch gcc gcc-c++ gcc-gfortran m4 make wget bzip2 tar zlib-devel libX11-devel pkgconfig
+
+or using yum
+
+    sudo yum install git patch gcc gcc-c++ gcc-gfortran m4 make wget bzip2 tar zlib-devel libX11-devel pkgconfig
+
+X11 is used to build `blot` and is optional and should be autodetected by the build script if not present.
+
+See [tpls/README.md] for more details but a simple example would be:
+
+    /path/to/goma/tpls/install-tpls.py -j <num procs> /path/to/library/install
+
+This will install to `/path/to/library/install`
+
+After completed you would then do:
+
+    source /path/to/library/install/config.sh
+    cd /path/to/goma
+    cmake -Bbuild
+    cmake --build build -j <num proc>
+
+
 #### Spack
 
 Third party libraries can be built with spack for development of goma using:
@@ -65,7 +100,7 @@ A spack package is in progress and soon one might be able to:
 
     spack install goma
 
-#### Legacy build script
+#### Legacy build script (deprecated)
 
 The legacy build script has been updated slightly with newer libraries.
 This is missing Omega_h and PETSc support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ endif()
 
 option(ENABLE_OMEGA_H "ENABLE_OMEGA_H" ON)
 if(ENABLE_OMEGA_H)
-  find_package(Omega_h 9)
+  find_package(Omega_h)
   if(Omega_h_FOUND)
     set_target_properties(Omega_h::omega_h PROPERTIES INTERFACE_COMPILE_OPTIONS
                                                       "")

--- a/scripts/build-goma-dependencies.sh
+++ b/scripts/build-goma-dependencies.sh
@@ -165,6 +165,12 @@ else
 fi
 
 
+echo "There is a new TPL build script in goma/tpls/ called install-tpls.py"
+echo "Please transition to using that script."
+echo "This script will be removed in a future release."
+continue_check
+
+
 if [ "$PRINT_MENU" == "false" ]; then
     if which mpiicc &> /dev/null; then
         MPI_NAME="intel"

--- a/tpls/Dockerfile
+++ b/tpls/Dockerfile
@@ -6,7 +6,7 @@ RUN apt autoremove && apt clean
 
 RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
 
-RUN /opt/goma/tpls/install-tpls.py --cc=gcc-12 --cxx=g++-12 --fc=gfortran-12 --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
+RUN PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc-12 --cxx=g++-12 --fc=gfortran-12 --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
 RUN { \
       echo '#!/usr/bin/env bash' \

--- a/tpls/Dockerfile
+++ b/tpls/Dockerfile
@@ -8,12 +8,30 @@ RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
 
 RUN PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc-12 --cxx=g++-12 --fc=gfortran-12 --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
+RUN rm -r /opt/goma
+
 RUN { \
       echo '#!/usr/bin/env bash' \
       && echo ". /opt/goma-libs/config.sh" \
       && echo 'exec "$@"'; \
     } > /entrypoint.sh \
 && chmod a+x /entrypoint.sh
+
+
+ARG USER=goma
+RUN adduser -m $USER
+RUN groupadd sudo
+RUN usermod -a -G sudo $USER
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# make sure everything is in place
+USER $USER
+ENV HOME /home/$USER
+ENV USER $USER
+ENV OMPI_MCA_btl_base_warn_component_unuse "0"
+ENV OMPI_ALLOW_RUN_AS_ROOT 1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM 1
+WORKDIR $HOME
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]

--- a/tpls/Dockerfile
+++ b/tpls/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+RUN apt update
+RUN apt install -y git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config autoconf python3-dev vim tmux nano gdb valgrind gcc-12 g++-12 gfortran-12 libssl-dev
+RUN apt autoremove && apt clean
+
+COPY ./ /opt/build-script/
+
+RUN /opt/build-script/install-tpls.py --cc=gcc-12 --cxx=g++-12 --fc=gfortran-12 --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma_libs
+   
+
+RUN cp /opt/build-script/config.sh > /entrypoint.sh \
+&& chmod a+x /entrypoint.sh 
+
+RUN { \
+      echo '#!/usr/bin/env bash' \
+      && echo ". /opt/goma_libs/config.sh" \
+      && echo 'exec "$@"'; \
+    } > /entrypoint.sh \
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/bin/bash" ]
+

--- a/tpls/Dockerfile
+++ b/tpls/Dockerfile
@@ -1,14 +1,17 @@
 FROM ubuntu:22.04
 
-RUN apt update
-RUN apt install -y git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config autoconf python3-dev vim tmux nano gdb valgrind gcc-12 g++-12 gfortran-12 libssl-dev
-RUN apt autoremove && apt clean
+RUN apt-get update
+RUN apt-get install -y git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config autoconf python3-dev vim tmux nano gdb valgrind libssl-dev
+RUN apt-get autoremove && apt-get clean
 
-RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
+RUN git clone https://github.com/wortiz/goma -b bst /opt/goma
 
-RUN PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc-12 --cxx=g++-12 --fc=gfortran-12 --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
+RUN PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
 RUN rm -r /opt/goma
+RUN rm -r /tmp/downloads
+RUN rm -r /tmp/extract
+RUN rm -r /opt/goma-libs/logs
 
 RUN { \
       echo '#!/usr/bin/env bash' \
@@ -17,21 +20,10 @@ RUN { \
     } > /entrypoint.sh \
 && chmod a+x /entrypoint.sh
 
-
-ARG USER=goma
-RUN adduser -m $USER
-RUN groupadd sudo
-RUN usermod -a -G sudo $USER
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
-# make sure everything is in place
-USER $USER
-ENV HOME /home/$USER
-ENV USER $USER
 ENV OMPI_MCA_btl_base_warn_component_unuse "0"
 ENV OMPI_ALLOW_RUN_AS_ROOT 1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM 1
-WORKDIR $HOME
+WORKDIR /opt/workdir
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]

--- a/tpls/Dockerfile
+++ b/tpls/Dockerfile
@@ -4,17 +4,13 @@ RUN apt update
 RUN apt install -y git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config autoconf python3-dev vim tmux nano gdb valgrind gcc-12 g++-12 gfortran-12 libssl-dev
 RUN apt autoremove && apt clean
 
-COPY ./ /opt/build-script/
+RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
 
-RUN /opt/build-script/install-tpls.py --cc=gcc-12 --cxx=g++-12 --fc=gfortran-12 --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma_libs
-   
-
-RUN cp /opt/build-script/config.sh > /entrypoint.sh \
-&& chmod a+x /entrypoint.sh 
+RUN /opt/goma/tpls/install-tpls.py --cc=gcc-12 --cxx=g++-12 --fc=gfortran-12 --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
 RUN { \
       echo '#!/usr/bin/env bash' \
-      && echo ". /opt/goma_libs/config.sh" \
+      && echo ". /opt/goma-libs/config.sh" \
       && echo 'exec "$@"'; \
     } > /entrypoint.sh \
 

--- a/tpls/Dockerfile
+++ b/tpls/Dockerfile
@@ -13,6 +13,7 @@ RUN { \
       && echo ". /opt/goma-libs/config.sh" \
       && echo 'exec "$@"'; \
     } > /entrypoint.sh \
+&& chmod a+x /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]

--- a/tpls/Dockerfile
+++ b/tpls/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update
 RUN apt-get install -y git build-essential m4 zlib1g-dev libx11-dev gfortran pkg-config autoconf python3-dev vim tmux nano gdb valgrind libssl-dev
 RUN apt-get autoremove && apt-get clean
 
-RUN git clone https://github.com/wortiz/goma -b bst /opt/goma
+RUN git clone https://github.com/goma/goma /opt/goma
 
 RUN PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 

--- a/tpls/Dockerfile-rocky
+++ b/tpls/Dockerfile-rocky
@@ -1,0 +1,19 @@
+FROM rockylinux:8.9
+
+RUN dnf update -y
+RUN dnf install -y git patch gcc-toolset-12 m4 make bzip2 tar zlib-devel openssl-devel pkgconfig python3-devel findutils
+
+RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
+
+RUN . opt/rh/gcc-toolset-12/enable && \
+    /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
+
+RUN { \
+      echo '#!/usr/bin/env bash' \
+      && echo ". /opt/goma-libs/config.sh" \
+      && echo 'exec "$@"'; \
+    } > /entrypoint.sh \
+
+ENTRYPOINT [ "/entrypoint.sh" ]
+CMD [ "/bin/bash" ]
+

--- a/tpls/Dockerfile-rocky
+++ b/tpls/Dockerfile-rocky
@@ -6,7 +6,7 @@ RUN dnf install -y git patch gcc-toolset-13 m4 make bzip2 tar zlib-devel openssl
 RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
 
 RUN . opt/rh/gcc-toolset-13/enable && \
-    /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
+    PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
 RUN { \
       echo '#!/usr/bin/env bash' \

--- a/tpls/Dockerfile-rocky
+++ b/tpls/Dockerfile-rocky
@@ -3,12 +3,15 @@ FROM rockylinux:8.9
 RUN dnf update -y
 RUN dnf install -y git patch gcc-toolset-13 m4 make bzip2 tar zlib-devel openssl-devel pkgconfig python3-devel findutils
 
-RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
+RUN git clone https://github.com/goma/goma /opt/goma
 
-RUN . opt/rh/gcc-toolset-13/enable && \
-    PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
+RUN . /opt/rh/gcc-toolset-13/enable && \
+    PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
 RUN rm -r /opt/goma
+RUN rm -r /tmp/downloads
+RUN rm -r /tmp/extract
+RUN rm -r /opt/goma-libs/logs
 
 RUN { \
       echo '#!/usr/bin/env bash' \
@@ -18,19 +21,10 @@ RUN { \
     } > /entrypoint.sh \
 && chmod a+x /entrypoint.sh
 
-ARG USER=goma
-RUN adduser --disabled-password --gecos '' $USER
-RUN adduser $USER sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
-# make sure everything is in place
-RUN chown -R $USER:$USER /home/$USER
-USER $USER
-ENV HOME /home/$USER
-ENV USER $USER
 ENV OMPI_MCA_btl_base_warn_component_unuse "0"
 ENV OMPI_ALLOW_RUN_AS_ROOT 1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM 1
-WORKDIR $HOME
+WORKDIR /opt/workdir
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]

--- a/tpls/Dockerfile-rocky
+++ b/tpls/Dockerfile-rocky
@@ -1,18 +1,20 @@
 FROM rockylinux:8.9
 
 RUN dnf update -y
-RUN dnf install -y git patch gcc-toolset-12 m4 make bzip2 tar zlib-devel openssl-devel pkgconfig python3-devel findutils
+RUN dnf install -y git patch gcc-toolset-13 m4 make bzip2 tar zlib-devel openssl-devel pkgconfig python3-devel findutils
 
 RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
 
-RUN . opt/rh/gcc-toolset-12/enable && \
+RUN . opt/rh/gcc-toolset-13/enable && \
     /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
 RUN { \
       echo '#!/usr/bin/env bash' \
+      && echo ". /opt/rh/gcc-toolset-13/enable" \
       && echo ". /opt/goma-libs/config.sh" \
       && echo 'exec "$@"'; \
     } > /entrypoint.sh \
+&& chmod a+x /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]

--- a/tpls/Dockerfile-rocky
+++ b/tpls/Dockerfile-rocky
@@ -8,6 +8,8 @@ RUN git clone https://github.com/wortiz/goma -b build-script /opt/goma
 RUN . opt/rh/gcc-toolset-13/enable && \
     PYTHONUNBUFFERED=1 /opt/goma/tpls/install-tpls.py --cc=gcc --cxx=g++ --fc=gfortran --build-shared=yes --download-dir=/tmp/downloads -j 32 --extract-dir=/tmp/extract /opt/goma-libs
 
+RUN rm -r /opt/goma
+
 RUN { \
       echo '#!/usr/bin/env bash' \
       && echo ". /opt/rh/gcc-toolset-13/enable" \
@@ -16,6 +18,21 @@ RUN { \
     } > /entrypoint.sh \
 && chmod a+x /entrypoint.sh
 
+ARG USER=goma
+RUN adduser --disabled-password --gecos '' $USER
+RUN adduser $USER sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# make sure everything is in place
+RUN chown -R $USER:$USER /home/$USER
+USER $USER
+ENV HOME /home/$USER
+ENV USER $USER
+ENV OMPI_MCA_btl_base_warn_component_unuse "0"
+ENV OMPI_ALLOW_RUN_AS_ROOT 1
+ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM 1
+WORKDIR $HOME
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 CMD [ "/bin/bash" ]
+
 

--- a/tpls/README.md
+++ b/tpls/README.md
@@ -21,7 +21,7 @@ Build with a prebuilt openmpi with 4 CPUs:
 
 Build with static libraries, shared is set by default:
 
-    ./install-tpls.py --build-shared=no /path/to/install
+    ./install-tpls.py --build-static /path/to/install
 
 Reuse downloads:
 
@@ -40,12 +40,12 @@ in your shell of choice and used to compile and run Goma.
 
 Usage:
     
-    usage: install-tpls.py [-h] [--cc CC] [--cxx CXX] [--fc FC] [--download-dir DOWNLOAD_DIR] [--extract-dir EXTRACT_DIR] [--build-shared BUILD_SHARED]
-                           [-j JOBS] [--cmake-dir CMAKE_DIR] [--openmpi-dir OPENMPI_DIR] [--hdf5-dir HDF5_DIR] [--pnetcdf-dir PNETCDF_DIR]
-                           [--netcdf-dir NETCDF_DIR] [--fmt-dir FMT_DIR] [--seacas-dir SEACAS_DIR] [--openblas-dir OPENBLAS_DIR] [--metis-dir METIS_DIR]
-                           [--parmetis-dir PARMETIS_DIR] [--arpack_ng-dir ARPACK_NG_DIR] [--scalapack-dir SCALAPACK_DIR] [--mumps-dir MUMPS_DIR]
-                           [--superlu_dist-dir SUPERLU_DIST_DIR] [--suitesparse-dir SUITESPARSE_DIR] [--trilinos-dir TRILINOS_DIR] [--petsc-dir PETSC_DIR]
-                           [--omega_h-dir OMEGA_H_DIR]
+    usage: install-tpls.py [-h] [--cc CC] [--cxx CXX] [--fc FC] [--download-dir DOWNLOAD_DIR] [--extract-dir EXTRACT_DIR] [--build-shared] [--build-static] [-j JOBS] [--enable-parmetis]
+                           [--disable-parmetis] [--cmake-dir CMAKE_DIR] [--openmpi-dir OPENMPI_DIR] [--hdf5-dir HDF5_DIR] [--pnetcdf-dir PNETCDF_DIR] [--netcdf-dir NETCDF_DIR] [--fmt-dir FMT_DIR]
+                           [--seacas-dir SEACAS_DIR] [--bison-dir BISON_DIR] [--flex-dir FLEX_DIR] [--openblas-dir OPENBLAS_DIR] [--metis-dir METIS_DIR] [--parmetis-dir PARMETIS_DIR]
+                           [--scotch-dir SCOTCH_DIR] [--arpack_ng-dir ARPACK_NG_DIR] [--scalapack-dir SCALAPACK_DIR] [--mumps-dir MUMPS_DIR] [--superlu_dist-dir SUPERLU_DIST_DIR]
+                           [--suitesparse-dir SUITESPARSE_DIR] [--trilinos-dir TRILINOS_DIR] [--petsc-dir PETSC_DIR] [--petsc_complex-dir PETSC_COMPLEX_DIR] [--omega_h-dir OMEGA_H_DIR]
+                           [--sparse-dir SPARSE_DIR]
                            INSTALL_DIR
     
     Third party library installer for the finite element code Goma
@@ -55,16 +55,18 @@ Usage:
     
     options:
       -h, --help            show this help message and exit
-      --cc CC               C compiler to use
-      --cxx CXX             C++ compiler to use
-      --fc FC               Fortran compiler to use
+      --cc CC               C compiler to use, default is CC environment variable or gcc
+      --cxx CXX             C++ compiler to use, default is CXX environment variable or g++
+      --fc FC               Fortran compiler to use, defualt is FC environment variable or gfortran
       --download-dir DOWNLOAD_DIR
                             Download location of tarballs
       --extract-dir EXTRACT_DIR
                             Extract and Build location
-      --build-shared BUILD_SHARED
-                            Build shared libraries
+      --build-shared        Build shared libraries (Default)
+      --build-static        Build static libraries
       -j JOBS, --jobs JOBS  Number of parallel jobs
+      --enable-parmetis     Build ParMETIS library, (Default, check license requirements)
+      --disable-parmetis    Disable ParMETIS library
       --cmake-dir CMAKE_DIR
                             System location of package cmake
       --openmpi-dir OPENMPI_DIR
@@ -77,12 +79,17 @@ Usage:
       --fmt-dir FMT_DIR     System location of package fmt
       --seacas-dir SEACAS_DIR
                             System location of package seacas
+      --bison-dir BISON_DIR
+                            System location of package bison
+      --flex-dir FLEX_DIR   System location of package flex
       --openblas-dir OPENBLAS_DIR
                             System location of package openblas
       --metis-dir METIS_DIR
                             System location of package metis
       --parmetis-dir PARMETIS_DIR
                             System location of package parmetis
+      --scotch-dir SCOTCH_DIR
+                            System location of package scotch
       --arpack_ng-dir ARPACK_NG_DIR
                             System location of package arpack-ng
       --scalapack-dir SCALAPACK_DIR
@@ -97,5 +104,9 @@ Usage:
                             System location of package trilinos
       --petsc-dir PETSC_DIR
                             System location of package petsc
+      --petsc_complex-dir PETSC_COMPLEX_DIR
+                            System location of package petsc-complex
       --omega_h-dir OMEGA_H_DIR
                             System location of package omega-h
+      --sparse-dir SPARSE_DIR
+                            System location of package sparse

--- a/tpls/README.md
+++ b/tpls/README.md
@@ -3,3 +3,99 @@
 These are third party libraries with separate license files.
 
 Please look at comments or license files for the separate license
+
+# Script to install all tpls
+
+Third party libraries required for Goma can be installed using the `install-tpls.py` script
+available in this directory.
+
+Examples:
+
+Build with a nonstandard compiler:
+
+    ./install-tpls.py --cc=gcc-13 --cxx=g++-13 --fc=gfortran-13 /path/to/install
+
+Build with a prebuilt openmpi:
+
+    ./install-tpls.py --cc=mpicc --cxx=mpicxx --fc==mpifort --openmpi-dir=$MPI_HOME /path/to/install
+
+Build with static libraries, shared is set by default:
+
+    ./install-tpls.py --build-shared=no /path/to/install
+
+Reuse downloads:
+
+    ./install-tpls.py --download-dir=/path/to/downloads /path/to/install
+
+Default locations:
+
+Downloads are downloaded to `/path/to/install/downloads`, and sources/builds are found in `/path/to/install/sources`
+feel free to remove after installation.
+
+## Usage
+
+Once installed a `config.sh` and `config.fish` file are generated in `/path/to/install` and can be sourced
+in your shell of choice and used to compile and run Goma.
+
+
+Usage:
+    
+    usage: install-tpls.py [-h] [--cc CC] [--cxx CXX] [--fc FC] [--download-dir DOWNLOAD_DIR] [--extract-dir EXTRACT_DIR] [--build-shared BUILD_SHARED]
+                           [-j JOBS] [--cmake-dir CMAKE_DIR] [--openmpi-dir OPENMPI_DIR] [--hdf5-dir HDF5_DIR] [--pnetcdf-dir PNETCDF_DIR]
+                           [--netcdf-dir NETCDF_DIR] [--fmt-dir FMT_DIR] [--seacas-dir SEACAS_DIR] [--openblas-dir OPENBLAS_DIR] [--metis-dir METIS_DIR]
+                           [--parmetis-dir PARMETIS_DIR] [--arpack_ng-dir ARPACK_NG_DIR] [--scalapack-dir SCALAPACK_DIR] [--mumps-dir MUMPS_DIR]
+                           [--superlu_dist-dir SUPERLU_DIST_DIR] [--suitesparse-dir SUITESPARSE_DIR] [--trilinos-dir TRILINOS_DIR] [--petsc-dir PETSC_DIR]
+                           [--omega_h-dir OMEGA_H_DIR]
+                           INSTALL_DIR
+    
+    Third party library installer for the finite element code Goma
+    
+    positional arguments:
+      INSTALL_DIR           Install location of TPLs
+    
+    options:
+      -h, --help            show this help message and exit
+      --cc CC               C compiler to use
+      --cxx CXX             C++ compiler to use
+      --fc FC               Fortran compiler to use
+      --download-dir DOWNLOAD_DIR
+                            Download location of tarballs
+      --extract-dir EXTRACT_DIR
+                            Extract and Build location
+      --build-shared BUILD_SHARED
+                            Build shared libraries
+      -j JOBS, --jobs JOBS  Number of parallel jobs
+      --cmake-dir CMAKE_DIR
+                            System location of package cmake
+      --openmpi-dir OPENMPI_DIR
+                            System location of package openmpi
+      --hdf5-dir HDF5_DIR   System location of package hdf5
+      --pnetcdf-dir PNETCDF_DIR
+                            System location of package pnetcdf
+      --netcdf-dir NETCDF_DIR
+                            System location of package netcdf
+      --fmt-dir FMT_DIR     System location of package fmt
+      --seacas-dir SEACAS_DIR
+                            System location of package seacas
+      --openblas-dir OPENBLAS_DIR
+                            System location of package openblas
+      --metis-dir METIS_DIR
+                            System location of package metis
+      --parmetis-dir PARMETIS_DIR
+                            System location of package parmetis
+      --arpack_ng-dir ARPACK_NG_DIR
+                            System location of package arpack-ng
+      --scalapack-dir SCALAPACK_DIR
+                            System location of package scalapack
+      --mumps-dir MUMPS_DIR
+                            System location of package mumps
+      --superlu_dist-dir SUPERLU_DIST_DIR
+                            System location of package superlu_dist
+      --suitesparse-dir SUITESPARSE_DIR
+                            System location of package suitesparse
+      --trilinos-dir TRILINOS_DIR
+                            System location of package trilinos
+      --petsc-dir PETSC_DIR
+                            System location of package petsc
+      --omega_h-dir OMEGA_H_DIR
+                            System location of package omega-h

--- a/tpls/README.md
+++ b/tpls/README.md
@@ -9,7 +9,16 @@ Please look at comments or license files for the separate license
 Third party libraries required for Goma can be installed using the `install-tpls.py` script
 available in this directory.
 
-Examples:
+## Warning on licenses
+
+By default the `install-tpls.py` script will install with `ParMETIS` but the license is quite
+restrictive. If you are not a government or education employee consider using `--disable-parmetis`
+or read the license restrictions. 
+
+Currently our main interface to SuperLU_DIST is through Trilinos and Trilinos requires SuperLU_DIST 
+be built with ParMETIS support so if ParMETIS is disabled so is SuperLU_DIST.
+
+## Examples:
 
 Build with a nonstandard compiler:
 

--- a/tpls/README.md
+++ b/tpls/README.md
@@ -15,9 +15,9 @@ Build with a nonstandard compiler:
 
     ./install-tpls.py --cc=gcc-13 --cxx=g++-13 --fc=gfortran-13 /path/to/install
 
-Build with a prebuilt openmpi:
+Build with a prebuilt openmpi with 4 CPUs:
 
-    ./install-tpls.py --cc=mpicc --cxx=mpicxx --fc==mpifort --openmpi-dir=$MPI_HOME /path/to/install
+    ./install-tpls.py -j 4 --cc=mpicc --cxx=mpicxx --fc==mpifort --openmpi-dir=$MPI_HOME /path/to/install
 
 Build with static libraries, shared is set by default:
 

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -83,31 +83,45 @@ if __name__ == "__main__":
     if args.cc:
         if CC:
             logger.log(
-                "CC {} is environment variable, overriding with --cc={}".format(
+                "CC {} is an environment variable, overriding with --cc={}".format(
                     CC, args.cc
                 )
             )
         CC = str(args.cc)
     if args.cxx:
-        CXX = str(args.cxx)
-        logger.log(
-            "CXX {} is environment variable, overriding with --cxx={}".format(
-                CXX, args.cxx
+        if CXX:
+            logger.log(
+                "CXX {} is an environment variable, overriding with --cxx={}".format(
+                    CXX, args.cxx
+                )
             )
-        )
+        CXX = str(args.cxx)
     if args.fc:
+        if FC:
+            logger.log(
+                "FC {} is an environment variable, overriding with --fc={}".format(FC, args.fc)
+            )
         FC = str(args.fc)
-        logger.log(
-            "FC {} is environment variable, overriding with --fc={}".format(FC, args.fc)
-        )
 
     if CC:
         tpl_registry.set_environment_variable("CC", CC)
+    else:
+        print("C compiler not set, defaulting to gcc, set with --cc")
+        tpl_registry.set_environment_variable("CC", "gcc")
+        
     if CXX:
         tpl_registry.set_environment_variable("CXX", CXX)
+    else:
+        print("C++ compiler not set, defaulting to g++, set with --cxx")
+        tpl_registry.set_environment_variable("CXX", "g++")
+
     if FC:
         tpl_registry.set_environment_variable("FC", FC)
         tpl_registry.set_environment_variable("F77", FC)
+    else:
+        print("Fortran compiler not set, defaulting to gfortan set with --fc")
+        tpl_registry.set_environment_variable("FC", "gfortran")
+        tpl_registry.set_environment_variable("F77", "gfortran")
 
     for p in packages:
         pm = importlib.import_module("tpl_tools." + ".".join(["packages", p]))

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -40,9 +40,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="""Third party library installer for the finite element code Goma"""
     )
-    parser.add_argument("--cc", help="C compiler to use", type=pathlib.Path)
-    parser.add_argument("--cxx", help="C++ compiler to use", type=pathlib.Path)
-    parser.add_argument("--fc", help="Fortran compiler to use", type=pathlib.Path)
+    parser.add_argument("--cc", help="C compiler to use, default is CC environment variable or gcc", type=pathlib.Path)
+    parser.add_argument("--cxx", help="C++ compiler to use, default is CXX environment variable or g++", type=pathlib.Path)
+    parser.add_argument("--fc", help="Fortran compiler to use, defualt is FC environment variable or gfortran", type=pathlib.Path)
     parser.add_argument(
         "--download-dir", help="Download location of tarballs", type=pathlib.Path
     )

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -115,7 +115,14 @@ if __name__ == "__main__":
             package_dir = getattr(args, pc.name + "_dir")
 
             build = Builder(
-                pc, jobs, download_dir, extract_dir, package_dir, logger, tpl_registry, args.build_shared
+                pc,
+                jobs,
+                download_dir,
+                extract_dir,
+                package_dir,
+                logger,
+                tpl_registry,
+                args.build_shared,
             )
             if build.check(True):
                 build.logger.log("Package {} found at {}".format(pc.name, package_dir))
@@ -124,7 +131,14 @@ if __name__ == "__main__":
             build.register()
         else:
             build = Builder(
-                pc, jobs, download_dir, extract_dir, install_dir, logger, tpl_registry, args.build_shared
+                pc,
+                jobs,
+                download_dir,
+                extract_dir,
+                install_dir,
+                logger,
+                tpl_registry,
+                args.build_shared,
             )
 
             if build.check():
@@ -140,8 +154,18 @@ if __name__ == "__main__":
             if not build.check():
                 break
             build.register()
-    tpl_registry.config.write_config(os.path.join(install_dir,"config.sh"))
-    logger.log("Bash config written to {}, source with bash".format(os.path.join(install_dir, "config.sh")))
+    tpl_registry.config.write_config(os.path.join(install_dir, "config.sh"))
+    logger.log(
+        "Bash config written to {}, source with bash".format(
+            os.path.join(install_dir, "config.sh")
+        )
+    )
 
-    tpl_registry.config.write_config(os.path.join(install_dir,"config.fish"), shell="fish")
-    logger.log("Fish config written to {}, source with fish".format(os.path.join(install_dir, "config.fish")))
+    tpl_registry.config.write_config(
+        os.path.join(install_dir, "config.fish"), shell="fish"
+    )
+    logger.log(
+        "Fish config written to {}, source with fish".format(
+            os.path.join(install_dir, "config.fish")
+        )
+    )

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+from tpl_tools.builder import Builder
+from tpl_tools.registry import Registry
+import importlib
+import tpl_tools.utils as utils
+import os
+import argparse
+import pathlib
+
+packages = [
+    "cmake",
+    "openmpi",
+    "hdf5",
+    "pnetcdf",
+    "netcdf",
+    "fmt",
+    "seacas",
+    "openblas",
+    "metis",
+    "parmetis",
+    "arpack-ng",
+    "scalapack",
+    "mumps",
+    "superlu_dist",
+    "suitesparse",
+    "trilinos",
+    "petsc",
+    "omega_h",
+]
+
+
+if __name__ == "__main__":
+    CC = os.environ.get("CC")
+    CXX = os.environ.get("CXX")
+    FC = os.environ.get("FC")
+    tpl_registry = Registry()
+    logger = utils.PrintLogger()
+    parser = argparse.ArgumentParser(
+        description="""Third party library installer for the finite element code Goma"""
+    )
+    parser.add_argument("--cc", help="C compiler to use", type=pathlib.Path)
+    parser.add_argument("--cxx", help="C++ compiler to use", type=pathlib.Path)
+    parser.add_argument("--fc", help="Fortran compiler to use", type=pathlib.Path)
+    parser.add_argument(
+        "--download-dir", help="Download location of tarballs", type=pathlib.Path
+    )
+    parser.add_argument(
+        "--extract-dir", help="Extract and Build location", type=pathlib.Path
+    )
+    parser.add_argument(
+        "--build-shared", help="Build shared libraries", type=bool, default=False
+    )
+    parser.add_argument(
+        "-j", "--jobs", help="Number of parallel jobs", type=int, default=1
+    )
+    parser.add_argument(
+        "INSTALL_DIR", help="Install location of TPLs", type=pathlib.Path
+    )
+
+    for p in packages:
+        pm = importlib.import_module("tpl_tools." + ".".join(["packages", p]))
+        pc = pm.Package()
+        parser.add_argument(
+            "--" + pc.name.replace("-", "_") + "-dir",
+            help="System location of package {}".format(pc.name),
+            type=pathlib.Path,
+        )
+
+    args = parser.parse_args()
+
+    install_dir = os.path.abspath(os.path.expanduser(args.INSTALL_DIR))
+    download_dir = os.path.join(install_dir, "downloads")
+    if args.download_dir:
+        download_dir = os.path.abspath(os.path.expanduser(args.download_dir))
+    extract_dir = os.path.join(install_dir, "sources")
+    if args.extract_dir:
+        extract_dir = os.path.abspath(os.path.expanduser(args.extract_dir))
+
+    jobs = args.jobs
+
+    if args.cc:
+        if CC:
+            logger.log(
+                "CC {} is environment variable, overriding with --cc={}".format(
+                    CC, args.cc
+                )
+            )
+        CC = str(args.cc)
+    if args.cxx:
+        CXX = str(args.cxx)
+        logger.log(
+            "CXX {} is environment variable, overriding with --cxx={}".format(
+                CXX, args.cxx
+            )
+        )
+    if args.fc:
+        FC = str(args.fc)
+        logger.log(
+            "FC {} is environment variable, overriding with --fc={}".format(FC, args.fc)
+        )
+
+    if CC:
+        tpl_registry.set_environment_variable("CC", CC)
+    if CXX:
+        tpl_registry.set_environment_variable("CXX", CXX)
+    if FC:
+        tpl_registry.set_environment_variable("FC", FC)
+        tpl_registry.set_environment_variable("F77", FC)
+
+    for p in packages:
+        pm = importlib.import_module("tpl_tools." + ".".join(["packages", p]))
+        pc = pm.Package()
+        if getattr(args, pc.name.replace("-", "_") + "_dir"):
+            package_dir = getattr(args, pc.name + "_dir")
+
+            build = Builder(
+                pc, jobs, download_dir, extract_dir, package_dir, logger, tpl_registry, args.build_shared
+            )
+            if build.check(True):
+                build.logger.log("Package {} found at {}".format(pc.name, package_dir))
+            else:
+                break
+            build.register()
+        else:
+            build = Builder(
+                pc, jobs, download_dir, extract_dir, install_dir, logger, tpl_registry, args.build_shared
+            )
+
+            if build.check():
+                build.logger.log(
+                    "Package {} already built, skipping".format(build._package.name)
+                )
+                build.register()
+                continue
+            build.download()
+            build.extract()
+            build.build()
+            build.install()
+            if not build.check():
+                break
+            build.register()
+    tpl_registry.config.write_config(os.path.join(install_dir,"config.sh"))
+    logger.log("Bash config written to {}, source with bash".format(os.path.join(install_dir, "config.sh")))
+
+    tpl_registry.config.write_config(os.path.join(install_dir,"config.fish"), shell="fish")
+    logger.log("Fish config written to {}, source with fish".format(os.path.join(install_dir, "config.fish")))

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -25,7 +25,7 @@ packages = [
     "suitesparse",
     "trilinos",
     "petsc",
-    "petsc-complex",
+    "petsc_complex",
     "omega_h",
     "sparse",
 ]

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -26,6 +26,7 @@ packages = [
     "trilinos",
     "petsc",
     "omega_h",
+    "sparse",
 ]
 
 

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -25,6 +25,7 @@ packages = [
     "suitesparse",
     "trilinos",
     "petsc",
+    "petsc-complex",
     "omega_h",
     "sparse",
 ]

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         "--extract-dir", help="Extract and Build location", type=pathlib.Path
     )
     parser.add_argument(
-        "--build-shared", help="Build shared libraries", type=bool, default=False
+        "--build-shared", help="Build shared libraries", type=bool, default=True
     )
     parser.add_argument(
         "-j", "--jobs", help="Number of parallel jobs", type=int, default=1

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -40,9 +40,21 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="""Third party library installer for the finite element code Goma"""
     )
-    parser.add_argument("--cc", help="C compiler to use, default is CC environment variable or gcc", type=pathlib.Path)
-    parser.add_argument("--cxx", help="C++ compiler to use, default is CXX environment variable or g++", type=pathlib.Path)
-    parser.add_argument("--fc", help="Fortran compiler to use, defualt is FC environment variable or gfortran", type=pathlib.Path)
+    parser.add_argument(
+        "--cc",
+        help="C compiler to use, default is CC environment variable or gcc",
+        type=pathlib.Path,
+    )
+    parser.add_argument(
+        "--cxx",
+        help="C++ compiler to use, default is CXX environment variable or g++",
+        type=pathlib.Path,
+    )
+    parser.add_argument(
+        "--fc",
+        help="Fortran compiler to use, defualt is FC environment variable or gfortran",
+        type=pathlib.Path,
+    )
     parser.add_argument(
         "--download-dir", help="Download location of tarballs", type=pathlib.Path
     )
@@ -99,7 +111,9 @@ if __name__ == "__main__":
     if args.fc:
         if FC:
             logger.log(
-                "FC {} is an environment variable, overriding with --fc={}".format(FC, args.fc)
+                "FC {} is an environment variable, overriding with --fc={}".format(
+                    FC, args.fc
+                )
             )
         FC = str(args.fc)
 
@@ -108,7 +122,7 @@ if __name__ == "__main__":
     else:
         print("C compiler not set, defaulting to gcc, set with --cc")
         tpl_registry.set_environment_variable("CC", "gcc")
-        
+
     if CXX:
         tpl_registry.set_environment_variable("CXX", CXX)
     else:

--- a/tpls/install-tpls.py
+++ b/tpls/install-tpls.py
@@ -67,26 +67,33 @@ if __name__ == "__main__":
         "--extract-dir", help="Extract and Build location", type=pathlib.Path
     )
     parser.add_argument(
-        "--build-shared", help="Build shared libraries (Default)", action='store_true'
+        "--build-shared", help="Build shared libraries (Default)", action="store_true"
     )
     parser.add_argument(
-        "--build-static", help="Build static libraries", dest='enable_shared', action='store_false'
+        "--build-static",
+        help="Build static libraries",
+        dest="enable_shared",
+        action="store_false",
     )
     parser.set_defaults(build_shared=True)
     parser.add_argument(
         "-j", "--jobs", help="Number of parallel jobs", type=int, default=1
     )
     parser.add_argument(
-        "--enable-parmetis", help="Build ParMETIS library, (Default, check license requirements)", action='store_true'
+        "--enable-parmetis",
+        help="Build ParMETIS library, (Default, check license requirements)",
+        action="store_true",
     )
     parser.add_argument(
-        "--disable-parmetis", help="Disable ParMETIS library", dest='enable_parmetis', action='store_false'
+        "--disable-parmetis",
+        help="Disable ParMETIS library",
+        dest="enable_parmetis",
+        action="store_false",
     )
     parser.set_defaults(enable_parmetis=True)
     parser.add_argument(
         "INSTALL_DIR", help="Install location of TPLs", type=pathlib.Path
     )
-
 
     for p in packages:
         pm = importlib.import_module("tpl_tools." + ".".join(["packages", p]))
@@ -104,8 +111,6 @@ if __name__ == "__main__":
         packages.remove("parmetis")
         packages.remove("superlu_dist")
 
-
-
     install_dir = os.path.abspath(os.path.expanduser(args.INSTALL_DIR))
     download_dir = os.path.join(install_dir, "downloads")
     if args.download_dir:
@@ -115,8 +120,6 @@ if __name__ == "__main__":
         extract_dir = os.path.abspath(os.path.expanduser(args.extract_dir))
 
     jobs = args.jobs
-
-
 
     if args.cc:
         if CC:
@@ -178,6 +181,7 @@ if __name__ == "__main__":
                 logger,
                 tpl_registry,
                 args.build_shared,
+                prebuilt=True,
             )
             if build.check(True):
                 build.logger.log("Package {} found at {}".format(pc.name, package_dir))

--- a/tpls/tpl_tools/builder.py
+++ b/tpls/tpl_tools/builder.py
@@ -101,7 +101,7 @@ class Builder(object):
 
     def register(self):
         if hasattr(self._package, "register"):
-            self.logger.log("Registering ", self._package.name)
+            self.logger.log("Registering:", self._package.name)
             self._package.register(self)
 
     def install_dir(self):

--- a/tpls/tpl_tools/builder.py
+++ b/tpls/tpl_tools/builder.py
@@ -108,9 +108,7 @@ class Builder(object):
 
     def install_dir(self):
         if self.prebuilt:
-            return os.path.join(
-                self._install_dir
-            )
+            return os.path.join(self._install_dir)
 
         return os.path.join(
             self._install_dir, self._package.name + "-" + self._package.version

--- a/tpls/tpl_tools/builder.py
+++ b/tpls/tpl_tools/builder.py
@@ -120,7 +120,7 @@ class Builder(object):
             else:
                 command.append(jobs_flag)
                 command.append(str(self._jobs))
-        self.logger.log("Running command: {}".format(command))
+        self.logger.log("Running command: {}".format(" ".join(command)))
         cwd = os.path.join(self._extract_dir, self._extracted_folder)
         self.logger.log("In directory: {}".format(cwd))
         log_directory = os.path.join(self._install_dir, "logs")

--- a/tpls/tpl_tools/builder.py
+++ b/tpls/tpl_tools/builder.py
@@ -1,0 +1,190 @@
+import os
+import subprocess
+import tarfile
+import sys
+from tpl_tools import utils
+
+
+def mkdir_p(directory):
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+
+def print_and_log(line, file):
+    sys.stdout.write(line)
+    file.write(line)
+
+def print_and_log_err(line, file):
+    sys.stderr.write(line)
+    file.write(line)
+
+class Builder(object):
+
+    def __init__(
+        self,
+        package,
+        jobs,
+        download_dir,
+        extract_dir,
+        install_dir,
+        logger,
+        registry,
+        build_shared,
+    ):
+        self._dependencies = []
+        self._configure_options = []
+        self._package = package
+        self.build_shared = build_shared
+        self._download_dir = download_dir
+        self._extract_dir = extract_dir
+        self._extracted_folder = None
+        self._install_dir = install_dir
+        self.logger = logger
+        self._jobs = jobs
+        self._registry = registry
+        return
+
+    def set_dependency(self, dep):
+        self._dependencies.append(dep)
+
+    def get_dependencies(self):
+        return list(set(self._dependencies))
+
+    def add_option(self, opt_string):
+        self._configure_options.append(opt_string)
+
+    def get_options(self):
+        return self._configure_options
+
+    def download(self):
+        mkdir_p(self._download_dir)
+        url = self._package.url
+        sha256 = self._package.sha256
+        filename = os.path.join(self._download_dir, self._package.filename)
+        self.logger.log("Downloading file: {}".format(filename))
+        success = utils.download_file(url, filename, sha256)
+        if success:
+            self.logger.log("Successfully downloaded: {}".format(filename))
+        return success
+
+    def extract(self):
+        mkdir_p(self._extract_dir)
+        filename = os.path.join(self._download_dir, self._package.filename)
+        self.logger.log("Extracting {}".format(self._package.name))
+        self.logger.log("Extracting from {}".format(filename))
+        tf = tarfile.open(filename)
+        tf.extractall(os.path.join(self._extract_dir))
+        self._extracted_folder = tf.getnames()[0]
+        self.logger.log(
+            "Extracted {} to {}".format(
+                self._package.name,
+                os.path.join(self._extract_dir, self._extracted_folder),
+            )
+        )
+
+    def build(self):
+        self._package.set_environment(self)
+        self._package.configure_options(self)
+        if hasattr(self._package, "configure"):
+            self.logger.log("Configuring {}".format(self._package.name))
+            self._package.configure(self)
+        if hasattr(self._package, "build"):
+            self.logger.log("Building {}".format(self._package.name))
+            self._package.build(self)
+
+    def install(self):
+        if hasattr(self._package, "install"):
+            self.logger.log("Installing {}".format(self._package.name))
+            self._package.install(self)
+
+    def register(self):
+        if hasattr(self._package, "register"):
+            self.logger.log("Registering ", self._package.name)
+            self._package.register(self)
+
+    def install_dir(self):
+        return os.path.join(
+            self._install_dir, self._package.name + "-" + self._package.version
+        )
+
+    def run_command(self, command_list, jobs_flag=None, parallel=False, env=None, command_id=None):
+        command = command_list
+        if parallel and jobs_flag:
+            if jobs_flag[-1] == "=":
+                jobs_flag = jobs_flag + str(self._jobs)
+                command.append(jobs_flag)
+            else:
+                command.append(jobs_flag)
+                command.append(str(self._jobs))
+        self.logger.log("Running command: {}".format(command))
+        cwd = os.path.join(self._extract_dir, self._extracted_folder)
+        self.logger.log("In directory: {}".format(cwd))
+        log_directory = os.path.join(self._install_dir, "logs")
+        mkdir_p(log_directory)
+        logfile = self._package.name + "-" + self._package.version
+        if command_id:
+            logfile += str(command_id)
+        logfile += ".log"
+        logfile = os.path.join(log_directory, logfile)
+        self.logger.log("log available at : {}".format(logfile))
+        with open(logfile, "a") as lf:
+            runenv = self.env
+            if env:
+                runenv = env
+            cmd = subprocess.Popen(command, cwd=cwd, env=runenv, stderr=lf, stdout=lf)
+        cmd.wait()
+        if cmd.returncode != 0:
+            with open(logfile, "r") as f:
+                for line in f:
+                    sys.stderr.write(line)
+            raise RuntimeError("Command resulted in a non-zero error code")
+
+
+
+    def check(self, skip_named_install=False):
+        self.logger.log("Checking install of {}".format(self._package.name))
+        install_dir = self.install_dir()
+        if skip_named_install:
+            install_dir = self._install_dir
+        if hasattr(self._package, "executables"):
+            bindir = os.path.join(install_dir, "bin")
+            for e in self._package.executables:
+                exe = os.path.join(bindir, e)
+                self.logger.log("Checking for {}".format(exe))
+                if not os.path.isfile(exe):
+                    self.logger.log("File not found: ", exe)
+                    return False
+                self.logger.log("Found executable: {}".format(exe))
+        if hasattr(self._package, "libraries"):
+            for lib in self._package.libraries:
+                found = False
+                prefix = ["", "lib"]
+                directories = ["", "lib", "lib64"]
+                extension = utils.get_library_extension(self.build_shared)
+                self.logger.log("Checking for {}".format(lib))
+                for d in directories:
+                    for p in prefix:
+                        checkpath = install_dir
+                        if d != "":
+                            checkpath = os.path.join(checkpath, d)
+                        if os.path.exists(os.path.join(checkpath, p + lib + extension)):
+                            found = True
+                if not found:
+                    self.logger.log("Failed to find library: {}".format("lib" + lib + extension))
+                    return False
+                self.logger.log("Found library: {}".format(lib))
+        if hasattr(self._package, "includes"):
+            for header in self._package.includes:
+                directories = ["", "include"]
+                found = False
+                for d in directories:
+                    checkpath = install_dir
+                    if d != "":
+                        checkpath = os.path.join(checkpath, d)
+                    if os.path.exists(os.path.join(checkpath, header)):
+                        found = True
+                if not found:
+                    self.logger.log("Failed to find include: {}".format(header))
+                    return False
+                self.logger.log("Found include: {}".format(header))
+        return True

--- a/tpls/tpl_tools/builder.py
+++ b/tpls/tpl_tools/builder.py
@@ -14,9 +14,11 @@ def print_and_log(line, file):
     sys.stdout.write(line)
     file.write(line)
 
+
 def print_and_log_err(line, file):
     sys.stderr.write(line)
     file.write(line)
+
 
 class Builder(object):
 
@@ -107,7 +109,9 @@ class Builder(object):
             self._install_dir, self._package.name + "-" + self._package.version
         )
 
-    def run_command(self, command_list, jobs_flag=None, parallel=False, env=None, command_id=None):
+    def run_command(
+        self, command_list, jobs_flag=None, parallel=False, env=None, command_id=None
+    ):
         command = command_list
         if parallel and jobs_flag:
             if jobs_flag[-1] == "=":
@@ -139,8 +143,6 @@ class Builder(object):
                     sys.stderr.write(line)
             raise RuntimeError("Command resulted in a non-zero error code")
 
-
-
     def check(self, skip_named_install=False):
         self.logger.log("Checking install of {}".format(self._package.name))
         install_dir = self.install_dir()
@@ -170,7 +172,9 @@ class Builder(object):
                         if os.path.exists(os.path.join(checkpath, p + lib + extension)):
                             found = True
                 if not found:
-                    self.logger.log("Failed to find library: {}".format("lib" + lib + extension))
+                    self.logger.log(
+                        "Failed to find library: {}".format("lib" + lib + extension)
+                    )
                     return False
                 self.logger.log("Found library: {}".format(lib))
         if hasattr(self._package, "includes"):

--- a/tpls/tpl_tools/builder.py
+++ b/tpls/tpl_tools/builder.py
@@ -32,6 +32,7 @@ class Builder(object):
         logger,
         registry,
         build_shared,
+        prebuilt=False,
     ):
         self._dependencies = []
         self._configure_options = []
@@ -44,6 +45,7 @@ class Builder(object):
         self.logger = logger
         self._jobs = jobs
         self._registry = registry
+        self.prebuilt = prebuilt
         return
 
     def set_dependency(self, dep):
@@ -105,6 +107,11 @@ class Builder(object):
             self._package.register(self)
 
     def install_dir(self):
+        if self.prebuilt:
+            return os.path.join(
+                self._install_dir
+            )
+
         return os.path.join(
             self._install_dir, self._package.name + "-" + self._package.version
         )

--- a/tpls/tpl_tools/packages/arpack-ng.py
+++ b/tpls/tpl_tools/packages/arpack-ng.py
@@ -3,14 +3,14 @@ from tpl_tools.packages import packages
 
 class Package(packages.CMakePackage):
     def __init__(self):
-        self.name = 'arpack-ng'
+        self.name = "arpack-ng"
         self.version = "3.9.1"
         self.sha256 = "f6641deb07fa69165b7815de9008af3ea47eb39b2bb97521fbf74c97aba6e844"
         self.filename = "arpack-ng-" + self.version + ".tar.gz"
         self.url = (
             "https://github.com/opencollab/arpack-ng/archive/refs/tags/"
-            + self.version +
-            ".tar.gz"
+            + self.version
+            + ".tar.gz"
         )
         self.libraries = ["arpack", "parpack"]
 

--- a/tpls/tpl_tools/packages/arpack-ng.py
+++ b/tpls/tpl_tools/packages/arpack-ng.py
@@ -1,0 +1,34 @@
+from tpl_tools.packages import packages
+
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = 'arpack-ng'
+        self.version = "3.9.1"
+        self.sha256 = "f6641deb07fa69165b7815de9008af3ea47eb39b2bb97521fbf74c97aba6e844"
+        self.filename = "arpack-ng-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/opencollab/arpack-ng/archive/refs/tags/"
+            + self.version +
+            ".tar.gz"
+        )
+        self.libraries = ["arpack", "parpack"]
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        builder.add_option("-D=MPI=ON")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("ARPACK_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/bison.py
+++ b/tpls/tpl_tools/packages/bison.py
@@ -1,0 +1,27 @@
+from tpl_tools.packages import packages
+import os
+
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = "bison"
+        self.version = "3.8.2"
+        self.sha256 = "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
+        self.filename = "bison-" + self.version + "tar.bz2"
+        self.url = (
+            "http://ftp.gnu.org/gnu/bison/bison-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.executables = ["bison"]
+
+    def setDependencies(self, builder):
+        return
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.append_environment_variable("BISON_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
+        registry.append_environment_variable(
+            "PATH", os.path.join(builder.install_dir(), "bin")
+        )

--- a/tpls/tpl_tools/packages/bison.py
+++ b/tpls/tpl_tools/packages/bison.py
@@ -8,11 +8,7 @@ class Package(packages.AutotoolsPackage):
         self.version = "3.8.2"
         self.sha256 = "06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
         self.filename = "bison-" + self.version + "tar.bz2"
-        self.url = (
-            "http://ftp.gnu.org/gnu/bison/bison-"
-            + self.version
-            + ".tar.gz"
-        )
+        self.url = "http://ftp.gnu.org/gnu/bison/bison-" + self.version + ".tar.gz"
         self.executables = ["bison"]
 
     def setDependencies(self, builder):

--- a/tpls/tpl_tools/packages/cmake.py
+++ b/tpls/tpl_tools/packages/cmake.py
@@ -5,8 +5,8 @@ import os
 class Package(packages.AutotoolsPackage):
     def __init__(self):
         self.name = "cmake"
-        self.version = "3.30.1"
-        self.sha256 = "df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1"
+        self.version = "3.30.2"
+        self.sha256 = "46074c781eccebc433e98f0bbfa265ca3fd4381f245ca3b140e7711531d60db2"
         self.filename = "cmake-" + self.version + ".tar.gz"
         self.compression = "gz"
         self.url = (

--- a/tpls/tpl_tools/packages/cmake.py
+++ b/tpls/tpl_tools/packages/cmake.py
@@ -1,13 +1,14 @@
 from tpl_tools.packages import packages
 import os
 
+
 class Package(packages.AutotoolsPackage):
     def __init__(self):
         self.name = "cmake"
         self.version = "3.30.1"
         self.sha256 = "df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1"
         self.filename = "cmake-" + self.version + ".tar.gz"
-        self.compression = 'gz'
+        self.compression = "gz"
         self.url = (
             "https://github.com/Kitware/CMake/releases/download/v"
             + self.version
@@ -16,7 +17,7 @@ class Package(packages.AutotoolsPackage):
             + ".tar.gz"
         )
         self.executables = ["cmake"]
-    
+
     def configure(self, builder):
         configure_options = ["./bootstrap"]
         configure_options.extend(builder.get_options())
@@ -26,5 +27,9 @@ class Package(packages.AutotoolsPackage):
     def register(self, builder):
         registry = builder._registry
         registry.register_package(self.name, builder.install_dir())
-        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'cmake'))
-        registry.append_environment_variable("PATH",os.path.join(builder.install_dir(), 'bin'))
+        registry.register_executable(
+            os.path.join(builder.install_dir(), "bin", "cmake")
+        )
+        registry.append_environment_variable(
+            "PATH", os.path.join(builder.install_dir(), "bin")
+        )

--- a/tpls/tpl_tools/packages/cmake.py
+++ b/tpls/tpl_tools/packages/cmake.py
@@ -1,0 +1,30 @@
+from tpl_tools.packages import packages
+import os
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = "cmake"
+        self.version = "3.30.1"
+        self.sha256 = "df9b3c53e3ce84c3c1b7c253e5ceff7d8d1f084ff0673d048f260e04ccb346e1"
+        self.filename = "cmake-" + self.version + ".tar.gz"
+        self.compression = 'gz'
+        self.url = (
+            "https://github.com/Kitware/CMake/releases/download/v"
+            + self.version
+            + "/cmake-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.executables = ["cmake"]
+    
+    def configure(self, builder):
+        configure_options = ["./bootstrap"]
+        configure_options.extend(builder.get_options())
+        configure_options.append("--prefix=" + builder.install_dir())
+        builder.run_command(configure_options, jobs_flag="--parallel=", parallel=True)
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'cmake'))
+        registry.append_environment_variable("PATH",os.path.join(builder.install_dir(), 'bin'))

--- a/tpls/tpl_tools/packages/flex.py
+++ b/tpls/tpl_tools/packages/flex.py
@@ -1,0 +1,27 @@
+from tpl_tools.packages import packages
+import os
+
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = "flex"
+        self.version = "2.6.4"
+        self.sha256 = "e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995"
+        self.filename = "flex-" + self.version + "tar.bz2"
+        self.url = (
+            "https://github.com/westes/flex/releases/download/v" + self.version + "/flex-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.executables = ["flex"]
+
+    def setDependencies(self, builder):
+        return
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.append_environment_variable("FLEX_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
+        registry.append_environment_variable(
+            "PATH", os.path.join(builder.install_dir(), "bin")
+        )

--- a/tpls/tpl_tools/packages/flex.py
+++ b/tpls/tpl_tools/packages/flex.py
@@ -9,7 +9,9 @@ class Package(packages.AutotoolsPackage):
         self.sha256 = "e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995"
         self.filename = "flex-" + self.version + "tar.bz2"
         self.url = (
-            "https://github.com/westes/flex/releases/download/v" + self.version + "/flex-"
+            "https://github.com/westes/flex/releases/download/v"
+            + self.version
+            + "/flex-"
             + self.version
             + ".tar.gz"
         )

--- a/tpls/tpl_tools/packages/fmt.py
+++ b/tpls/tpl_tools/packages/fmt.py
@@ -3,7 +3,7 @@ from tpl_tools.packages import packages
 
 class Package(packages.CMakePackage):
     def __init__(self):
-        self.name = 'fmt'
+        self.name = "fmt"
         self.version = "10.2.1"
         self.sha256 = "1250e4cc58bf06ee631567523f48848dc4596133e163f02615c97f78bab6c811"
         self.filename = "fmt-" + self.version + ".tar.gz"
@@ -16,11 +16,11 @@ class Package(packages.CMakePackage):
         self.libraries = ["fmt"]
 
     def setDependencies(self, builder):
-        builder.set_dependency('packages.openmpi')
-        builder.set_dependency('packages.hdf5')
-        builder.set_dependency('packages.pnetcdf')
-        builder.set_dependency('packages.netcdf')
-        builder.set_dependency('packages.fmt')
+        builder.set_dependency("packages.openmpi")
+        builder.set_dependency("packages.hdf5")
+        builder.set_dependency("packages.pnetcdf")
+        builder.set_dependency("packages.netcdf")
+        builder.set_dependency("packages.fmt")
         return
 
     def configure_options(self, builder):

--- a/tpls/tpl_tools/packages/fmt.py
+++ b/tpls/tpl_tools/packages/fmt.py
@@ -1,0 +1,38 @@
+from tpl_tools.packages import packages
+
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = 'fmt'
+        self.version = "10.2.1"
+        self.sha256 = "1250e4cc58bf06ee631567523f48848dc4596133e163f02615c97f78bab6c811"
+        self.filename = "fmt-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/fmtlib/fmt/archive/refs/tags/"
+            + self.version
+            + ".tar.gz"
+        )
+        self.includes = ["fmt/core.h", "fmt/format.h"]
+        self.libraries = ["fmt"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency('packages.openmpi')
+        builder.set_dependency('packages.hdf5')
+        builder.set_dependency('packages.pnetcdf')
+        builder.set_dependency('packages.netcdf')
+        builder.set_dependency('packages.fmt')
+        return
+
+    def configure_options(self, builder):
+        CXX = builder.env["CXX"]
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        builder.add_option("-DCMAKE_CXX_COMPILER=" + CXX)
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("FMT_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/hdf5.py
+++ b/tpls/tpl_tools/packages/hdf5.py
@@ -5,15 +5,16 @@ import os
 class Package(packages.AutotoolsPackage):
     def __init__(self):
         self.name = "hdf5"
-        self.version = "1.12.2"
-        self.sha256 = "1a88bbe36213a2cea0c8397201a459643e7155c9dc91e062675b3fb07ee38afe"
+        self.version = "1.14.4.3"
+        version_tag = "1.14.4-3"
+        self.sha256 = "019ac451d9e1cf89c0482ba2a06f07a46166caf23f60fea5ef3c37724a318e03"
         self.filename = "hdf5-" + self.version + ".tar.bz2"
         self.url = (
-            "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-"
+            "https://github.com/HDFGroup/hdf5/releases/download/hdf5_"
             + self.version
-            + "/src/hdf5-"
-            + self.version
-            + ".tar.bz2"
+            + "/hdf5-"
+            + version_tag
+            + ".tar.gz"
         )
         self.libraries = ["hdf5"]
 

--- a/tpls/tpl_tools/packages/hdf5.py
+++ b/tpls/tpl_tools/packages/hdf5.py
@@ -1,0 +1,40 @@
+from tpl_tools.packages import packages
+import os
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = 'hdf5'
+        self.version = "1.12.2"
+        self.sha256 = "1a88bbe36213a2cea0c8397201a459643e7155c9dc91e062675b3fb07ee38afe"
+        self.filename = "hdf5-" + self.version + ".tar.bz2"
+        self.url = (
+            "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-"
+            + self.version
+            + "/src/hdf5-"
+            + self.version
+            + ".tar.bz2"
+        )
+        self.libraries = ["hdf5"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency('packages.openmpi')
+    
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("--enable-shared")
+        else:
+            builder.add_option("--enable-shared=off")
+        builder.add_option("--enable-parallel")
+        builder.add_option("--with-default-api-version=v18")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("HDF5_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
+        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), 'bin'))
+    

--- a/tpls/tpl_tools/packages/hdf5.py
+++ b/tpls/tpl_tools/packages/hdf5.py
@@ -1,9 +1,10 @@
 from tpl_tools.packages import packages
 import os
 
+
 class Package(packages.AutotoolsPackage):
     def __init__(self):
-        self.name = 'hdf5'
+        self.name = "hdf5"
         self.version = "1.12.2"
         self.sha256 = "1a88bbe36213a2cea0c8397201a459643e7155c9dc91e062675b3fb07ee38afe"
         self.filename = "hdf5-" + self.version + ".tar.bz2"
@@ -17,8 +18,8 @@ class Package(packages.AutotoolsPackage):
         self.libraries = ["hdf5"]
 
     def setDependencies(self, builder):
-        builder.set_dependency('packages.openmpi')
-    
+        builder.set_dependency("packages.openmpi")
+
     def set_environment(self, builder):
         builder.env = builder._registry.get_environment().copy()
         builder.env["CC"] = builder._registry.get_executable("mpicc")
@@ -36,5 +37,6 @@ class Package(packages.AutotoolsPackage):
         registry.register_package(self.name, builder.install_dir())
         registry.set_environment_variable("HDF5_DIR", builder.install_dir())
         registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
-        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), 'bin'))
-    
+        registry.append_environment_variable(
+            "PATH", os.path.join(builder.install_dir(), "bin")
+        )

--- a/tpls/tpl_tools/packages/metis.py
+++ b/tpls/tpl_tools/packages/metis.py
@@ -1,0 +1,31 @@
+from tpl_tools.packages import packages
+
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = 'metis'
+        self.version = "5.1.0-p12"
+        self.sha256 = "2f16abe87394d4fd1430d66a8995076c352af40f7a4d1c5300b3b1cc9d545663"
+        self.filename = "petsc-pkg-metis-" + self.version + ".tar.gz"
+        self.url = (
+            "https://bitbucket.org/petsc/pkg-metis/get/v"
+            + self.version +
+            ".tar.gz"
+        )
+        self.libraries = ["metis"]
+        self.includes = ["metis.h"]
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+            builder.add_option("-D=SHARED:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+            builder.add_option("-D=SHARED:BOOL=OFF")
+        builder.add_option("-D=GKLIB_PATH=./GKlib")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("METIS_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/metis.py
+++ b/tpls/tpl_tools/packages/metis.py
@@ -3,14 +3,12 @@ from tpl_tools.packages import packages
 
 class Package(packages.CMakePackage):
     def __init__(self):
-        self.name = 'metis'
+        self.name = "metis"
         self.version = "5.1.0-p12"
         self.sha256 = "2f16abe87394d4fd1430d66a8995076c352af40f7a4d1c5300b3b1cc9d545663"
         self.filename = "petsc-pkg-metis-" + self.version + ".tar.gz"
         self.url = (
-            "https://bitbucket.org/petsc/pkg-metis/get/v"
-            + self.version +
-            ".tar.gz"
+            "https://bitbucket.org/petsc/pkg-metis/get/v" + self.version + ".tar.gz"
         )
         self.libraries = ["metis"]
         self.includes = ["metis.h"]

--- a/tpls/tpl_tools/packages/mumps.py
+++ b/tpls/tpl_tools/packages/mumps.py
@@ -29,25 +29,46 @@ class Package(packages.GenericPackage):
             f.write("IPORD    = -I$(topdir)/PORD/include/\n")
             f.write("LPORD    = -L$(LPORDDIR) -lpord$(PLAT)\n")
             f.write("LMETISDIR = " + builder.env["METIS_DIR"] + "/lib\n")
-            f.write("LPARMETISDIR = " + builder.env["PARMETIS_DIR"] + "/lib\n")
+            if "PARMETIS_DIR" in builder.env:
+                f.write("LPARMETISDIR = " + builder.env["PARMETIS_DIR"] + "/lib\n")
             f.write(
                 "IMETIS = -I"
                 + builder.env["METIS_DIR"]
-                + "/include -I"
-                + builder.env["PARMETIS_DIR"]
-                + "/include \n"
-            )
+                + "/include")
+            
+            if "PARMETIS_DIR" in builder.env:
+                f.write(" -I"
+                    + builder.env["PARMETIS_DIR"]
+                    + "/include \n"
+                )
+            else:
+                f.write("\n")
             f.write("LMETIS    = -L$(LPARMETISDIR) -lparmetis -L$(LMETISDIR) -lmetis\n")
-            f.write("ORDERINGSF  = -Dpord -Dmetis -Dparmetis\n")
+            f.write("SCOTCHDIR = " + builder.env["SCOTCH_DIR"] + "\n")
+            f.write("ISCOTCH = -I" + builder.env["SCOTCH_DIR"] + "/include\n")
+            f.write(
+                "LSCOTCH = -L"
+                + builder.env["SCOTCH_DIR"]
+                + "/lib -lptesmumps -lptscotch -lptscotcherr -lscotch -lscotcherr\n"
+            )
+            f.write("ORDERINGSF  = -Dpord -Dmetis -Dptscotch")
+            if "PARMETIS_DIR" in builder.env:
+                f.write(" -Dparmetis\n")
+            else:
+                f.write("\n")
             f.write("ORDERINGSC  = $(ORDERINGSF)\n")
-            f.write("LORDERINGS = $(LMETIS) $(LPORD)\n")
-            f.write("IORDERINGSF = \n")
-            f.write("IORDERINGSC = $(IMETIS) $(IPORD)\n")
+            f.write("LORDERINGS = $(LMETIS) $(LPORD) $(LSCOTCH)\n")
+            f.write("IORDERINGSF = $(ISCOTCH)\n")
+            f.write("IORDERINGSC = $(IMETIS) $(IPORD) $(ISCOTCH)\n")
             f.write("LIBEXT_SHARED  = .so\n")
             f.write("SONAME = -soname\n")
             f.write(
-                "SHARED_OPT = -shared -Wl,-rpath," + builder.install_dir() + "/lib\n"
+                "SHARED_OPT = -shared -Wl,-rpath," + builder.install_dir() + "/lib -Wl,-rpath," + builder.env["SCOTCH_DIR"] + 
+                "/lib"
             )
+            if builder.env["PARMETIS_DIR"]:
+                f.write(" -Wl,-rpath," + builder.env["PARMETIS_DIR"] + "/lib")
+            f.write(" -Wl,-rpath,"+builder.env["METIS_DIR"] +"/lib\n")
             f.write("FPIC_OPT = -fPIC\n")
             f.write("LIBEXT  = .a\n")
             f.write("OUTC    = -o\n")

--- a/tpls/tpl_tools/packages/mumps.py
+++ b/tpls/tpl_tools/packages/mumps.py
@@ -37,7 +37,7 @@ class Package(packages.GenericPackage):
             f.write("IORDERINGSC = $(IMETIS) $(IPORD)\n")
             f.write("LIBEXT_SHARED  = .so\n")
             f.write("SONAME = -soname\n")
-            f.write("SHARED_OPT = -shared\n")
+            f.write("SHARED_OPT = -shared -Wl,-rpath," + builder.install_dir() + "/lib\n")
             f.write("FPIC_OPT = -fPIC\n")
             f.write("LIBEXT  = .a\n")
             f.write("OUTC    = -o\n")

--- a/tpls/tpl_tools/packages/mumps.py
+++ b/tpls/tpl_tools/packages/mumps.py
@@ -31,16 +31,10 @@ class Package(packages.GenericPackage):
             f.write("LMETISDIR = " + builder.env["METIS_DIR"] + "/lib\n")
             if "PARMETIS_DIR" in builder.env:
                 f.write("LPARMETISDIR = " + builder.env["PARMETIS_DIR"] + "/lib\n")
-            f.write(
-                "IMETIS = -I"
-                + builder.env["METIS_DIR"]
-                + "/include")
-            
+            f.write("IMETIS = -I" + builder.env["METIS_DIR"] + "/include")
+
             if "PARMETIS_DIR" in builder.env:
-                f.write(" -I"
-                    + builder.env["PARMETIS_DIR"]
-                    + "/include \n"
-                )
+                f.write(" -I" + builder.env["PARMETIS_DIR"] + "/include \n")
             else:
                 f.write("\n")
             f.write("LMETIS    = -L$(LPARMETISDIR) -lparmetis -L$(LMETISDIR) -lmetis\n")
@@ -63,12 +57,15 @@ class Package(packages.GenericPackage):
             f.write("LIBEXT_SHARED  = .so\n")
             f.write("SONAME = -soname\n")
             f.write(
-                "SHARED_OPT = -shared -Wl,-rpath," + builder.install_dir() + "/lib -Wl,-rpath," + builder.env["SCOTCH_DIR"] + 
-                "/lib"
+                "SHARED_OPT = -shared -Wl,-rpath,"
+                + builder.install_dir()
+                + "/lib -Wl,-rpath,"
+                + builder.env["SCOTCH_DIR"]
+                + "/lib"
             )
             if builder.env["PARMETIS_DIR"]:
                 f.write(" -Wl,-rpath," + builder.env["PARMETIS_DIR"] + "/lib")
-            f.write(" -Wl,-rpath,"+builder.env["METIS_DIR"] +"/lib\n")
+            f.write(" -Wl,-rpath," + builder.env["METIS_DIR"] + "/lib\n")
             f.write("FPIC_OPT = -fPIC\n")
             f.write("LIBEXT  = .a\n")
             f.write("OUTC    = -o\n")

--- a/tpls/tpl_tools/packages/mumps.py
+++ b/tpls/tpl_tools/packages/mumps.py
@@ -2,17 +2,14 @@ from tpl_tools.packages import packages
 import os
 import shutil
 
+
 class Package(packages.GenericPackage):
     def __init__(self):
         self.name = "mumps"
         self.version = "5.7.3"
         self.sha256 = "84a47f7c4231b9efdf4d4f631a2cae2bdd9adeaabc088261d15af040143ed112"
         self.filename = "mumps-" + self.version + ".tar.gz"
-        self.url = (
-            "https://mumps-solver.org/MUMPS_"
-            + self.version +
-            ".tar.gz"
-        )
+        self.url = "https://mumps-solver.org/MUMPS_" + self.version + ".tar.gz"
         self.libraries = ["dmumps", "zmumps"]
 
     def set_environment(self, builder):
@@ -22,13 +19,24 @@ class Package(packages.GenericPackage):
         builder.env["FC"] = builder._registry.get_executable("mpifort")
 
     def configure_options(self, builder):
-        with open(os.path.join(builder._extract_dir,builder._extracted_folder, "Makefile.inc"), "w") as f:
+        with open(
+            os.path.join(
+                builder._extract_dir, builder._extracted_folder, "Makefile.inc"
+            ),
+            "w",
+        ) as f:
             f.write("LPORDDIR = $(topdir)/PORD/lib/\n")
             f.write("IPORD    = -I$(topdir)/PORD/include/\n")
             f.write("LPORD    = -L$(LPORDDIR) -lpord$(PLAT)\n")
             f.write("LMETISDIR = " + builder.env["METIS_DIR"] + "/lib\n")
             f.write("LPARMETISDIR = " + builder.env["PARMETIS_DIR"] + "/lib\n")
-            f.write("IMETIS = -I" + builder.env["METIS_DIR"] + "/include -I" + builder.env["PARMETIS_DIR"] + "/include \n")
+            f.write(
+                "IMETIS = -I"
+                + builder.env["METIS_DIR"]
+                + "/include -I"
+                + builder.env["PARMETIS_DIR"]
+                + "/include \n"
+            )
             f.write("LMETIS    = -L$(LPARMETISDIR) -lparmetis -L$(LMETISDIR) -lmetis\n")
             f.write("ORDERINGSF  = -Dpord -Dmetis -Dparmetis\n")
             f.write("ORDERINGSC  = $(ORDERINGSF)\n")
@@ -37,7 +45,9 @@ class Package(packages.GenericPackage):
             f.write("IORDERINGSC = $(IMETIS) $(IPORD)\n")
             f.write("LIBEXT_SHARED  = .so\n")
             f.write("SONAME = -soname\n")
-            f.write("SHARED_OPT = -shared -Wl,-rpath," + builder.install_dir() + "/lib\n")
+            f.write(
+                "SHARED_OPT = -shared -Wl,-rpath," + builder.install_dir() + "/lib\n"
+            )
             f.write("FPIC_OPT = -fPIC\n")
             f.write("LIBEXT  = .a\n")
             f.write("OUTC    = -o\n")
@@ -51,7 +61,13 @@ class Package(packages.GenericPackage):
             f.write("AR      = ar vr \n")
             f.write("RANLIB  = ranlib \n")
             f.write("LAPACK = " + builder.env["LAPACK_LIBRARIES"] + "\n")
-            f.write("SCALAP  = -L" + builder.env["SCALAPACK_DIR"] + "/lib -lscalapack " + builder.env["LAPACK_LIBRARIES"] + "\n")
+            f.write(
+                "SCALAP  = -L"
+                + builder.env["SCALAPACK_DIR"]
+                + "/lib -lscalapack "
+                + builder.env["LAPACK_LIBRARIES"]
+                + "\n"
+            )
             f.write("BLAS = " + builder.env["BLAS_LIBRARIES"] + "\n")
             f.write("LIBOTHERS = -lpthread\n")
             f.write("CDEFS = -DAdd_\n")
@@ -65,20 +81,23 @@ class Package(packages.GenericPackage):
             f.write("LIBS = $(LIBPAR)\n")
             f.write("LIBSEQNEEDED =\n")
 
-
     def build(self, builder):
         if builder.build_shared:
             builder.run_command(["make", "allshared"], jobs_flag="-j", parallel=True)
         else:
             builder.run_command(["make", "all"], jobs_flag="-j", parallel=True)
-    
+
     def install(self, builder):
         if not os.path.exists(builder.install_dir()):
             os.makedirs(builder.install_dir())
-        build_dir = os.path.join(builder._extract_dir,builder._extracted_folder)
-        shutil.copytree(os.path.join(build_dir, "include"), os.path.join(builder.install_dir(), "include"))
-        shutil.copytree(os.path.join(build_dir, "lib"), os.path.join(builder.install_dir(), "lib"))
-        
+        build_dir = os.path.join(builder._extract_dir, builder._extracted_folder)
+        shutil.copytree(
+            os.path.join(build_dir, "include"),
+            os.path.join(builder.install_dir(), "include"),
+        )
+        shutil.copytree(
+            os.path.join(build_dir, "lib"), os.path.join(builder.install_dir(), "lib")
+        )
 
     def register(self, builder):
         registry = builder._registry

--- a/tpls/tpl_tools/packages/mumps.py
+++ b/tpls/tpl_tools/packages/mumps.py
@@ -1,0 +1,87 @@
+from tpl_tools.packages import packages
+import os
+import shutil
+
+class Package(packages.GenericPackage):
+    def __init__(self):
+        self.name = "mumps"
+        self.version = "5.7.3"
+        self.sha256 = "84a47f7c4231b9efdf4d4f631a2cae2bdd9adeaabc088261d15af040143ed112"
+        self.filename = "mumps-" + self.version + ".tar.gz"
+        self.url = (
+            "https://mumps-solver.org/MUMPS_"
+            + self.version +
+            ".tar.gz"
+        )
+        self.libraries = ["dmumps", "zmumps"]
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        with open(os.path.join(builder._extract_dir,builder._extracted_folder, "Makefile.inc"), "w") as f:
+            f.write("LPORDDIR = $(topdir)/PORD/lib/\n")
+            f.write("IPORD    = -I$(topdir)/PORD/include/\n")
+            f.write("LPORD    = -L$(LPORDDIR) -lpord$(PLAT)\n")
+            f.write("LMETISDIR = " + builder.env["METIS_DIR"] + "/lib\n")
+            f.write("LPARMETISDIR = " + builder.env["PARMETIS_DIR"] + "/lib\n")
+            f.write("IMETIS = -I" + builder.env["METIS_DIR"] + "/include -I" + builder.env["PARMETIS_DIR"] + "/include \n")
+            f.write("LMETIS    = -L$(LPARMETISDIR) -lparmetis -L$(LMETISDIR) -lmetis\n")
+            f.write("ORDERINGSF  = -Dpord -Dmetis -Dparmetis\n")
+            f.write("ORDERINGSC  = $(ORDERINGSF)\n")
+            f.write("LORDERINGS = $(LMETIS) $(LPORD)\n")
+            f.write("IORDERINGSF = \n")
+            f.write("IORDERINGSC = $(IMETIS) $(IPORD)\n")
+            f.write("LIBEXT_SHARED  = .so\n")
+            f.write("SONAME = -soname\n")
+            f.write("SHARED_OPT = -shared\n")
+            f.write("FPIC_OPT = -fPIC\n")
+            f.write("LIBEXT  = .a\n")
+            f.write("OUTC    = -o\n")
+            f.write("OUTF    = -o\n")
+            f.write("RM      = rm -f\n")
+            f.write("# CC : C compiler\n")
+            f.write("CC      = " + builder.env["CC"] + "\n")
+            f.write("# FC : Fortran 90 compiler\n")
+            f.write("FC      = " + builder.env["FC"] + "\n")
+            f.write("FL      = " + builder.env["FC"] + "\n")
+            f.write("AR      = ar vr \n")
+            f.write("RANLIB  = ranlib \n")
+            f.write("LAPACK = " + builder.env["LAPACK_LIBRARIES"] + "\n")
+            f.write("SCALAP  = -L" + builder.env["SCALAPACK_DIR"] + "/lib -lscalapack " + builder.env["LAPACK_LIBRARIES"] + "\n")
+            f.write("BLAS = " + builder.env["BLAS_LIBRARIES"] + "\n")
+            f.write("LIBOTHERS = -lpthread\n")
+            f.write("CDEFS = -DAdd_\n")
+            f.write("FPIC_OPT = -fPIC\n")
+            f.write("OPTF    = -O3 -fallow-argument-mismatch\n")
+            f.write("OPTC    = -O3 -fPIC -I.\n")
+            f.write("OPTL    = -O3 -fallow-argument-mismatch\n")
+            f.write("INCPAR  = \n")
+            f.write("LIBPAR  = $(SCALAP) $(LAPACK) -lmpi\n")
+            f.write("INCS = $(INCPAR)\n")
+            f.write("LIBS = $(LIBPAR)\n")
+            f.write("LIBSEQNEEDED =\n")
+
+
+    def build(self, builder):
+        if builder.build_shared:
+            builder.run_command(["make", "allshared"], jobs_flag="-j", parallel=True)
+        else:
+            builder.run_command(["make", "all"], jobs_flag="-j", parallel=True)
+    
+    def install(self, builder):
+        if not os.path.exists(builder.install_dir()):
+            os.makedirs(builder.install_dir())
+        build_dir = os.path.join(builder._extract_dir,builder._extracted_folder)
+        shutil.copytree(os.path.join(build_dir, "include"), os.path.join(builder.install_dir(), "include"))
+        shutil.copytree(os.path.join(build_dir, "lib"), os.path.join(builder.install_dir(), "lib"))
+        
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("MUMPS_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/netcdf.py
+++ b/tpls/tpl_tools/packages/netcdf.py
@@ -2,11 +2,11 @@ from tpl_tools.packages import packages
 import os
 
 
-class Package(packages.AutotoolsPackage):
+class Package(packages.CMakePackage):
     def __init__(self):
         self.name = "netcdf"
-        self.version = "4.9.0"
-        self.sha256 = "4c956022b79c08e5e14eee8df51b13c28e6121c2b7e7faadc21b375949400b49"
+        self.version = "4.9.2"
+        self.sha256 = "cf11babbbdb9963f09f55079e0b019f6d0371f52f8e1264a5ba8e9fdab1a6c48"
         self.filename = "netcdf-c-" + self.version + ".tar.gz"
         self.url = (
             "https://downloads.unidata.ucar.edu/netcdf-c/"
@@ -30,20 +30,17 @@ class Package(packages.AutotoolsPackage):
         builder.env["CC"] = builder._registry.get_executable("mpicc")
         builder.env["CXX"] = builder._registry.get_executable("mpicxx")
         builder.env["FC"] = builder._registry.get_executable("mpifort")
-        builder.env["CFLAGS"] = "-I" + builder.env["HDF5_DIR"] + "/include"
-        builder.env["CFLAGS"] += " -I" + builder.env["PNETCDF_DIR"] + "/include"
-        builder.env["CPPFLAGS"] = "-I" + builder.env["HDF5_DIR"] + "/include"
-        builder.env["CPPFLAGS"] += " -I" + builder.env["PNETCDF_DIR"] + "/include"
-        builder.env["LDFLAGS"] = "-L" + builder.env["HDF5_DIR"] + "/lib"
-        builder.env["LDFLAGS"] += " -L" + builder.env["PNETCDF_DIR"] + "/lib"
 
     def configure_options(self, builder):
         if builder.build_shared:
-            builder.add_option("--enable-shared")
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
         else:
-            builder.add_option("--enable-shared=off")
-        builder.add_option("--enable-pnetcdf")
-        builder.add_option("--disable-dap")
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        builder.add_option("-DENABLE_DAP=OFF")
+        builder.add_option("-DENABLE_BYTERANGE:BOOL=OFF")
+        builder.add_option("-DENABLE_PNETCDF:BOOL=ON")
+        builder.add_option("-DENABLE_CDF5=ON")
+        builder.add_option("-DENABLE_MMAP:BOOL=ON")
 
     def register(self, builder):
         registry = builder._registry

--- a/tpls/tpl_tools/packages/netcdf.py
+++ b/tpls/tpl_tools/packages/netcdf.py
@@ -1,0 +1,52 @@
+from tpl_tools.packages import packages
+import os
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = 'netcdf'
+        self.version = "4.9.0"
+        self.sha256 = "4c956022b79c08e5e14eee8df51b13c28e6121c2b7e7faadc21b375949400b49"
+        self.filename = "netcdf-c-" + self.version + ".tar.gz"
+        self.url = (
+            "https://downloads.unidata.ucar.edu/netcdf-c/"
+            + self.version
+            + "/netcdf-c-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.executables = ["ncdump"]
+        self.libraries = ["netcdf"]
+        self.includes = ["netcdf.h"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency('packages.openmpi')
+        builder.set_dependency('packages.hdf5')
+        builder.set_dependency('packages.pnetcdf')
+        return
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+        builder.env["CFLAGS"] = "-I" + builder.env["HDF5_DIR"] + "/include"
+        builder.env["CFLAGS"] += " -I" + builder.env["PNETCDF_DIR"] + "/include"
+        builder.env["CPPFLAGS"] = "-I" + builder.env["HDF5_DIR"] + "/include"
+        builder.env["CPPFLAGS"] += " -I" + builder.env["PNETCDF_DIR"] + "/include"
+        builder.env["LDFLAGS"] ="-L" + builder.env["HDF5_DIR"] + "/lib" 
+        builder.env["LDFLAGS"] +=" -L" + builder.env["PNETCDF_DIR"] + "/lib" 
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("--enable-shared")
+        else:
+            builder.add_option("--enable-shared=off")
+        builder.add_option("--enable-pnetcdf")
+        builder.add_option("--disable-dap")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("NETCDF_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
+        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), "bin"))

--- a/tpls/tpl_tools/packages/netcdf.py
+++ b/tpls/tpl_tools/packages/netcdf.py
@@ -1,9 +1,10 @@
 from tpl_tools.packages import packages
 import os
 
+
 class Package(packages.AutotoolsPackage):
     def __init__(self):
-        self.name = 'netcdf'
+        self.name = "netcdf"
         self.version = "4.9.0"
         self.sha256 = "4c956022b79c08e5e14eee8df51b13c28e6121c2b7e7faadc21b375949400b49"
         self.filename = "netcdf-c-" + self.version + ".tar.gz"
@@ -19,9 +20,9 @@ class Package(packages.AutotoolsPackage):
         self.includes = ["netcdf.h"]
 
     def setDependencies(self, builder):
-        builder.set_dependency('packages.openmpi')
-        builder.set_dependency('packages.hdf5')
-        builder.set_dependency('packages.pnetcdf')
+        builder.set_dependency("packages.openmpi")
+        builder.set_dependency("packages.hdf5")
+        builder.set_dependency("packages.pnetcdf")
         return
 
     def set_environment(self, builder):
@@ -33,8 +34,8 @@ class Package(packages.AutotoolsPackage):
         builder.env["CFLAGS"] += " -I" + builder.env["PNETCDF_DIR"] + "/include"
         builder.env["CPPFLAGS"] = "-I" + builder.env["HDF5_DIR"] + "/include"
         builder.env["CPPFLAGS"] += " -I" + builder.env["PNETCDF_DIR"] + "/include"
-        builder.env["LDFLAGS"] ="-L" + builder.env["HDF5_DIR"] + "/lib" 
-        builder.env["LDFLAGS"] +=" -L" + builder.env["PNETCDF_DIR"] + "/lib" 
+        builder.env["LDFLAGS"] = "-L" + builder.env["HDF5_DIR"] + "/lib"
+        builder.env["LDFLAGS"] += " -L" + builder.env["PNETCDF_DIR"] + "/lib"
 
     def configure_options(self, builder):
         if builder.build_shared:
@@ -49,4 +50,6 @@ class Package(packages.AutotoolsPackage):
         registry.register_package(self.name, builder.install_dir())
         registry.set_environment_variable("NETCDF_DIR", builder.install_dir())
         registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
-        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), "bin"))
+        registry.append_environment_variable(
+            "PATH", os.path.join(builder.install_dir(), "bin")
+        )

--- a/tpls/tpl_tools/packages/omega_h.py
+++ b/tpls/tpl_tools/packages/omega_h.py
@@ -4,11 +4,11 @@ import os
 class Package(packages.CMakePackage):
     def __init__(self):
         self.name = 'omega-h'
-        self.version = "scorec-v10.8.4"
+        self.version = "9.34.13"
         self.sha256 = "a8c85314acdc30e4680d97191674d3ab6f15ee3a59cbfe169c3bf541aa9cf9d8"
         self.filename = "omega-h-" + self.version + ".tar.gz"
         self.url = (
-            "https://github.com/SCOREC/omega_h/archive/refs/tags/"
+            "https://github.com/sandialabs/omega_h/releases/tag/v"
             + self.version
             + ".tar.gz"
         )

--- a/tpls/tpl_tools/packages/omega_h.py
+++ b/tpls/tpl_tools/packages/omega_h.py
@@ -1,9 +1,10 @@
 from tpl_tools.packages import packages
 import os
 
+
 class Package(packages.CMakePackage):
     def __init__(self):
-        self.name = 'omega-h'
+        self.name = "omega-h"
         self.version = "9.34.13"
         self.sha256 = "a8c85314acdc30e4680d97191674d3ab6f15ee3a59cbfe169c3bf541aa9cf9d8"
         self.filename = "omega-h-" + self.version + ".tar.gz"
@@ -17,7 +18,7 @@ class Package(packages.CMakePackage):
         self.includes = ["Omega_h_adapt.hpp", "Omega_h_mesh.hpp"]
 
     def setDependencies(self, builder):
-        builder.set_dependency('packages.openmpi')
+        builder.set_dependency("packages.openmpi")
         return
 
     def set_environment(self, builder):

--- a/tpls/tpl_tools/packages/omega_h.py
+++ b/tpls/tpl_tools/packages/omega_h.py
@@ -1,0 +1,46 @@
+from tpl_tools.packages import packages
+import os
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = 'omega-h'
+        self.version = "scorec-v10.8.4"
+        self.sha256 = "a8c85314acdc30e4680d97191674d3ab6f15ee3a59cbfe169c3bf541aa9cf9d8"
+        self.filename = "omega-h-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/SCOREC/omega_h/archive/refs/tags/"
+            + self.version
+            + ".tar.gz"
+        )
+        self.executables = []
+        self.libraries = ["omega_h"]
+        self.includes = ["Omega_h_adapt.hpp", "Omega_h_mesh.hpp"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency('packages.openmpi')
+        return
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+
+        CC = builder.env["CC"]
+        CXX = builder.env["CXX"]
+        FC = builder.env["FC"]
+        builder.add_option("-DCMAKE_C_COMPILER=" + CC)
+        builder.add_option("-DCMAKE_CXX_COMPILER=" + CXX)
+        builder.add_option("-DCMAKE_Fortran_COMPILER=" + FC)
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("OMEGA_H_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/omega_h.py
+++ b/tpls/tpl_tools/packages/omega_h.py
@@ -6,10 +6,10 @@ class Package(packages.CMakePackage):
     def __init__(self):
         self.name = "omega-h"
         self.version = "9.34.13"
-        self.sha256 = "a8c85314acdc30e4680d97191674d3ab6f15ee3a59cbfe169c3bf541aa9cf9d8"
+        self.sha256 = "2eadfd6d634abc0b50396a82fd446f8f0b586ba6e64788c47827162c2aadec02"
         self.filename = "omega-h-" + self.version + ".tar.gz"
         self.url = (
-            "https://github.com/sandialabs/omega_h/releases/tag/v"
+            "https://github.com/sandialabs/omega_h/archive/refs/tags/v"
             + self.version
             + ".tar.gz"
         )

--- a/tpls/tpl_tools/packages/openblas.py
+++ b/tpls/tpl_tools/packages/openblas.py
@@ -5,8 +5,8 @@ import os
 class Package(packages.GenericPackage):
     def __init__(self):
         self.name = "openblas"
-        self.version = "0.3.27"
-        self.sha256 = "aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897"
+        self.version = "0.3.28"
+        self.sha256 = "f1003466ad074e9b0c8d421a204121100b0751c96fc6fcf3d1456bd12f8a00a1"
         self.filename = "OpenBLAS" + self.version + ".tar.gz"
         self.compression = "gz"
         self.url = (

--- a/tpls/tpl_tools/packages/openblas.py
+++ b/tpls/tpl_tools/packages/openblas.py
@@ -1,0 +1,45 @@
+from tpl_tools.packages import packages
+import os
+
+class Package(packages.GenericPackage):
+    def __init__(self):
+        self.name = "openblas"
+        self.version = "0.3.27"
+        self.sha256 = "aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897"
+        self.filename = "OpenBLAS" + self.version + ".tar.gz"
+        self.compression = 'gz'
+        self.url = (
+            "https://github.com/OpenMathLib/OpenBLAS/releases/download/v"
+            + self.version
+            + "/OpenBLAS-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.libraries = ['openblas']
+    
+    def build(self, builder):
+        self.build_command = ["make"]
+        self.build_command.append("USE_THREAD=0")
+        self.build_command.append("USE_OPENMP=0")
+        if builder.build_shared:
+            self.build_command.append("NO_SHARED=0")
+        else:
+            self.build_command.append("NO_SHARED=1")
+        builder.run_command(self.build_command, jobs_flag="-j", parallel=True)
+
+    def install(self, builder):
+        command = self.build_command.copy()
+        command.append("PREFIX=" + builder.install_dir())
+        command.append("install")
+        builder.run_command(command)
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        ext = ".a"
+        if builder.build_shared:
+            ext = ".so"
+        registry.set_environment_variable("OPENBLAS_DIR", builder.install_dir())
+        registry.set_environment_variable("BLAS_LIBRARIES", os.path.join(builder.install_dir(), "lib/libopenblas" + ext))
+        registry.set_environment_variable("LAPACK_LIBRARIES", os.path.join(builder.install_dir(), "lib/libopenblas" + ext))
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/openblas.py
+++ b/tpls/tpl_tools/packages/openblas.py
@@ -1,13 +1,14 @@
 from tpl_tools.packages import packages
 import os
 
+
 class Package(packages.GenericPackage):
     def __init__(self):
         self.name = "openblas"
         self.version = "0.3.27"
         self.sha256 = "aa2d68b1564fe2b13bc292672608e9cdeeeb6dc34995512e65c3b10f4599e897"
         self.filename = "OpenBLAS" + self.version + ".tar.gz"
-        self.compression = 'gz'
+        self.compression = "gz"
         self.url = (
             "https://github.com/OpenMathLib/OpenBLAS/releases/download/v"
             + self.version
@@ -15,8 +16,8 @@ class Package(packages.GenericPackage):
             + self.version
             + ".tar.gz"
         )
-        self.libraries = ['openblas']
-    
+        self.libraries = ["openblas"]
+
     def build(self, builder):
         self.build_command = ["make"]
         self.build_command.append("USE_THREAD=0")
@@ -40,6 +41,12 @@ class Package(packages.GenericPackage):
         if builder.build_shared:
             ext = ".so"
         registry.set_environment_variable("OPENBLAS_DIR", builder.install_dir())
-        registry.set_environment_variable("BLAS_LIBRARIES", os.path.join(builder.install_dir(), "lib/libopenblas" + ext))
-        registry.set_environment_variable("LAPACK_LIBRARIES", os.path.join(builder.install_dir(), "lib/libopenblas" + ext))
+        registry.set_environment_variable(
+            "BLAS_LIBRARIES",
+            os.path.join(builder.install_dir(), "lib/libopenblas" + ext),
+        )
+        registry.set_environment_variable(
+            "LAPACK_LIBRARIES",
+            os.path.join(builder.install_dir(), "lib/libopenblas" + ext),
+        )
         registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/openmpi.py
+++ b/tpls/tpl_tools/packages/openmpi.py
@@ -1,0 +1,31 @@
+from tpl_tools.packages import packages
+import os
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = 'openmpi'
+        self.version = "4.1.6"
+        self.sha256 = "f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"
+        self.filename = "openmpi-" + self.version + "tar.bz2"
+        self.url = (
+"https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-"
++ self.version + ".tar.bz2"
+        )
+        self.executables = ["mpicc", "mpifort", "mpicxx"]
+
+    def setDependencies(self, builder):
+        return
+    
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'mpicc'))
+        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'mpicxx'))
+        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'mpifort'))
+        registry.set_environment_variable("MPI_HOME", builder.install_dir())
+        registry.set_environment_variable("MPI_C_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpicc'))
+        registry.set_environment_variable("MPI_CXX_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpicxx'))
+        registry.set_environment_variable("MPI_FORTRAN_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpifort'))
+        registry.set_environment_variable("MPI_Fortran_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpifort'))
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
+        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), 'bin'))

--- a/tpls/tpl_tools/packages/openmpi.py
+++ b/tpls/tpl_tools/packages/openmpi.py
@@ -1,31 +1,51 @@
 from tpl_tools.packages import packages
 import os
 
+
 class Package(packages.AutotoolsPackage):
     def __init__(self):
-        self.name = 'openmpi'
+        self.name = "openmpi"
         self.version = "4.1.6"
         self.sha256 = "f740994485516deb63b5311af122c265179f5328a0d857a567b85db00b11e415"
         self.filename = "openmpi-" + self.version + "tar.bz2"
         self.url = (
-"https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-"
-+ self.version + ".tar.bz2"
+            "https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-"
+            + self.version
+            + ".tar.bz2"
         )
         self.executables = ["mpicc", "mpifort", "mpicxx"]
 
     def setDependencies(self, builder):
         return
-    
+
     def register(self, builder):
         registry = builder._registry
         registry.register_package(self.name, builder.install_dir())
-        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'mpicc'))
-        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'mpicxx'))
-        registry.register_executable(os.path.join(builder.install_dir(), 'bin', 'mpifort'))
+        registry.register_executable(
+            os.path.join(builder.install_dir(), "bin", "mpicc")
+        )
+        registry.register_executable(
+            os.path.join(builder.install_dir(), "bin", "mpicxx")
+        )
+        registry.register_executable(
+            os.path.join(builder.install_dir(), "bin", "mpifort")
+        )
         registry.set_environment_variable("MPI_HOME", builder.install_dir())
-        registry.set_environment_variable("MPI_C_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpicc'))
-        registry.set_environment_variable("MPI_CXX_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpicxx'))
-        registry.set_environment_variable("MPI_FORTRAN_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpifort'))
-        registry.set_environment_variable("MPI_Fortran_COMPILER", os.path.join(builder.install_dir(), 'bin', 'mpifort'))
+        registry.set_environment_variable(
+            "MPI_C_COMPILER", os.path.join(builder.install_dir(), "bin", "mpicc")
+        )
+        registry.set_environment_variable(
+            "MPI_CXX_COMPILER", os.path.join(builder.install_dir(), "bin", "mpicxx")
+        )
+        registry.set_environment_variable(
+            "MPI_FORTRAN_COMPILER",
+            os.path.join(builder.install_dir(), "bin", "mpifort"),
+        )
+        registry.set_environment_variable(
+            "MPI_Fortran_COMPILER",
+            os.path.join(builder.install_dir(), "bin", "mpifort"),
+        )
         registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
-        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), 'bin'))
+        registry.append_environment_variable(
+            "PATH", os.path.join(builder.install_dir(), "bin")
+        )

--- a/tpls/tpl_tools/packages/packages.py
+++ b/tpls/tpl_tools/packages/packages.py
@@ -1,0 +1,57 @@
+
+class GenericPackage(object):
+
+    def setDependencies(self, builder):
+        return
+
+    def configure_options(self, builder):
+        return
+
+    def configure(self, builder):
+        return
+    
+    def build(self, builder):
+        return
+    
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        return
+    
+    def install(self, builder):
+        return
+    
+    def register(self, builder):
+        raise NotImplementedError
+
+
+class AutotoolsPackage(GenericPackage):
+
+    def configure(self, builder):
+        configure_options = ["./configure"]
+        configure_options.extend(builder.get_options())
+        configure_options.append("--prefix=" + builder.install_dir())
+        builder.run_command(configure_options)
+    
+    def build(self, builder):
+        builder.run_command(["make"], jobs_flag="-j", parallel=True)
+    
+    def install(self, builder):
+        builder.run_command(["make", "install"])
+
+class CMakePackage(GenericPackage):
+
+    def configure(self, builder):
+        cmake = builder._registry.get_executable('cmake')
+        configure_options = [cmake, "-B", "build_tpl"]
+        configure_options.extend(builder.get_options())
+        configure_options.append("-DCMAKE_INSTALL_PREFIX=" + builder.install_dir())
+        configure_options.append("-DCMAKE_BUILD_TYPE=Release")
+        builder.run_command(configure_options)
+    
+    def build(self, builder):
+        cmake = builder._registry.get_executable('cmake')
+        builder.run_command([cmake, "--build", "build_tpl"], jobs_flag="-j", parallel=True)
+    
+    def install(self, builder):
+        cmake = builder._registry.get_executable('cmake')
+        builder.run_command([cmake, "--install", "build_tpl"])

--- a/tpls/tpl_tools/packages/packages.py
+++ b/tpls/tpl_tools/packages/packages.py
@@ -1,4 +1,3 @@
-
 class GenericPackage(object):
 
     def setDependencies(self, builder):
@@ -9,17 +8,17 @@ class GenericPackage(object):
 
     def configure(self, builder):
         return
-    
+
     def build(self, builder):
         return
-    
+
     def set_environment(self, builder):
         builder.env = builder._registry.get_environment().copy()
         return
-    
+
     def install(self, builder):
         return
-    
+
     def register(self, builder):
         raise NotImplementedError
 
@@ -31,27 +30,30 @@ class AutotoolsPackage(GenericPackage):
         configure_options.extend(builder.get_options())
         configure_options.append("--prefix=" + builder.install_dir())
         builder.run_command(configure_options)
-    
+
     def build(self, builder):
         builder.run_command(["make"], jobs_flag="-j", parallel=True)
-    
+
     def install(self, builder):
         builder.run_command(["make", "install"])
+
 
 class CMakePackage(GenericPackage):
 
     def configure(self, builder):
-        cmake = builder._registry.get_executable('cmake')
+        cmake = builder._registry.get_executable("cmake")
         configure_options = [cmake, "-B", "build_tpl"]
         configure_options.extend(builder.get_options())
         configure_options.append("-DCMAKE_INSTALL_PREFIX=" + builder.install_dir())
         configure_options.append("-DCMAKE_BUILD_TYPE=Release")
         builder.run_command(configure_options)
-    
+
     def build(self, builder):
-        cmake = builder._registry.get_executable('cmake')
-        builder.run_command([cmake, "--build", "build_tpl"], jobs_flag="-j", parallel=True)
-    
+        cmake = builder._registry.get_executable("cmake")
+        builder.run_command(
+            [cmake, "--build", "build_tpl"], jobs_flag="-j", parallel=True
+        )
+
     def install(self, builder):
-        cmake = builder._registry.get_executable('cmake')
+        cmake = builder._registry.get_executable("cmake")
         builder.run_command([cmake, "--install", "build_tpl"])

--- a/tpls/tpl_tools/packages/parmetis.py
+++ b/tpls/tpl_tools/packages/parmetis.py
@@ -4,8 +4,8 @@ from tpl_tools.packages import packages
 class Package(packages.CMakePackage):
     def __init__(self):
         self.name = "parmetis"
-        self.version = "4.0.3-p8"
-        self.sha256 = "3f45bbf43c3a8447eb6a2eedfb713279c9dda50a3498b45914e5d5e584d31df9"
+        self.version = "4.0.3-p9"
+        self.sha256 = "612717e85992c984f09b0f5670be421bbb90a4c04145ab5b9a3358b92765d891"
         self.filename = "petsc-pkg-parmetis-" + self.version + ".tar.gz"
         self.url = (
             "https://bitbucket.org/petsc/pkg-parmetis/get/v" + self.version + ".tar.gz"

--- a/tpls/tpl_tools/packages/parmetis.py
+++ b/tpls/tpl_tools/packages/parmetis.py
@@ -3,14 +3,12 @@ from tpl_tools.packages import packages
 
 class Package(packages.CMakePackage):
     def __init__(self):
-        self.name = 'parmetis'
+        self.name = "parmetis"
         self.version = "4.0.3-p8"
         self.sha256 = "3f45bbf43c3a8447eb6a2eedfb713279c9dda50a3498b45914e5d5e584d31df9"
         self.filename = "petsc-pkg-parmetis-" + self.version + ".tar.gz"
         self.url = (
-            "https://bitbucket.org/petsc/pkg-parmetis/get/v"
-            + self.version +
-            ".tar.gz"
+            "https://bitbucket.org/petsc/pkg-parmetis/get/v" + self.version + ".tar.gz"
         )
         self.libraries = ["parmetis"]
         self.includes = ["parmetis.h"]
@@ -21,7 +19,6 @@ class Package(packages.CMakePackage):
         builder.env["CXX"] = builder._registry.get_executable("mpicxx")
         builder.env["FC"] = builder._registry.get_executable("mpifort")
 
-
     def configure_options(self, builder):
         if builder.build_shared:
             builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
@@ -30,7 +27,9 @@ class Package(packages.CMakePackage):
             builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
             builder.add_option("-D=SHARED:BOOL=OFF")
         builder.add_option("-D=GKLIB_PATH=./headers")
-        builder.add_option("-D=METIS_PATH=" + builder._registry.environment["METIS_DIR"])
+        builder.add_option(
+            "-D=METIS_PATH=" + builder._registry.environment["METIS_DIR"]
+        )
 
     def register(self, builder):
         registry = builder._registry

--- a/tpls/tpl_tools/packages/parmetis.py
+++ b/tpls/tpl_tools/packages/parmetis.py
@@ -1,0 +1,39 @@
+from tpl_tools.packages import packages
+
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = 'parmetis'
+        self.version = "4.0.3-p8"
+        self.sha256 = "3f45bbf43c3a8447eb6a2eedfb713279c9dda50a3498b45914e5d5e584d31df9"
+        self.filename = "petsc-pkg-parmetis-" + self.version + ".tar.gz"
+        self.url = (
+            "https://bitbucket.org/petsc/pkg-parmetis/get/v"
+            + self.version +
+            ".tar.gz"
+        )
+        self.libraries = ["parmetis"]
+        self.includes = ["parmetis.h"]
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+            builder.add_option("-D=SHARED:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+            builder.add_option("-D=SHARED:BOOL=OFF")
+        builder.add_option("-D=GKLIB_PATH=./headers")
+        builder.add_option("-D=METIS_PATH=" + builder._registry.environment["METIS_DIR"])
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("PARMETIS_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/petsc.py
+++ b/tpls/tpl_tools/packages/petsc.py
@@ -52,7 +52,9 @@ class Package(packages.AutotoolsPackage):
                 "--with-superlu_dist-dir=" + builder.env["SUPERLU_DIST_DIR"]
             )
             configure_options.append("--with-parmetis=1")
-            configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
+            configure_options.append(
+                "--with-parmetis-dir=" + builder.env["PARMETIS_DIR"]
+            )
         configure_options.append("--with-metis=1")
         configure_options.append("--with-metis-dir=" + builder.env["METIS_DIR"])
         configure_options.append("--with-ptscotch=1")

--- a/tpls/tpl_tools/packages/petsc.py
+++ b/tpls/tpl_tools/packages/petsc.py
@@ -18,6 +18,7 @@ class Package(packages.AutotoolsPackage):
 
     def set_environment(self, builder):
         builder.env = builder._registry.get_environment().copy()
+        builder.env["PETSC_ARCH"] = "arch-c-opt"
         builder.env["PETSC_DIR"] = os.path.join(
             builder._extract_dir, builder._extracted_folder
         )
@@ -45,14 +46,17 @@ class Package(packages.AutotoolsPackage):
         configure_options.append("--download-strumpack")
         configure_options.append("--with-scalapack=1")
         configure_options.append("--with-scalapack-dir=" + builder.env["SCALAPACK_DIR"])
-        configure_options.append("--with-superlu_dist=1")
-        configure_options.append(
-            "--with-superlu_dist-dir=" + builder.env["SUPERLU_DIST_DIR"]
-        )
+        if "PARMETIS_DIR" in builder.env:
+            configure_options.append("--with-superlu_dist=1")
+            configure_options.append(
+                "--with-superlu_dist-dir=" + builder.env["SUPERLU_DIST_DIR"]
+            )
+            configure_options.append("--with-parmetis=1")
+            configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
         configure_options.append("--with-metis=1")
         configure_options.append("--with-metis-dir=" + builder.env["METIS_DIR"])
-        configure_options.append("--with-parmetis=1")
-        configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
+        configure_options.append("--with-ptscotch=1")
+        configure_options.append("--with-ptscotch-dir=" + builder.env["SCOTCH_DIR"])
         configure_options.append("--with-blas-lib=" + builder.env["BLAS_LIBRARIES"])
         configure_options.append("--with-lapack-lib=" + builder.env["LAPACK_LIBRARIES"])
         configure_options.append("--with-mumps=1")

--- a/tpls/tpl_tools/packages/petsc.py
+++ b/tpls/tpl_tools/packages/petsc.py
@@ -15,6 +15,10 @@ class Package(packages.AutotoolsPackage):
         )
         self.includes = ["petsc"]
         self.libraries = ["petsc", "HYPRE", "strumpack"]
+    
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["PETSC_DIR"] = os.path.join(builder._extract_dir, builder._extracted_folder)
 
     def configure(self, builder):
         configure_options = ["./configure"]
@@ -37,9 +41,6 @@ class Package(packages.AutotoolsPackage):
         configure_options.append("--with-debugging=0")
         configure_options.append("--download-hypre")
         configure_options.append("--download-strumpack")
-        configure_options.append("COPTFLAGS=-O3")
-        configure_options.append("CXXOPTFLAGS=-O3")
-        configure_options.append("FOPTFLAGS=-O3")
         configure_options.append("--with-scalapack=1")
         configure_options.append("--with-scalapack-dir=" + builder.env["SCALAPACK_DIR"])
         configure_options.append("--with-superlu_dist=1")
@@ -54,6 +55,9 @@ class Package(packages.AutotoolsPackage):
         configure_options.append("--with-lapack-lib=" + builder.env["LAPACK_LIBRARIES"])
         configure_options.append("--with-mumps=1")
         configure_options.append("--with-mumps-dir=" + builder.env["MUMPS_DIR"])
+        configure_options.append("COPTFLAGS=-O3")
+        configure_options.append("CXXOPTFLAGS=-O3")
+        configure_options.append("FOPTFLAGS=-O3")
         builder.run_command(configure_options)
 
     def register(self, builder):

--- a/tpls/tpl_tools/packages/petsc.py
+++ b/tpls/tpl_tools/packages/petsc.py
@@ -1,0 +1,62 @@
+from tpl_tools.packages import packages
+import os
+
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = "petsc"
+        self.version = "3.21.4"
+        self.sha256 = "a9ae076d4617c7d84ce2bed37194022319c19f19b3930edf148b2bc8ecf2248d"
+        self.filename = "petsc-" + self.version + ".tar.gz"
+        self.url = (
+            "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.includes = ["petsc"]
+        self.libraries = ["petsc", "HYPRE", "strumpack"]
+
+    def configure(self, builder):
+        configure_options = ["./configure"]
+        configure_options.extend(builder.get_options())
+        configure_options.append("--prefix=" + builder.install_dir())
+        configure_options.append("--with-mpi")
+        configure_options.append(
+            "--with-cc=" + builder._registry.get_executable("mpicc")
+        )
+        configure_options.append(
+            "--with-fc=" + builder._registry.get_executable("mpifort")
+        )
+        configure_options.append(
+            "--with-cxx=" + builder._registry.get_executable("mpicxx")
+        )
+        if builder.build_shared:
+            configure_options.append("--with-shared-libraries=1")
+        else:
+            configure_options.append("--with-shared-libraries=0")
+        configure_options.append("--with-debugging=0")
+        configure_options.append("--download-hypre")
+        configure_options.append("--download-strumpack")
+        configure_options.append("COPTFLAGS=-O3")
+        configure_options.append("CXXOPTFLAGS=-O3")
+        configure_options.append("FOPTFLAGS=-O3")
+        configure_options.append("--with-scalapack=1")
+        configure_options.append("--with-scalapack-dir=" + builder.env["SCALAPACK_DIR"])
+        configure_options.append("--with-superlu_dist=1")
+        configure_options.append(
+            "--with-superlu_dist-dir=" + builder.env["SUPERLU_DIST_DIR"]
+        )
+        configure_options.append("--with-metis=1")
+        configure_options.append("--with-metis-dir=" + builder.env["METIS_DIR"])
+        configure_options.append("--with-parmetis=1")
+        configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
+        configure_options.append("--with-blas-lib=" + builder.env["BLAS_LIBRARIES"])
+        configure_options.append("--with-lapack-lib=" + builder.env["LAPACK_LIBRARIES"])
+        configure_options.append("--with-mumps=1")
+        configure_options.append("--with-mumps-dir=" + builder.env["MUMPS_DIR"])
+        builder.run_command(configure_options)
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("PETSC_DIR", builder.install_dir())

--- a/tpls/tpl_tools/packages/petsc.py
+++ b/tpls/tpl_tools/packages/petsc.py
@@ -15,10 +15,12 @@ class Package(packages.AutotoolsPackage):
         )
         self.includes = ["petsc"]
         self.libraries = ["petsc", "HYPRE", "strumpack"]
-    
+
     def set_environment(self, builder):
         builder.env = builder._registry.get_environment().copy()
-        builder.env["PETSC_DIR"] = os.path.join(builder._extract_dir, builder._extracted_folder)
+        builder.env["PETSC_DIR"] = os.path.join(
+            builder._extract_dir, builder._extracted_folder
+        )
 
     def configure(self, builder):
         configure_options = ["./configure"]

--- a/tpls/tpl_tools/packages/petsc_complex.py
+++ b/tpls/tpl_tools/packages/petsc_complex.py
@@ -18,7 +18,9 @@ class Package(packages.AutotoolsPackage):
 
     def set_environment(self, builder):
         builder.env = builder._registry.get_environment().copy()
-        builder.env["PETSC_DIR"] = os.path.join(builder._extract_dir, builder._extracted_folder)
+        builder.env["PETSC_DIR"] = os.path.join(
+            builder._extract_dir, builder._extracted_folder
+        )
 
     def petsc_options(self, builder):
         configure_options = ["./configure"]

--- a/tpls/tpl_tools/packages/petsc_complex.py
+++ b/tpls/tpl_tools/packages/petsc_complex.py
@@ -1,0 +1,67 @@
+from tpl_tools.packages import packages
+import os
+
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = "petsc-complex"
+        self.version = "3.21.4"
+        self.sha256 = "a9ae076d4617c7d84ce2bed37194022319c19f19b3930edf148b2bc8ecf2248d"
+        self.filename = "petsc-" + self.version + ".tar.gz"
+        self.url = (
+            "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.includes = ["petsc"]
+        self.libraries = ["petsc", "HYPRE"]
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["PETSC_DIR"] = os.path.join(builder._extract_dir, builder._extracted_folder)
+
+    def petsc_options(self, builder):
+        configure_options = ["./configure"]
+        configure_options.extend(builder.get_options())
+        configure_options.append("--prefix=" + builder.install_dir())
+        configure_options.append("--with-mpi")
+        configure_options.append(
+            "--with-cc=" + builder._registry.get_executable("mpicc")
+        )
+        configure_options.append(
+            "--with-fc=" + builder._registry.get_executable("mpifort")
+        )
+        configure_options.append(
+            "--with-cxx=" + builder._registry.get_executable("mpicxx")
+        )
+        if builder.build_shared:
+            configure_options.append("--with-shared-libraries=1")
+        else:
+            configure_options.append("--with-shared-libraries=0")
+        configure_options.append("--with-debugging=0")
+        configure_options.append("--download-hypre")
+        configure_options.append("--with-scalapack=1")
+        configure_options.append("--with-scalapack-dir=" + builder.env["SCALAPACK_DIR"])
+        configure_options.append("--with-metis=1")
+        configure_options.append("--with-metis-dir=" + builder.env["METIS_DIR"])
+        configure_options.append("--with-parmetis=1")
+        configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
+        configure_options.append("--with-blas-lib=" + builder.env["BLAS_LIBRARIES"])
+        configure_options.append("--with-lapack-lib=" + builder.env["LAPACK_LIBRARIES"])
+        configure_options.append("--with-mumps=1")
+        configure_options.append("--with-mumps-dir=" + builder.env["MUMPS_DIR"])
+        configure_options.append("--with-scalar-type=complex")
+        configure_options.append("COPTFLAGS=-O3")
+        configure_options.append("CXXOPTFLAGS=-O3")
+        configure_options.append("FOPTFLAGS=-O3")
+        configure_options.append("PETSC_ARCH=arch-c-complex")
+        return configure_options
+
+    def configure(self, builder):
+        configure_options = self.petsc_options(builder)
+        builder.run_command(configure_options)
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("PETSC_COMPLEX_DIR", builder.install_dir())

--- a/tpls/tpl_tools/packages/petsc_complex.py
+++ b/tpls/tpl_tools/packages/petsc_complex.py
@@ -18,6 +18,7 @@ class Package(packages.AutotoolsPackage):
 
     def set_environment(self, builder):
         builder.env = builder._registry.get_environment().copy()
+        builder.env["PETSC_ARCH"] = "arch-c-complex"
         builder.env["PETSC_DIR"] = os.path.join(
             builder._extract_dir, builder._extracted_folder
         )
@@ -46,8 +47,11 @@ class Package(packages.AutotoolsPackage):
         configure_options.append("--with-scalapack-dir=" + builder.env["SCALAPACK_DIR"])
         configure_options.append("--with-metis=1")
         configure_options.append("--with-metis-dir=" + builder.env["METIS_DIR"])
-        configure_options.append("--with-parmetis=1")
-        configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
+        if "PARMETIS_DIR" in builder.env:
+            configure_options.append("--with-parmetis=1")
+            configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
+        configure_options.append("--with-ptscotch=1")
+        configure_options.append("--with-ptscotch-dir=" + builder.env["SCOTCH_DIR"])
         configure_options.append("--with-blas-lib=" + builder.env["BLAS_LIBRARIES"])
         configure_options.append("--with-lapack-lib=" + builder.env["LAPACK_LIBRARIES"])
         configure_options.append("--with-mumps=1")

--- a/tpls/tpl_tools/packages/petsc_complex.py
+++ b/tpls/tpl_tools/packages/petsc_complex.py
@@ -49,7 +49,9 @@ class Package(packages.AutotoolsPackage):
         configure_options.append("--with-metis-dir=" + builder.env["METIS_DIR"])
         if "PARMETIS_DIR" in builder.env:
             configure_options.append("--with-parmetis=1")
-            configure_options.append("--with-parmetis-dir=" + builder.env["PARMETIS_DIR"])
+            configure_options.append(
+                "--with-parmetis-dir=" + builder.env["PARMETIS_DIR"]
+            )
         configure_options.append("--with-ptscotch=1")
         configure_options.append("--with-ptscotch-dir=" + builder.env["SCOTCH_DIR"])
         configure_options.append("--with-blas-lib=" + builder.env["BLAS_LIBRARIES"])

--- a/tpls/tpl_tools/packages/pnetcdf.py
+++ b/tpls/tpl_tools/packages/pnetcdf.py
@@ -1,8 +1,9 @@
 from tpl_tools.packages import packages
 
+
 class Package(packages.AutotoolsPackage):
     def __init__(self):
-        self.name = 'pnetcdf'
+        self.name = "pnetcdf"
         self.version = "1.13.0"
         self.sha256 = "aba0f1c77a51990ba359d0f6388569ff77e530ee574e40592a1e206ed9b2c491"
         self.filename = "pnetcdf-" + self.version + ".tar.gz"
@@ -14,7 +15,7 @@ class Package(packages.AutotoolsPackage):
         self.libraries = ["pnetcdf"]
 
     def setDependencies(self, builder):
-        builder.set_dependency('packages.openmpi')
+        builder.set_dependency("packages.openmpi")
         return
 
     def set_environment(self, builder):

--- a/tpls/tpl_tools/packages/pnetcdf.py
+++ b/tpls/tpl_tools/packages/pnetcdf.py
@@ -1,0 +1,34 @@
+from tpl_tools.packages import packages
+
+class Package(packages.AutotoolsPackage):
+    def __init__(self):
+        self.name = 'pnetcdf'
+        self.version = "1.13.0"
+        self.sha256 = "aba0f1c77a51990ba359d0f6388569ff77e530ee574e40592a1e206ed9b2c491"
+        self.filename = "pnetcdf-" + self.version + ".tar.gz"
+        self.url = (
+            "https://parallel-netcdf.github.io/Release/pnetcdf-"
+            + self.version
+            + ".tar.gz"
+        )
+        self.libraries = ["pnetcdf"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency('packages.openmpi')
+        return
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("--enable-shared")
+        builder.add_option("--disable-fortran")
+        builder.add_option("--disable-cxx")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("PNETCDF_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/scalapack.py
+++ b/tpls/tpl_tools/packages/scalapack.py
@@ -25,7 +25,7 @@ class Package(packages.CMakePackage):
             builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
         else:
             builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
-        builder.add_option("-D=MPI=ON")
+        builder.add_option("-D=SCALAPACK_BUILD_TESTS=OFF")
 
     def register(self, builder):
         registry = builder._registry

--- a/tpls/tpl_tools/packages/scalapack.py
+++ b/tpls/tpl_tools/packages/scalapack.py
@@ -1,0 +1,33 @@
+from tpl_tools.packages import packages
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = "scalapack"
+        self.version = "0234af94c6578c53ac4c19f2925eb6e5c4ad6f0f"
+        self.sha256 = "6252706d4ed2e69aa9531730541eb0bec2b7332e9a08d39024aa2ec96b224a42"
+        self.filename = "scalapack-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/Reference-ScaLAPACK/scalapack/archive/"
+            + self.version +
+            ".tar.gz"
+        )
+        self.libraries = ["scalapack"]
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        builder.add_option("-D=MPI=ON")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("SCALAPACK_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/scalapack.py
+++ b/tpls/tpl_tools/packages/scalapack.py
@@ -1,5 +1,6 @@
 from tpl_tools.packages import packages
 
+
 class Package(packages.CMakePackage):
     def __init__(self):
         self.name = "scalapack"
@@ -8,8 +9,8 @@ class Package(packages.CMakePackage):
         self.filename = "scalapack-" + self.version + ".tar.gz"
         self.url = (
             "https://github.com/Reference-ScaLAPACK/scalapack/archive/"
-            + self.version +
-            ".tar.gz"
+            + self.version
+            + ".tar.gz"
         )
         self.libraries = ["scalapack"]
 

--- a/tpls/tpl_tools/packages/scotch.py
+++ b/tpls/tpl_tools/packages/scotch.py
@@ -1,0 +1,62 @@
+from tpl_tools.packages import packages
+from tpl_tools import utils
+import os
+
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = "scotch"
+        self.version = "7.0.4"
+        self.sha256 = "8ef4719d6a3356e9c4ca7fefd7e2ac40deb69779a5c116f44da75d13b3d2c2c3"
+        self.filename = "scotch-" + self.version + ".tar.gz"
+        self.url = (
+            "https://gitlab.inria.fr/scotch/scotch/-/archive/v"
+            +self.version +"/scotch-v"
+            + self.version
+            + ".tar.gz"
+        )
+        self.executables = []
+        self.libraries = ["scotch", "ptscotch"]
+        self.includes = []
+
+    def setDependencies(self, builder):
+        builder.set_dependency("packages.openmpi")
+        builder.set_dependency("packages.hdf5")
+        builder.set_dependency("packages.pnetcdf")
+        builder.set_dependency("packages.netcdf")
+        builder.set_dependency("packages.fmt")
+        return
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+
+        CC = builder.env["CC"]
+        CXX = builder.env["CXX"]
+        FC = builder.env["FC"]
+        builder.add_option("-DCMAKE_C_COMPILER=" + CC)
+        builder.add_option("-DCMAKE_CXX_COMPILER=" + CXX)
+        builder.add_option("-DCMAKE_Fortran_COMPILER=" + FC)
+    
+    def install(self, builder):
+        cmake = builder._registry.get_executable("cmake")
+        builder.run_command([cmake, "--install", "build_tpl"])
+        mi = os.path.join(builder.install_dir(), "include/metis.h")
+        pi = os.path.join(builder.install_dir(), "include/parmetis.h")
+        for f in [mi,pi]:
+            if os.path.exists(f):
+                os.unlink(f)
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("SCOTCH_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/scotch.py
+++ b/tpls/tpl_tools/packages/scotch.py
@@ -11,7 +11,8 @@ class Package(packages.CMakePackage):
         self.filename = "scotch-" + self.version + ".tar.gz"
         self.url = (
             "https://gitlab.inria.fr/scotch/scotch/-/archive/v"
-            +self.version +"/scotch-v"
+            + self.version
+            + "/scotch-v"
             + self.version
             + ".tar.gz"
         )
@@ -45,13 +46,13 @@ class Package(packages.CMakePackage):
         builder.add_option("-DCMAKE_C_COMPILER=" + CC)
         builder.add_option("-DCMAKE_CXX_COMPILER=" + CXX)
         builder.add_option("-DCMAKE_Fortran_COMPILER=" + FC)
-    
+
     def install(self, builder):
         cmake = builder._registry.get_executable("cmake")
         builder.run_command([cmake, "--install", "build_tpl"])
         mi = os.path.join(builder.install_dir(), "include/metis.h")
         pi = os.path.join(builder.install_dir(), "include/parmetis.h")
-        for f in [mi,pi]:
+        for f in [mi, pi]:
             if os.path.exists(f):
                 os.unlink(f)
 

--- a/tpls/tpl_tools/packages/seacas.py
+++ b/tpls/tpl_tools/packages/seacas.py
@@ -1,5 +1,7 @@
 from tpl_tools.packages import packages
+from tpl_tools import utils
 import os
+
 
 class Package(packages.CMakePackage):
     def __init__(self):
@@ -37,7 +39,10 @@ class Package(packages.CMakePackage):
             builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
         builder.add_option("-D=TPL_ENABLE_Netcdf:BOOL=ON")
         builder.add_option("-D=TPL_ENABLE_MPI:BOOL=ON")
-        builder.add_option("-D=TPL_ENABLE_X11:BOOL=ON")
+        if utils.check_for_x11(builder._extract_dir, builder.env["CC"]):
+            builder.add_option("-D=TPL_ENABLE_X11:BOOL=ON")
+        else:
+            builder.add_option("-D=TPL_ENABLE_X11:BOOL=OFF")
 
         CC = builder.env["CC"]
         CXX = builder.env["CXX"]

--- a/tpls/tpl_tools/packages/seacas.py
+++ b/tpls/tpl_tools/packages/seacas.py
@@ -1,0 +1,66 @@
+from tpl_tools.packages import packages
+import os
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = 'seacas'
+        self.version = "2024-07-10"
+        self.sha256 = "b2ba6ca80359fed8ed2a8a210052582c7a3b7b837253bd1e9be941047dcab3ff"
+        self.filename = "seacas-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/sandialabs/seacas/archive/refs/tags/v"
+            + self.version
+            + ".tar.gz"
+        )
+        self.executables = ["algebra","aprepro", "mapvar", "explore", "blot"]
+        self.libraries = ["exodus", "aprepro_lib"]
+        self.includes = ["exodusII.h", "aprepro.h"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency('packages.openmpi')
+        builder.set_dependency('packages.hdf5')
+        builder.set_dependency('packages.pnetcdf')
+        builder.set_dependency('packages.netcdf')
+        builder.set_dependency('packages.fmt')
+        return
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        builder.add_option("-D=TPL_ENABLE_Netcdf:BOOL=ON")
+        builder.add_option("-D=TPL_ENABLE_MPI:BOOL=ON")
+        builder.add_option("-D=TPL_ENABLE_X11:BOOL=ON")
+
+        CC = builder.env["CC"]
+        CXX = builder.env["CXX"]
+        FC = builder.env["FC"]
+        builder.add_option("-DCMAKE_C_COMPILER=" + CC)
+        builder.add_option("-DCMAKE_CXX_COMPILER=" + CXX)
+        builder.add_option("-DCMAKE_Fortran_COMPILER=" + FC)
+        builder.add_option("-DPNetCDF_ROOT:PATH=" + builder.env["PNETCDF_DIR"])
+        builder.add_option("-DNetCDF_ROOT:PATH=" + builder.env["NETCDF_DIR"])
+        builder.add_option("-DnetCDF_ROOT:PATH=" + builder.env["NETCDF_DIR"])
+        builder.add_option("-DHDF5_ROOT:PATH=" + builder.env["HDF5_DIR"])
+        builder.add_option("-DHDF5_DIR:PATH=" + builder.env["HDF5_DIR"])
+        builder.add_option("-DTPL_ENABLE_Matio=OFF")
+        builder.add_option("-DSeacas_ENABLE_ALL_PACKAGES:BOOL=ON")
+        builder.add_option("-DSeacas_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON") 
+        builder.add_option("-DSeacas_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("ACCESS", builder.install_dir())
+        registry.set_environment_variable("SEACAS_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
+        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), 'bin'))
+        if builder.build_shared:
+            registry.append_environment_variable("PYTHONPATH", os.path.join(builder.install_dir(), 'lib'))

--- a/tpls/tpl_tools/packages/seacas.py
+++ b/tpls/tpl_tools/packages/seacas.py
@@ -14,7 +14,7 @@ class Package(packages.CMakePackage):
             + self.version
             + ".tar.gz"
         )
-        self.executables = ["algebra","aprepro", "mapvar", "explore", "blot"]
+        self.executables = ["algebra","aprepro", "mapvar", "explore"]
         self.libraries = ["exodus", "aprepro_lib"]
         self.includes = ["exodusII.h", "aprepro.h"]
 

--- a/tpls/tpl_tools/packages/seacas.py
+++ b/tpls/tpl_tools/packages/seacas.py
@@ -5,7 +5,7 @@ import os
 
 class Package(packages.CMakePackage):
     def __init__(self):
-        self.name = 'seacas'
+        self.name = "seacas"
         self.version = "2024-07-10"
         self.sha256 = "b2ba6ca80359fed8ed2a8a210052582c7a3b7b837253bd1e9be941047dcab3ff"
         self.filename = "seacas-" + self.version + ".tar.gz"
@@ -14,16 +14,16 @@ class Package(packages.CMakePackage):
             + self.version
             + ".tar.gz"
         )
-        self.executables = ["algebra","aprepro", "mapvar", "explore"]
+        self.executables = ["algebra", "aprepro", "mapvar", "explore"]
         self.libraries = ["exodus", "aprepro_lib"]
         self.includes = ["exodusII.h", "aprepro.h"]
 
     def setDependencies(self, builder):
-        builder.set_dependency('packages.openmpi')
-        builder.set_dependency('packages.hdf5')
-        builder.set_dependency('packages.pnetcdf')
-        builder.set_dependency('packages.netcdf')
-        builder.set_dependency('packages.fmt')
+        builder.set_dependency("packages.openmpi")
+        builder.set_dependency("packages.hdf5")
+        builder.set_dependency("packages.pnetcdf")
+        builder.set_dependency("packages.netcdf")
+        builder.set_dependency("packages.fmt")
         return
 
     def set_environment(self, builder):
@@ -57,7 +57,7 @@ class Package(packages.CMakePackage):
         builder.add_option("-DHDF5_DIR:PATH=" + builder.env["HDF5_DIR"])
         builder.add_option("-DTPL_ENABLE_Matio=OFF")
         builder.add_option("-DSeacas_ENABLE_ALL_PACKAGES:BOOL=ON")
-        builder.add_option("-DSeacas_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON") 
+        builder.add_option("-DSeacas_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON")
         builder.add_option("-DSeacas_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON")
 
     def register(self, builder):
@@ -66,6 +66,10 @@ class Package(packages.CMakePackage):
         registry.set_environment_variable("ACCESS", builder.install_dir())
         registry.set_environment_variable("SEACAS_DIR", builder.install_dir())
         registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())
-        registry.append_environment_variable("PATH", os.path.join(builder.install_dir(), 'bin'))
+        registry.append_environment_variable(
+            "PATH", os.path.join(builder.install_dir(), "bin")
+        )
         if builder.build_shared:
-            registry.append_environment_variable("PYTHONPATH", os.path.join(builder.install_dir(), 'lib'))
+            registry.append_environment_variable(
+                "PYTHONPATH", os.path.join(builder.install_dir(), "lib")
+            )

--- a/tpls/tpl_tools/packages/sparse.py
+++ b/tpls/tpl_tools/packages/sparse.py
@@ -1,6 +1,8 @@
 from tpl_tools.packages import packages
+from tpl_tools.builder import mkdir_p
 import os
 import shutil
+import glob
 
 
 class Package(packages.GenericPackage):
@@ -36,13 +38,11 @@ class Package(packages.GenericPackage):
             f.write("\n")
             f.write("HFILES = spConfig.h spDefs.h spMatrix.h\n")
             f.write(
-                "CFILES = spAllocate.c spBuild.c spFactor.c spOutput.c spSolve.c spUtils.c \\n"
+                "CFILES = spAllocate.c spBuild.c spFactor.c spOutput.c spSolve.c spUtils.c spFortran.c\n"
             )
-            f.write("         spFortran.c\n")
             f.write(
-                "OFILES = spAllocate.o spBuild.o spFactor.o spOutput.o spSolve.o spUtils.o \\n"
+                "OFILES = spAllocate.o spBuild.o spFactor.o spOutput.o spSolve.o spUtils.o spFortran.o\n"
             )
-            f.write("         spFortran.o\n")
             if builder.build_shared:
                 f.write("LIBRARY = ../lib/libsparse.so\n")
             else:
@@ -54,30 +54,29 @@ class Package(packages.GenericPackage):
             f.write("SOURCE = $(HFILES) $(CFILES)\n")
             f.write("\n")
             f.write("$(DESTINATION)  : $(LIBRARY) $(TESTO)\n")
-            f.write(
-                "        $(CC) $(CFLAGS) -o $(DESTINATION) $(TESTO) $(LIBRARY) -lm\n"
-            )
+            f.write("\t$(CC) $(CFLAGS) -o $(DESTINATION) $(TESTO) $(LIBRARY) -lm\n")
             f.write("\n")
             if builder.build_shared:
                 f.write("$(LIBRARY)      : $(OFILES)\n")
-                f.write("        $(CC) -shared $(LIBRARY) $?\n")
+                f.write("\t$(CC) -shared -o $(LIBRARY) $?\n")
             else:
                 f.write("$(LIBRARY)      : $(OFILES)\n")
-                f.write("        ar r   $(LIBRARY) $?\n")
-                f.write("        ranlib $(LIBRARY)\n")
+                f.write("\tar r   $(LIBRARY) $?\n")
+                f.write("\tranlib $(LIBRARY)\n")
             f.write("\n")
 
     def build(self, builder):
-        builder.run_command(["make"])
+        builder.run_command(["make", "-C", "src"])
 
     def install(self, builder):
         if not os.path.exists(builder.install_dir()):
             os.makedirs(builder.install_dir())
         build_dir = os.path.join(builder._extract_dir, builder._extracted_folder)
-        shutil.copytree(
-            os.path.join(build_dir, "include"),
-            os.path.join(builder.install_dir(), "include"),
-        )
+        include_dir = os.path.join(builder.install_dir(), "include")
+        mkdir_p(include_dir)
+        for file in glob.glob(build_dir + "/src/*.h"):
+            shutil.copy(file, include_dir)
+
         shutil.copytree(
             os.path.join(build_dir, "lib"), os.path.join(builder.install_dir(), "lib")
         )

--- a/tpls/tpl_tools/packages/sparse.py
+++ b/tpls/tpl_tools/packages/sparse.py
@@ -2,24 +2,30 @@ from tpl_tools.packages import packages
 import os
 import shutil
 
+
 class Package(packages.GenericPackage):
     def __init__(self):
         self.name = "sparse"
         self.version = "1.4b"
-        self.sha256="63e6646244fd8f4d89f7f70fbf4cfd46b7688d21b22840a0ce57d294a7496d28"
+        self.sha256 = "63e6646244fd8f4d89f7f70fbf4cfd46b7688d21b22840a0ce57d294a7496d28"
         self.filename = "sparse-" + self.version + ".tar.gz"
         self.url = (
             "http://downloads.sourceforge.net/project/sparse/sparse/sparse"
-            + self.version +
-            "/sparse" 
-            + self.version +
-            ".tar.gz"
+            + self.version
+            + "/sparse"
+            + self.version
+            + ".tar.gz"
         )
         self.includes = ["spMatrix.h"]
         self.libraries = ["sparse"]
 
     def configure_options(self, builder):
-        with open(os.path.join(builder._extract_dir,builder._extracted_folder, "src", "Makefile"), "w") as f:
+        with open(
+            os.path.join(
+                builder._extract_dir, builder._extracted_folder, "src", "Makefile"
+            ),
+            "w",
+        ) as f:
             if builder.build_shared:
                 f.write("CFLAGS = -O2 -fPIC\n")
             else:
@@ -29,9 +35,13 @@ class Package(packages.GenericPackage):
             f.write("CC = " + builder.env["CC"] + "\n")
             f.write("\n")
             f.write("HFILES = spConfig.h spDefs.h spMatrix.h\n")
-            f.write("CFILES = spAllocate.c spBuild.c spFactor.c spOutput.c spSolve.c spUtils.c \\n")
+            f.write(
+                "CFILES = spAllocate.c spBuild.c spFactor.c spOutput.c spSolve.c spUtils.c \\n"
+            )
             f.write("         spFortran.c\n")
-            f.write("OFILES = spAllocate.o spBuild.o spFactor.o spOutput.o spSolve.o spUtils.o \\n")
+            f.write(
+                "OFILES = spAllocate.o spBuild.o spFactor.o spOutput.o spSolve.o spUtils.o \\n"
+            )
             f.write("         spFortran.o\n")
             if builder.build_shared:
                 f.write("LIBRARY = ../lib/libsparse.so\n")
@@ -44,7 +54,9 @@ class Package(packages.GenericPackage):
             f.write("SOURCE = $(HFILES) $(CFILES)\n")
             f.write("\n")
             f.write("$(DESTINATION)  : $(LIBRARY) $(TESTO)\n")
-            f.write("        $(CC) $(CFLAGS) -o $(DESTINATION) $(TESTO) $(LIBRARY) -lm\n")
+            f.write(
+                "        $(CC) $(CFLAGS) -o $(DESTINATION) $(TESTO) $(LIBRARY) -lm\n"
+            )
             f.write("\n")
             if builder.build_shared:
                 f.write("$(LIBRARY)      : $(OFILES)\n")
@@ -55,17 +67,20 @@ class Package(packages.GenericPackage):
                 f.write("        ranlib $(LIBRARY)\n")
             f.write("\n")
 
-
     def build(self, builder):
         builder.run_command(["make"])
-    
+
     def install(self, builder):
         if not os.path.exists(builder.install_dir()):
             os.makedirs(builder.install_dir())
-        build_dir = os.path.join(builder._extract_dir,builder._extracted_folder)
-        shutil.copytree(os.path.join(build_dir, "include"), os.path.join(builder.install_dir(), "include"))
-        shutil.copytree(os.path.join(build_dir, "lib"), os.path.join(builder.install_dir(), "lib"))
-        
+        build_dir = os.path.join(builder._extract_dir, builder._extracted_folder)
+        shutil.copytree(
+            os.path.join(build_dir, "include"),
+            os.path.join(builder.install_dir(), "include"),
+        )
+        shutil.copytree(
+            os.path.join(build_dir, "lib"), os.path.join(builder.install_dir(), "lib")
+        )
 
     def register(self, builder):
         registry = builder._registry

--- a/tpls/tpl_tools/packages/sparse.py
+++ b/tpls/tpl_tools/packages/sparse.py
@@ -1,0 +1,74 @@
+from tpl_tools.packages import packages
+import os
+import shutil
+
+class Package(packages.GenericPackage):
+    def __init__(self):
+        self.name = "sparse"
+        self.version = "1.4b"
+        self.sha256="63e6646244fd8f4d89f7f70fbf4cfd46b7688d21b22840a0ce57d294a7496d28"
+        self.filename = "sparse-" + self.version + ".tar.gz"
+        self.url = (
+            "http://downloads.sourceforge.net/project/sparse/sparse/sparse"
+            + self.version +
+            "/sparse" 
+            + self.version +
+            ".tar.gz"
+        )
+        self.includes = ["spMatrix.h"]
+        self.libraries = ["sparse"]
+
+    def configure_options(self, builder):
+        with open(os.path.join(builder._extract_dir,builder._extracted_folder, "src", "Makefile"), "w") as f:
+            if builder.build_shared:
+                f.write("CFLAGS = -O2 -fPIC\n")
+            else:
+                f.write("CFLAGS = -O2\n")
+            f.write("LINTFLAGS = -lc -lm\n")
+            f.write("SHELL = /bin/sh\n")
+            f.write("CC = " + builder.env["CC"] + "\n")
+            f.write("\n")
+            f.write("HFILES = spConfig.h spDefs.h spMatrix.h\n")
+            f.write("CFILES = spAllocate.c spBuild.c spFactor.c spOutput.c spSolve.c spUtils.c \\n")
+            f.write("         spFortran.c\n")
+            f.write("OFILES = spAllocate.o spBuild.o spFactor.o spOutput.o spSolve.o spUtils.o \\n")
+            f.write("         spFortran.o\n")
+            if builder.build_shared:
+                f.write("LIBRARY = ../lib/libsparse.so\n")
+            else:
+                f.write("LIBRARY = ../lib/libsparse.a\n")
+            f.write("DESTINATION = ../bin/sparse\n")
+            f.write("TESTC = spTest.c\n")
+            f.write("TESTO = spTest.o\n")
+            f.write("\n")
+            f.write("SOURCE = $(HFILES) $(CFILES)\n")
+            f.write("\n")
+            f.write("$(DESTINATION)  : $(LIBRARY) $(TESTO)\n")
+            f.write("        $(CC) $(CFLAGS) -o $(DESTINATION) $(TESTO) $(LIBRARY) -lm\n")
+            f.write("\n")
+            if builder.build_shared:
+                f.write("$(LIBRARY)      : $(OFILES)\n")
+                f.write("        $(CC) -shared $(LIBRARY) $?\n")
+            else:
+                f.write("$(LIBRARY)      : $(OFILES)\n")
+                f.write("        ar r   $(LIBRARY) $?\n")
+                f.write("        ranlib $(LIBRARY)\n")
+            f.write("\n")
+
+
+    def build(self, builder):
+        builder.run_command(["make"])
+    
+    def install(self, builder):
+        if not os.path.exists(builder.install_dir()):
+            os.makedirs(builder.install_dir())
+        build_dir = os.path.join(builder._extract_dir,builder._extracted_folder)
+        shutil.copytree(os.path.join(build_dir, "include"), os.path.join(builder.install_dir(), "include"))
+        shutil.copytree(os.path.join(build_dir, "lib"), os.path.join(builder.install_dir(), "lib"))
+        
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("SPARSE_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/suitesparse.py
+++ b/tpls/tpl_tools/packages/suitesparse.py
@@ -4,8 +4,8 @@ from tpl_tools.packages import packages
 class Package(packages.CMakePackage):
     def __init__(self):
         self.name = "suitesparse"
-        self.version = "7.7.0"
-        self.sha256 = "529b067f5d80981f45ddf6766627b8fc5af619822f068f342aab776e683df4f3"
+        self.version = "7.8.1"
+        self.sha256 = "b645488ec0d9b02ebdbf27d9ae307f705de2b6133edb64617a72c7b4c6c3ff44"
         self.filename = "suitesparse-" + self.version + ".tar.gz"
         self.url = (
             "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v"

--- a/tpls/tpl_tools/packages/suitesparse.py
+++ b/tpls/tpl_tools/packages/suitesparse.py
@@ -1,0 +1,39 @@
+from tpl_tools.packages import packages
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = "suitesparse"
+        self.version = "7.7.0"
+        self.sha256 = "529b067f5d80981f45ddf6766627b8fc5af619822f068f342aab776e683df4f3"
+        self.filename = "suitesparse-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/DrTimothyAldenDavis/SuiteSparse/archive/refs/tags/v"
+            + self.version
+            + ".tar.gz"
+        )
+        self.libraries = ["umfpack", "suitesparseconfig"]
+        self.includes = ["suitesparse/umfpack.h"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency("packages.openmpi")
+        builder.set_dependency("packages.openblas")
+        builder.set_dependency("packages.metis")
+        builder.set_dependency("packages.parmetis")
+        return
+
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        builder.add_option("-D=BLAS_LIBRARIES=" + builder.env["BLAS_LIBRARIES"])
+        builder.add_option("-D=LAPACK_LIBRARIES=" + builder.env["LAPACK_LIBRARIES"])
+        builder.add_option('-D=SUITESPARSE_ENABLE_PROJECTS=suitesparse_config;amd;camd;ccolamd;colamd;cholmod;umfpack')
+
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("SUITESPARSE_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/suitesparse.py
+++ b/tpls/tpl_tools/packages/suitesparse.py
@@ -1,5 +1,6 @@
 from tpl_tools.packages import packages
 
+
 class Package(packages.CMakePackage):
     def __init__(self):
         self.name = "suitesparse"
@@ -21,7 +22,6 @@ class Package(packages.CMakePackage):
         builder.set_dependency("packages.parmetis")
         return
 
-
     def configure_options(self, builder):
         if builder.build_shared:
             builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
@@ -29,8 +29,9 @@ class Package(packages.CMakePackage):
             builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
         builder.add_option("-D=BLAS_LIBRARIES=" + builder.env["BLAS_LIBRARIES"])
         builder.add_option("-D=LAPACK_LIBRARIES=" + builder.env["LAPACK_LIBRARIES"])
-        builder.add_option('-D=SUITESPARSE_ENABLE_PROJECTS=suitesparse_config;amd;camd;ccolamd;colamd;cholmod;umfpack')
-
+        builder.add_option(
+            "-D=SUITESPARSE_ENABLE_PROJECTS=suitesparse_config;amd;camd;ccolamd;colamd;cholmod;umfpack"
+        )
 
     def register(self, builder):
         registry = builder._registry

--- a/tpls/tpl_tools/packages/superlu_dist.py
+++ b/tpls/tpl_tools/packages/superlu_dist.py
@@ -1,0 +1,82 @@
+from tpl_tools.packages import packages
+
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = "superlu_dist"
+        self.version = "9.0.0"
+        self.sha256 = "aa43d33d4b1b0f5f7b5ad7685e9a6bc25088832c6c74d2ab8f75a2c9f4e9e955"
+        self.filename = "superlu_dist-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/xiaoyeli/superlu_dist/archive/refs/tags/v"
+            + self.version
+            + ".tar.gz"
+        )
+        self.libraries = ["superlu_dist"]
+        self.includes = ["superlu_dist_config.h"]
+
+    def setDependencies(self, builder):
+        builder.set_dependency("packages.openmpi")
+        builder.set_dependency("packages.openblas")
+        builder.set_dependency("packages.metis")
+        builder.set_dependency("packages.parmetis")
+        return
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        builder.add_option("-D=TPL_ENABLE_Netcdf:BOOL=ON")
+        builder.add_option("-D=TPL_ENABLE_MPI:BOOL=ON")
+        builder.add_option("-D=TPL_ENABLE_X11:BOOL=ON")
+
+        CC = builder.env["CC"]
+        CXX = builder.env["CXX"]
+        FC = builder.env["FC"]
+        builder.add_option("-DCMAKE_C_COMPILER=" + CC)
+        builder.add_option("-DCMAKE_CXX_COMPILER=" + CXX)
+        builder.add_option("-DCMAKE_Fortran_COMPILER=" + FC)
+        builder.add_option("-DPNetCDF_ROOT:PATH=" + builder.env["PNETCDF_DIR"])
+        builder.add_option("-DNetCDF_ROOT:PATH=" + builder.env["NETCDF_DIR"])
+        builder.add_option("-DnetCDF_ROOT:PATH=" + builder.env["NETCDF_DIR"])
+        builder.add_option("-DHDF5_ROOT:PATH=" + builder.env["HDF5_DIR"])
+        builder.add_option("-DHDF5_DIR:PATH=" + builder.env["HDF5_DIR"])
+        builder.add_option("-DTPL_ENABLE_Matio=OFF")
+        builder.add_option("-DSeacas_ENABLE_ALL_PACKAGES:BOOL=ON")
+        builder.add_option("-DSeacas_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON")
+        builder.add_option("-DSeacas_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON")
+        builder.add_option("-DTPL_BLAS_LIBRARIES=" + builder.env["BLAS_LIBRARIES"])
+        ext = ".a"
+        if builder.build_shared:
+            ext = ".so"
+        builder.add_option(
+            "-DTPL_PARMETIS_LIBRARIES="
+            + builder.env["PARMETIS_DIR"]
+            + "/lib/libparmetis"
+            + ext
+            + ";"
+            + builder.env["METIS_DIR"]
+            + "/lib/libmetis"
+            + ext
+        )
+        builder.add_option("-Denable_openmp:BOOL=FALSE")
+        builder.add_option(
+            "-DTPL_PARMETIS_INCLUDE_DIRS="
+            + builder.env["PARMETIS_DIR"]
+            + "/include;"
+            + builder.env["METIS_DIR"]
+            + "/include"
+        )
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("SUPERLU_DIST_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/trilinos.py
+++ b/tpls/tpl_tools/packages/trilinos.py
@@ -137,14 +137,14 @@ class Package(packages.CMakePackage):
                 + "/include"
             )
             builder.add_option(
-               "-DTPL_ParMETIS_LIBRARIES="
-               + builder.env["PARMETIS_DIR"]
-               + "/lib/libparmetis"
-               + ext
-               + ";"
-               + builder.env["METIS_DIR"]
-               + "/lib/libmetis"
-               + ext
+                "-DTPL_ParMETIS_LIBRARIES="
+                + builder.env["PARMETIS_DIR"]
+                + "/lib/libparmetis"
+                + ext
+                + ";"
+                + builder.env["METIS_DIR"]
+                + "/lib/libmetis"
+                + ext
             )
         else:
             builder.add_option("-DTPL_ENABLE_ParMETIS:BOOL=OFF")

--- a/tpls/tpl_tools/packages/trilinos.py
+++ b/tpls/tpl_tools/packages/trilinos.py
@@ -1,0 +1,161 @@
+from tpl_tools.packages import packages
+
+
+class Package(packages.CMakePackage):
+    def __init__(self):
+        self.name = "trilinos"
+        self.version = "15.1.0"
+        self.sha256 = "91940c8677b03ec06b3368f7ff8b835ba94dfa6551c6fb168faf10195f32b421"
+        self.filename = "trilinos-" + self.version + ".tar.gz"
+        self.url = (
+            "https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-release-"
+            + self.version.replace(".", "-")
+            + ".tar.gz"
+        )
+        self.libraries = ["amesos2", "belos", "aztecoo", "amesos"]
+        self.includes = [
+            "Amesos2.hpp",
+            "BelosSolverFactory.hpp",
+            "Sacado.hpp",
+            "AztecOO.h",
+            "Amesos.h",
+        ]
+
+    def setDependencies(self, builder):
+        return
+
+    def set_environment(self, builder):
+        builder.env = builder._registry.get_environment().copy()
+        builder.env["CC"] = builder._registry.get_executable("mpicc")
+        builder.env["CXX"] = builder._registry.get_executable("mpicxx")
+        builder.env["FC"] = builder._registry.get_executable("mpifort")
+
+    def configure_options(self, builder):
+        if builder.build_shared:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=ON")
+        else:
+            builder.add_option("-D=BUILD_SHARED_LIBS:BOOL=OFF")
+        CC = builder.env["CC"]
+        CXX = builder.env["CXX"]
+        FC = builder.env["FC"]
+        builder.add_option("-DCMAKE_C_COMPILER=" + CC)
+        builder.add_option("-DCMAKE_CXX_COMPILER=" + CXX)
+        builder.add_option("-DCMAKE_Fortran_COMPILER=" + FC)
+        builder.add_option("-DTrilinos_SHOW_DEPRECATED_WARNINGS=OFF")
+        builder.add_option("-DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE")
+        builder.add_option("-DTPL_ENABLE_Boost:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_Triutils:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_SEACAS:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_Epetra:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Xpetra:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_Ifpack:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Ifpack2:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Teuchos:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_ML:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_MueLu:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_Stratimikos:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Teko:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Belos:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Amesos2:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Amesos:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_AztecOO:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Sacado:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_EpetraExt:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Thyra:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_ThyraTpetraAdapters:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Tpetra:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_Stratimikos:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_TESTS:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON")
+        builder.add_option("-DTPL_ENABLE_MPI:BOOL=ON ")
+        builder.add_option("-DMPI_BASE_DIR:PATH=" + builder.env["MPI_HOME"])
+        builder.add_option("-DEpetraExt_BUILD_GRAPH_REORDERINGS:BOOL=ON")
+        builder.add_option("-DTPL_ENABLE_LAPACK:BOOL=ON")
+        builder.add_option("-DLAPACK_LIBRARY_DIRS=" + builder.env["OPENBLAS_DIR"])
+        builder.add_option("-DLAPACK_LIBRARY_NAMES=openblas")
+        builder.add_option("-DTPL_ENABLE_BLAS:BOOL=ON ")
+        builder.add_option("-DHAVE_EPETRA_LAPACK_GSSVD3:BOOL=ON ")
+        builder.add_option("-DBLAS_LIBRARY_DIRS=" + builder.env["OPENBLAS_DIR"])
+        builder.add_option("-DBLAS_LIBRARY_NAMES=openblas")
+        builder.add_option("-DTPL_ENABLE_UMFPACK:BOOL=ON ")
+        builder.add_option(
+            "-DUMFPACK_LIBRARY_NAMES:STRING=umfpack;amd;suitesparseconfig;cholmod;colamd;ccolamd;camd"
+        )
+        builder.add_option(
+            "-DUMFPACK_LIBRARY_DIRS:PATH=" + builder.env["SUITESPARSE_DIR"] + "/lib"
+        )
+        builder.add_option(
+            "-DUMFPACK_INCLUDE_DIRS:PATH="
+            + builder.env["SUITESPARSE_DIR"]
+            + "/include/suitesparse"
+        )
+        builder.add_option("-DTPL_ENABLE_AMD:BOOL=ON ")
+        builder.add_option("-DAMD_LIBRARY_NAMES:STRING=amd;suitesparseconfig")
+        builder.add_option(
+            "-DAMD_LIBRARY_DIRS:PATH=" + builder.env["SUITESPARSE_DIR"] + "/lib"
+        )
+        builder.add_option(
+            "-DAMD_INCLUDE_DIRS:PATH="
+            + builder.env["SUITESPARSE_DIR"]
+            + "/include/suitesparse"
+        )
+        builder.add_option("-DTPL_ENABLE_SuperLUDist:BOOL=ON ")
+        builder.add_option("-DSuperLUDist_LIBRARY_NAMES:STRING=superlu_dist")
+        builder.add_option(
+            "-DSuperLUDist_LIBRARY_DIRS:PATH="
+            + builder.env["SUPERLU_DIST_DIR"]
+            + "/lib"
+        )
+        builder.add_option(
+            "-DSuperLUDist_INCLUDE_DIRS:PATH="
+            + builder.env["SUPERLU_DIST_DIR"]
+            + "/include"
+        )
+        builder.add_option("-DTPL_ENABLE_ParMETIS:BOOL=ON ")
+        builder.add_option(
+            "-DParMETIS_LIBRARY_DIRS:PATH="
+            + builder.env["PARMETIS_DIR"]
+            + "/lib;"
+            + builder.env["METIS_DIR"]
+            + "/lib"
+        )
+        builder.add_option(
+            "-DTPL_ParMETIS_INCLUDE_DIRS:PATH="
+            + builder.env["PARMETIS_DIR"]
+            + "/include;"
+            + builder.env["METIS_DIR"]
+            + "/include"
+        )
+        builder.add_option("-DTPL_ENABLE_MUMPS:BOOL=ON ")
+        builder.add_option(
+            "-DMUMPS_LIBRARY_NAMES:STRING=dmumps;mumps_common;pord;scalapack"
+        )
+        builder.add_option(
+            "-DMUMPS_LIBRARY_DIRS:PATH="
+            + builder.env["MUMPS_DIR"]
+            + "/lib;"
+            + builder.env["SCALAPACK_DIR"]
+            + "/lib"
+        )
+        builder.add_option(
+            "-DMUMPS_INCLUDE_DIRS:PATH=" + builder.env["MUMPS_DIR"] + "/include"
+        )
+        builder.add_option("-DCMAKE_CXX_FLAGS:STRING=-DMUMPS_5_0")
+        builder.add_option("-DAmesos_ENABLE_SCALAPACK:BOOL=ON ")
+        builder.add_option(
+            "-DSCALAPACK_LIBRARY_DIRS:FILEPATH=" + builder.env["SCALAPACK_DIR"] + "/lib"
+        )
+        builder.add_option("-DSCALAPACK_LIBRARY_NAMES:STRING=scalapack")
+        builder.add_option("-D Amesos_ENABLE_SuperLUDist:BOOL=ON ")
+        builder.add_option("-D Amesos_ENABLE_ParMETIS:BOOL=ON ")
+        builder.add_option("-D Amesos_ENABLE_LAPACK:BOOL=ON ")
+        builder.add_option("-D Amesos_ENABLE_KLU:BOOL=ON ")
+        builder.add_option("-D Amesos_ENABLE_UMFPACK:BOOL=ON ")
+        builder.add_option("-D Amesos_ENABLE_MUMPS:BOOL=ON ")
+        builder.add_option("-D Tpetra_INST_INT_INT:BOOL=ON ")
+
+    def register(self, builder):
+        registry = builder._registry
+        registry.register_package(self.name, builder.install_dir())
+        registry.set_environment_variable("TRILINOS_DIR", builder.install_dir())
+        registry.append_environment_variable("CMAKE_PREFIX_PATH", builder.install_dir())

--- a/tpls/tpl_tools/packages/trilinos.py
+++ b/tpls/tpl_tools/packages/trilinos.py
@@ -4,8 +4,8 @@ from tpl_tools.packages import packages
 class Package(packages.CMakePackage):
     def __init__(self):
         self.name = "trilinos"
-        self.version = "15.1.0"
-        self.sha256 = "91940c8677b03ec06b3368f7ff8b835ba94dfa6551c6fb168faf10195f32b421"
+        self.version = "16.0.0"
+        self.sha256 = "46bfc40419ed2aa2db38c144fb8e61d4aa8170eaa654a88d833ba6b92903f309"
         self.filename = "trilinos-" + self.version + ".tar.gz"
         self.url = (
             "https://github.com/trilinos/Trilinos/archive/refs/tags/trilinos-release-"
@@ -44,15 +44,17 @@ class Package(packages.CMakePackage):
         builder.add_option("-DTrilinos_SHOW_DEPRECATED_WARNINGS=OFF")
         builder.add_option("-DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE")
         builder.add_option("-DTPL_ENABLE_Boost:BOOL=OFF")
+        builder.add_option("-DTrilinos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_SECONDARY_TESTED_CODE=ON")
         builder.add_option("-DTrilinos_ENABLE_Triutils:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_SEACAS:BOOL=OFF")
         builder.add_option("-DTrilinos_ENABLE_Epetra:BOOL=ON")
-        builder.add_option("-DTrilinos_ENABLE_Xpetra:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_Xpetra:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Ifpack:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Ifpack2:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Teuchos:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_ML:BOOL=ON")
-        builder.add_option("-DTrilinos_ENABLE_MueLu:BOOL=OFF")
+        builder.add_option("-DTrilinos_ENABLE_MueLu:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Stratimikos:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Teko:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Belos:BOOL=ON")
@@ -63,6 +65,7 @@ class Package(packages.CMakePackage):
         builder.add_option("-DTrilinos_ENABLE_EpetraExt:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Thyra:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_ThyraTpetraAdapters:BOOL=ON")
+        builder.add_option("-DTrilinos_ENABLE_ThyraEpetraAdapters:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Tpetra:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_Stratimikos:BOOL=ON")
         builder.add_option("-DTrilinos_ENABLE_TESTS:BOOL=OFF")
@@ -99,42 +102,63 @@ class Package(packages.CMakePackage):
             + builder.env["SUITESPARSE_DIR"]
             + "/include/suitesparse"
         )
-        builder.add_option("-DTPL_ENABLE_SuperLUDist:BOOL=ON ")
-        builder.add_option("-DSuperLUDist_LIBRARY_NAMES:STRING=superlu_dist")
-        builder.add_option(
-            "-DSuperLUDist_LIBRARY_DIRS:PATH="
-            + builder.env["SUPERLU_DIST_DIR"]
-            + "/lib"
-        )
-        builder.add_option(
-            "-DSuperLUDist_INCLUDE_DIRS:PATH="
-            + builder.env["SUPERLU_DIST_DIR"]
-            + "/include"
-        )
-        builder.add_option("-DTPL_ENABLE_ParMETIS:BOOL=ON ")
-        builder.add_option(
-            "-DParMETIS_LIBRARY_DIRS:PATH="
-            + builder.env["PARMETIS_DIR"]
-            + "/lib;"
-            + builder.env["METIS_DIR"]
-            + "/lib"
-        )
-        builder.add_option(
-            "-DTPL_ParMETIS_INCLUDE_DIRS:PATH="
-            + builder.env["PARMETIS_DIR"]
-            + "/include;"
-            + builder.env["METIS_DIR"]
-            + "/include"
-        )
+        if "SUPERLU_DIST_DIR" in builder.env:
+            builder.add_option("-D Amesos_ENABLE_SuperLUDist:BOOL=ON ")
+            builder.add_option("-DTPL_ENABLE_SuperLUDist:BOOL=ON ")
+            builder.add_option("-DSuperLUDist_LIBRARY_NAMES:STRING=superlu_dist")
+            builder.add_option(
+                "-DSuperLUDist_LIBRARY_DIRS:PATH="
+                + builder.env["SUPERLU_DIST_DIR"]
+                + "/lib"
+            )
+            builder.add_option(
+                "-DSuperLUDist_INCLUDE_DIRS:PATH="
+                + builder.env["SUPERLU_DIST_DIR"]
+                + "/include"
+            )
+        ext = ".a"
+        if builder.build_shared:
+            ext = ".so"
+        if "PARMETIS_DIR" in builder.env:
+            builder.add_option("-DTPL_ENABLE_ParMETIS:BOOL=ON ")
+            builder.add_option("-D Amesos_ENABLE_ParMETIS:BOOL=ON ")
+            builder.add_option(
+                "-DParMETIS_LIBRARY_DIRS:PATH="
+                + builder.env["PARMETIS_DIR"]
+                + "/lib;"
+                + builder.env["METIS_DIR"]
+                + "/lib"
+            )
+            builder.add_option(
+                "-DTPL_ParMETIS_INCLUDE_DIRS:PATH="
+                + builder.env["PARMETIS_DIR"]
+                + "/include;"
+                + builder.env["METIS_DIR"]
+                + "/include"
+            )
+            builder.add_option(
+               "-DTPL_ParMETIS_LIBRARIES="
+               + builder.env["PARMETIS_DIR"]
+               + "/lib/libparmetis"
+               + ext
+               + ";"
+               + builder.env["METIS_DIR"]
+               + "/lib/libmetis"
+               + ext
+            )
+        else:
+            builder.add_option("-DTPL_ENABLE_ParMETIS:BOOL=OFF")
         builder.add_option("-DTPL_ENABLE_MUMPS:BOOL=ON ")
         builder.add_option(
-            "-DMUMPS_LIBRARY_NAMES:STRING=dmumps;mumps_common;pord;scalapack"
+            "-DMUMPS_LIBRARY_NAMES:STRING=dmumps;mumps_common;pord;scalapack;ptesmumps;ptscotch;ptscotcherr;scotch;scotcherr"
         )
         builder.add_option(
             "-DMUMPS_LIBRARY_DIRS:PATH="
             + builder.env["MUMPS_DIR"]
             + "/lib;"
             + builder.env["SCALAPACK_DIR"]
+            + "/lib;"
+            + builder.env["SCOTCH_DIR"]
             + "/lib"
         )
         builder.add_option(
@@ -146,8 +170,6 @@ class Package(packages.CMakePackage):
             "-DSCALAPACK_LIBRARY_DIRS:FILEPATH=" + builder.env["SCALAPACK_DIR"] + "/lib"
         )
         builder.add_option("-DSCALAPACK_LIBRARY_NAMES:STRING=scalapack")
-        builder.add_option("-D Amesos_ENABLE_SuperLUDist:BOOL=ON ")
-        builder.add_option("-D Amesos_ENABLE_ParMETIS:BOOL=ON ")
         builder.add_option("-D Amesos_ENABLE_LAPACK:BOOL=ON ")
         builder.add_option("-D Amesos_ENABLE_KLU:BOOL=ON ")
         builder.add_option("-D Amesos_ENABLE_UMFPACK:BOOL=ON ")

--- a/tpls/tpl_tools/registry.py
+++ b/tpls/tpl_tools/registry.py
@@ -1,0 +1,88 @@
+import os
+
+
+class Config(object):
+    def __init__(self):
+        self.environment = {}
+
+    def set_environment_variable(self, variable, value):
+        self.environment[variable] = value
+    
+    def append_environment_variable(self, variable, value):
+        if variable in self.environment.keys():
+            if type(self.environment[variable]) != list:
+                oldval = self.environment[variable]
+                self.environment[variable] = [oldval]
+            self.environment[variable].append(value)
+        else:
+            self.environment[variable] = value
+    
+    def write_config(self, file, shell="bash"):
+        with open(file, "w") as f:
+            if shell == "bash":
+                for k in self.environment.keys():
+                    if type(self.environment[k]) == list:
+                        f.write("export {}=".format(k))
+                        for item in self.environment[k]:
+                            f.write(item)
+                            f.write(":")
+                        f.write("${}".format(k))
+                        f.write("\n")
+                    else:
+                        f.write("export {}=".format(k))
+                        f.write("{}".format(self.environment[k]))
+                        f.write("\n")
+            elif shell == "fish":
+                for k in self.environment.keys():
+                    if type(self.environment[k]) == list:
+                        f.write("set -x {} ".format(k))
+                        for item in self.environment[k]:
+                            f.write(item)
+                            f.write(" ")
+                        f.write("${}".format(k))
+                        f.write("\n")
+                    else:
+                        f.write("export {}=".format(k))
+                        f.write("{}".format(self.environment[k]))
+                        f.write("\n")
+
+                    
+
+class Registry(object):
+    def __init__(self):
+        self.executables = {}
+        self.package_locations = {}
+        self.environment = os.environ.copy()
+        self.config = Config()
+
+    def register_executable(self, exe_path):
+        if os.path.isfile(exe_path):
+            name = os.path.basename(exe_path)
+            self.executables[name] = exe_path
+            print("Registering {}:{}".format(name, exe_path))
+        else:
+            raise ValueError("exe not a file {}".format(exe_path))
+
+    def register_package(self, package_name, package_path):
+        if os.path.exists(package_path):
+            self.package_locations[package_name] = package_path
+
+    def get_package(self, package_name):
+        return self.package_locations[package_name]
+
+    def get_executable(self, exe):
+        return self.executables[exe]
+
+    def get_environment(self):
+        return self.environment
+
+    def set_environment_variable(self, variable, value):
+        self.environment[variable] = value
+        self.config.set_environment_variable(variable, value)
+
+    def append_environment_variable(self, variable, value):
+        if variable in self.environment:
+            self.environment[variable] += os.pathsep + value
+        else:
+            self.environment[variable] = value
+        self.config.append_environment_variable(variable, value)

--- a/tpls/tpl_tools/registry.py
+++ b/tpls/tpl_tools/registry.py
@@ -7,7 +7,7 @@ class Config(object):
 
     def set_environment_variable(self, variable, value):
         self.environment[variable] = value
-    
+
     def append_environment_variable(self, variable, value):
         if variable in self.environment.keys():
             if type(self.environment[variable]) != list:
@@ -16,7 +16,7 @@ class Config(object):
             self.environment[variable].append(value)
         else:
             self.environment[variable] = value
-    
+
     def write_config(self, file, shell="bash"):
         with open(file, "w") as f:
             if shell == "bash":
@@ -46,7 +46,6 @@ class Config(object):
                         f.write("{}".format(self.environment[k]))
                         f.write("\n")
 
-                    
 
 class Registry(object):
     def __init__(self):

--- a/tpls/tpl_tools/utils.py
+++ b/tpls/tpl_tools/utils.py
@@ -85,8 +85,8 @@ def check_for_x11(extract_dir, cc):
     if cc:
         comp = cc
     with open(os.path.join(extract_dir, "x11test.c"), "w") as f:
-        f.write("int main() {}\n")
-    command = [cc, "-lX11"]
+        f.write("int main() { return 0; }\n")
+    command = [cc, "-lX11", "x11test.c"]
     result = subprocess.Popen(command, cwd=extract_dir)
     result.wait()
     os.remove(os.path.join(extract_dir, "x11test.c"))

--- a/tpls/tpl_tools/utils.py
+++ b/tpls/tpl_tools/utils.py
@@ -4,6 +4,7 @@ import shutil
 import os
 import hashlib
 import sys
+import subprocess
 
 
 # https://stackoverflow.com/questions/22058048/hashing-a-file-in-python
@@ -77,3 +78,20 @@ class PrintLogger(object):
 
     def log(self, *args):
         print(*args)
+
+def check_for_x11(extract_dir, cc):
+    comp = "cc"
+    if cc:
+        comp = cc
+    with open(os.path.join(extract_dir, "x11test.c")) as f:
+        f.write("int main() {}\n")
+    command = [cc, "-lX11"]
+    result = subprocess.Popen(command, cwd=extract_dir)
+    result.wait()
+    os.remove(os.path.join(extract_dir, "x11test.c"))
+    return result.returncode == 0
+
+
+
+
+

--- a/tpls/tpl_tools/utils.py
+++ b/tpls/tpl_tools/utils.py
@@ -79,6 +79,7 @@ class PrintLogger(object):
     def log(self, *args):
         print(*args)
 
+
 def check_for_x11(extract_dir, cc):
     comp = "cc"
     if cc:
@@ -90,8 +91,3 @@ def check_for_x11(extract_dir, cc):
     result.wait()
     os.remove(os.path.join(extract_dir, "x11test.c"))
     return result.returncode == 0
-
-
-
-
-

--- a/tpls/tpl_tools/utils.py
+++ b/tpls/tpl_tools/utils.py
@@ -1,0 +1,79 @@
+import urllib
+import urllib.request
+import shutil
+import os
+import hashlib
+import sys
+
+
+# https://stackoverflow.com/questions/22058048/hashing-a-file-in-python
+def sha256sum(filename, buffer_size=65536):
+    sha256 = hashlib.sha256()
+    with open(filename, "rb", buffering=0) as f:
+        while True:
+            data = f.read(buffer_size)
+            if not data:
+                break
+            sha256.update(data)
+    return sha256.hexdigest()
+
+
+VERBOSE = True
+
+
+def set_verbosity(verbosity):
+    global VERBOSE
+    VERBOSE = verbosity
+
+
+def print_if_verbose(*args):
+    if VERBOSE:
+        print(*args)
+
+
+def get_library_extension(shared):
+    if not shared:
+        return ".a"
+    if sys.platform == "darwin":
+        return ".dylib"
+    return ".so"
+
+
+def find_file(name, path):
+    for root, dirs, files in os.walk(path):
+        if name in files:
+            return os.path.join(root, name)
+    return None
+
+
+def download_file(url, filename, sha256=None):
+    skip_download = False
+    if os.path.exists(filename):
+        print("")
+        if os.path.isfile(filename):
+            print_if_verbose("File already exists: {}".format(filename))
+            skip_download = True
+
+    if not skip_download:
+        with urllib.request.urlopen(url) as req, open(filename, "wb") as f:
+            shutil.copyfileobj(req, f)
+
+    if os.path.isfile(filename):
+        if not sha256 is None:
+            sum = sha256sum(filename)
+            if sha256 != sum:
+                print_if_verbose("SHA mismatch {}".format(filename))
+                print_if_verbose("Expected: {}".format(sha256))
+                print_if_verbose("Actual: {}".format(sum))
+                raise ValueError(sha256 + " != " + sum)
+        return True
+    else:
+        return False
+
+
+class PrintLogger(object):
+    def __init__(self):
+        return
+
+    def log(self, *args):
+        print(*args)

--- a/tpls/tpl_tools/utils.py
+++ b/tpls/tpl_tools/utils.py
@@ -83,7 +83,7 @@ def check_for_x11(extract_dir, cc):
     comp = "cc"
     if cc:
         comp = cc
-    with open(os.path.join(extract_dir, "x11test.c")) as f:
+    with open(os.path.join(extract_dir, "x11test.c"), "w") as f:
         f.write("int main() {}\n")
     command = [cc, "-lX11"]
     result = subprocess.Popen(command, cwd=extract_dir)


### PR DESCRIPTION
New build script allows the following:

- Use of system libraries
- Specification of compilers on command line instead of editing file
- Headless build for clusters
- Builds shared libraries or static (shared by default for exodus.py)
- Use of system MPI from command line instead of editing file

Should be easier for those that haven't been able to use `spack`

Seems to work on RedHat 8 and newer (with newer compilers like from gcc-toolset)
Seems to work on Ubuntu 22.04 and newer

## TODO:

- [x] Check why library updates have introduced new test suite errors
- [x] See if versions need to be updated
- [x] Make ParMETIS optional for non-government/non-education users
- [x] Deprecate old build script