### PR TITLE
Adjust location of species id card in AC FC SPECIES_FLUX

### DIFF
--- a/docs/problem_description_file/augmenting_conditions/ac_flux_condition.rst
+++ b/docs/problem_description_file/augmenting_conditions/ac_flux_condition.rst
@@ -92,18 +92,18 @@ FC
     See below for a detailed description of each of these 
     constraints.
 
-[species_id]
-    This is an integer parameter that identifies the species 
-    component that is evaluated in the SPECIES_FLUX 
-    constraint. When other flux constraints are used this 
-    parameter should not appear.
-
 <side set>
     An integer parameter that identifies the side set over 
     which the flux condition will be integrated. Those 
     elements that belong to <mat_id> and have faces 
     included in <side set> will be evaluated in the 
     integration.
+
+[species_id]
+    This is an integer parameter that identifies the species 
+    component that is evaluated in the SPECIES_FLUX 
+    constraint. When other flux constraints are used this 
+    parameter should not appear.
 
 <flux_value>
     A float parameter that specifies the value that is 


### PR DESCRIPTION
The manual might have the order of the inputs switched for the AC (flux condition). I found that when passing it as <FC_TYPE> <sideset> [species_id] instead of <FC_TYPE> [species_id] <sideset>, the simulation converged correctly. Putting it in order <FC_TYPE> [species_id] <sideset> gave me a zero row sum.

_Originally posted by @Enos0022 in https://github.com/goma/goma/discussions/544#discussioncomment-14435823_