### PR TITLE
Add current AC_VALUE to aprepro AC flag

### DIFF
--- a/src/mm_fill_solid.c
+++ b/src/mm_fill_solid.c
@@ -96,7 +96,7 @@ int belly_flop(dbl mu) /* elastic modulus (plane stress case) */
   dbl grad_d_dot[DIM][DIM];
   dbl d_grad_d_dot[DIM][DIM][DIM][MDE]; /* displacement gradient*/
   dbl det2d;                            /* determinant of 2D deformation gradient tensor */
-  dbl det2d_old, det2d_dot;
+  dbl det2d_old, det2d_dot = 0.;
   dbl ddet2d_dx[DIM][MDE];     /* sensitivity */
   dbl ddet2d_dot_dx[DIM][MDE]; /* sensitivity */
   dbl cauchy_green[DIM][DIM];  /* strain tensor without division by determinant, etc. */

--- a/src/util/aprepro_helper.cpp
+++ b/src/util/aprepro_helper.cpp
@@ -68,6 +68,7 @@ extern "C" goma_error aprepro_parse_goma_augc(struct AC_Information *ac, double 
   SEAMS::Aprepro aprepro;
   std::string var = ac->AP_param;
   aprepro.add_variable(var, val, true);
+  aprepro.add_variable("AC_VALUE", ac->CONSTV, true);
   std::string filedata = ac->Aprepro_lib_string;
   auto result = aprepro.parse_string(filedata);
 


### PR DESCRIPTION
Lets you use AC_VALUE to use the current set value, e.g. the volume flux flux value in your aprepro AC. See https://github.com/goma/goma/pull/406

Useful for continuation in AC value.